### PR TITLE
Fix Vector VRL syntax errors causing pod crashes

### DIFF
--- a/gitops/core/apps/vector.yml
+++ b/gitops/core/apps/vector.yml
@@ -78,13 +78,13 @@ spec:
                 msg_str = to_string(.message) ?? ""
                 matches = parse_regex(msg_str, r'level=(?P<level>\w+)') ?? {}
                 if exists(matches.level) {
-                  .level = downcase(to_string(matches.level))
+                  .level = downcase(to_string(matches.level) ?? "info")
                 }
                 
                 if starts_with(msg_str, "{") {
                   parsed_json = parse_json(msg_str) ?? {}
                   if exists(parsed_json.level) {
-                    .level = downcase(to_string(parsed_json.level))
+                    .level = downcase(to_string(parsed_json.level) ?? "info")
                   }
                   if exists(parsed_json.msg) {
                     .msg = parsed_json.msg


### PR DESCRIPTION
## Problem
Vector pods are crashing with `CrashLoopBackOff` status due to VRL (Vector Remap Language) syntax errors. The specific error is:

```
error[E630]: fallible argument
.level = downcase(to_string(parsed_json.level))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
                 this expression can fail
                 handle the error before passing it in as an argument
```

## Solution
This PR fixes the VRL syntax errors by adding proper error handling to fallible `to_string()` function calls:

### Changes Made:
- **Fixed `to_string(matches.level)`**: Added `?? "info"` fallback
- **Fixed `to_string(parsed_json.level)`**: Added `?? "info"` fallback

### Before:
```vrl
.level = downcase(to_string(matches.level))
.level = downcase(to_string(parsed_json.level))
```

### After:
```vrl
.level = downcase(to_string(matches.level) ?? "info")
.level = downcase(to_string(parsed_json.level) ?? "info")
```

## Testing
- VRL syntax is now compliant with Vector's error handling requirements
- If `to_string()` fails, it gracefully falls back to "info" log level
- This resolves the `error[E630]: fallible argument` that was preventing Vector from starting

## Impact
- ✅ Fixes Vector pod crashes
- ✅ Enables log forwarding to Loki
- ✅ Maintains existing log parsing functionality
- ✅ Provides safe fallback behavior for malformed log levels

## Related Issues
This addresses the Vector configuration issues discovered in the ArgoCD application that were preventing successful log collection and forwarding to the Loki instance.