### PR TITLE
fix: Update Filebrowser chart version to 1.0.0

### DIFF
--- a/gitops/tools/apps/filebrowser.yml
+++ b/gitops/tools/apps/filebrowser.yml
@@ -9,7 +9,7 @@ spec:
   source:
     repoURL: https://utkuozdemir.org/helm-charts
     chart: filebrowser
-    targetRevision: "1.0.3"
+    targetRevision: "1.0.0"
     helm:
       values: |-
         image:


### PR DESCRIPTION
- Change from 1.0.3 to 1.0.0 as 1.0.3 not found in repository
- Should resolve ArgoCD sync error for Filebrowser application