### PR TITLE
Optimize Loki cache memory for homelab scale

### DIFF
--- a/gitops/core/apps/loki.yml
+++ b/gitops/core/apps/loki.yml
@@ -45,6 +45,27 @@ spec:
         write:
           replicas: 0
 
+        # Optimize cache sizes for homelab
+        chunksCache:
+          enabled: true
+          resources:
+            requests:
+              memory: 1Gi
+              cpu: 100m
+            limits:
+              memory: 1Gi
+              cpu: 200m
+
+        resultsCache:
+          enabled: true
+          resources:
+            requests:
+              memory: 512Mi
+              cpu: 100m
+            limits:
+              memory: 512Mi
+              cpu: 200m
+
         minio:
           enabled: true
           persistence:


### PR DESCRIPTION
- Reduce chunksCache from 9.8Gi to 1Gi
- Reduce resultsCache from 1.2Gi to 512Mi
- Add CPU limits to prevent resource contention
- Total memory savings: ~9GB on control plane node