### PR TITLE
Fix Vector VRL syntax errors - properly handle infallible operations

### DIFF
--- a/gitops/core/apps/vector.yml
+++ b/gitops/core/apps/vector.yml
@@ -78,13 +78,13 @@ spec:
                 msg_str = to_string(.message) ?? ""
                 matches = parse_regex(msg_str, r'level=(?P<level>\w+)') ?? {}
                 if exists(matches.level) {
-                  .level = downcase!(to_string(matches.level) ?? "info")
+                  .level = downcase(to_string(matches.level))
                 }
                 
                 if starts_with(msg_str, "{") {
                   parsed_json = parse_json(msg_str) ?? {}
                   if exists(parsed_json.level) {
-                    .level = downcase!(to_string(parsed_json.level) ?? "info")
+                    .level = downcase(to_string(parsed_json.level))
                   }
                   if exists(parsed_json.msg) {
                     .msg = parsed_json.msg


### PR DESCRIPTION
## Problem
Vector pods are crashing with VRL syntax errors introduced in PR #156. The errors are:
- **E651**: Unnecessary error coalescing operation on infallible functions
- **E620**: Can't abort infallible function

## Root Cause
When `exists(matches.level)` returns true, the `to_string(matches.level)` operation is infallible (cannot fail). Therefore:
1. The error coalescing operator `??` is unnecessary and causes error E651
2. The abort operator `!` on `downcase` is unnecessary and causes error E620

## Solution
This PR removes both unnecessary operators:
- **Line 81**: Changed `downcase!(to_string(matches.level) ?? "info")` to `downcase(to_string(matches.level))`
- **Line 87**: Changed `downcase!(to_string(parsed_json.level) ?? "info")` to `downcase(to_string(parsed_json.level))`

## Testing
The VRL syntax is now compliant with Vector's requirements:
- `to_string()` is used without error coalescing when the field is guaranteed to exist
- `downcase()` is used without the abort operator since it can't fail with valid string input

## Expected Result
- ✅ Vector pods will start successfully without exit code 78
- ✅ Logs will be properly parsed and forwarded to Loki
- ✅ Log levels will be correctly normalized to lowercase
