### PR TITLE
Add tenant_id to vector loki sink for auth

### DIFF
--- a/gitops/core/apps/vector.yml
+++ b/gitops/core/apps/vector.yml
@@ -93,6 +93,7 @@ spec:
               type: loki
               inputs: ["kubernetes_parsed"]
               endpoint: http://loki-backend.monitoring.svc.cluster.local:3100
+              tenant_id: "1"
               encoding:
                 codec: json
               labels:


### PR DESCRIPTION
- Added tenant_id: "1" to loki sink configuration  
- Required because Loki has auth_enabled: true
- This should resolve 404 errors when pushing to backend