### PR TITLE
Remove unnecessary error coalescing from infallible to_string calls

### DIFF
--- a/gitops/core/apps/vector.yml
+++ b/gitops/core/apps/vector.yml
@@ -78,13 +78,13 @@ spec:
                 msg_str = to_string(.message) ?? ""
                 matches = parse_regex(msg_str, r'level=(?P<level>\w+)') ?? {}
                 if exists(matches.level) {
-                  .level = downcase(to_string(matches.level) ?? "info")
+                  .level = downcase(to_string(matches.level))
                 }
                 
                 if starts_with(msg_str, "{") {
                   parsed_json = parse_json(msg_str) ?? {}
                   if exists(parsed_json.level) {
-                    .level = downcase(to_string(parsed_json.level) ?? "info")
+                    .level = downcase(to_string(parsed_json.level))
                   }
                   if exists(parsed_json.msg) {
                     .msg = parsed_json.msg


### PR DESCRIPTION
The to_string() function is infallible when used on fields that are known to exist (checked with exists()). The error coalescing operator ?? is unnecessary in these cases and causes Vector to fail with error[E651].

Fixed:
- Removed ?? "info" from to_string(matches.level) on line 81
- Removed ?? "info" from to_string(parsed_json.level) on line 87

Both are within if exists() blocks, making the to_string() calls infallible.