### PR TITLE
Fix vector-loki connectivity - use loki-backend directly

### DIFF
--- a/gitops/core/apps/vector.yml
+++ b/gitops/core/apps/vector.yml
@@ -92,7 +92,7 @@ spec:
             loki_kubernetes:
               type: loki
               inputs: ["kubernetes_parsed"]
-              endpoint: http://loki-gateway.monitoring.svc.cluster.local
+              endpoint: http://loki-backend.monitoring.svc.cluster.local:3100
               encoding:
                 codec: json
               labels:


### PR DESCRIPTION
- Changed endpoint from loki-gateway to loki-backend
- Loki backend mode doesn't support ingestion through gateway
- Direct connection to loki-backend:3100 bypasses routing issues
- This should resolve 404 errors when pushing logs