### PR TITLE
Fix Loki backend target configuration

### DIFF
--- a/gitops/core/apps/loki.yml
+++ b/gitops/core/apps/loki.yml
@@ -38,10 +38,12 @@ spec:
 
         backend:
           replicas: 2
+          extraArgs:
+            - -target=all
         read:
           replicas: 2
         write:
-          replicas: 3
+          replicas: 0
 
         minio:
           enabled: true
@@ -52,5 +54,3 @@ spec:
     automated: {}
     syncOptions:
       - CreateNamespace=true
-
-


### PR DESCRIPTION
- Set backend extraArgs to -target=all for ingestion support
- Set write.replicas: 0 to disable separate write pods
- This ensures backend pods handle all operations including ingestion
- Resolves 404 errors when vector tries to push logs