### PR TITLE
feat: Add TLS certificates for Jellyfin and Filebrowser

### DIFF
--- a/gitops/core/apps/certs.yml
+++ b/gitops/core/apps/certs.yml
@@ -51,5 +51,31 @@ spec:
     kind: ClusterIssuer
   secretName: zot-tls
 ---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: jellyfin-tls
+  namespace: gateways
+spec:
+  dnsNames:
+  - jellyfin.phillips-homelab.net
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  secretName: jellyfin-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: filebrowser-tls
+  namespace: gateways
+spec:
+  dnsNames:
+  - files.phillips-homelab.net
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  secretName: filebrowser-tls
+---
 
 

--- a/gitops/tools/apps/jellyfin.yml
+++ b/gitops/tools/apps/jellyfin.yml
@@ -33,12 +33,8 @@ spec:
             size: 200Gi
         
         service:
-          main:
-            type: LoadBalancer
-            loadBalancerIP: ""
-            ports:
-              http:
-                port: 8096
+          type: LoadBalancer
+          port: 8096
         
         ingress:
           main:


### PR DESCRIPTION
- Add jellyfin-tls certificate for jellyfin.phillips-homelab.net
- Add filebrowser-tls certificate for files.phillips-homelab.net
- Fix service configuration for LoadBalancer access