### PR TITLE
feat: Add OpenWebUI deployment with GPU support and HTTPS access

### DIFF
--- a/gitops/core/apps/certs.yml
+++ b/gitops/core/apps/certs.yml
@@ -77,5 +77,18 @@ spec:
     kind: ClusterIssuer
   secretName: filebrowser-tls
 ---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: openwebui-tls
+  namespace: gateways
+spec:
+  dnsNames:
+  - openwebui.phillips-homelab.net
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  secretName: openwebui-tls
+---
 
 

--- a/gitops/core/apps/gateways.yml
+++ b/gitops/core/apps/gateways.yml
@@ -83,6 +83,20 @@ spec:
   - group: ""
     kind: Service
 ---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-openwebui-service
+  namespace: tools
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: gateways
+  to:
+  - group: ""
+    kind: Service
+---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -139,6 +153,14 @@ spec:
       certificateRefs:
       - kind: Secret
         name: filebrowser-tls
+  - name: https-7
+    protocol: HTTPS
+    port: 443
+    hostname: openwebui.phillips-homelab.net
+    tls:
+      certificateRefs:
+      - kind: Secret
+        name: openwebui-tls
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -253,4 +275,22 @@ spec:
     - name: filebrowser
       namespace: media
       port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: https-app-route-7
+  namespace: gateways
+spec:
+  parentRefs:
+  - name: tls-gateway
+    sectionName: https-7
+    namespace: gateways
+  hostnames:
+  - openwebui.phillips-homelab.net
+  rules:
+  - backendRefs:
+    - name: open-webui
+      namespace: tools
+      port: 8080
 ---

--- a/gitops/tools/apps/openwebui-secrets.yml
+++ b/gitops/tools/apps/openwebui-secrets.yml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: openwebui-secrets
+  namespace: tools
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: staging
+  target:
+    creationPolicy: Owner
+  data:
+  - secretKey: webui_secret_key
+    remoteRef:
+      key: openwebui-config
+      property: webui_secret_key

--- a/gitops/tools/apps/openwebui.yml
+++ b/gitops/tools/apps/openwebui.yml
@@ -1,0 +1,89 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: openwebui
+  namespace: argocd
+spec:
+  project: default
+  
+  source:
+    repoURL: https://helm.openwebui.com
+    chart: open-webui
+    targetRevision: "7.2.0"
+    helm:
+      values: |-
+        image:
+          repository: ghcr.io/open-webui/open-webui
+          tag: main
+          pullPolicy: IfNotPresent
+        
+        nodeSelector:
+          kubernetes.io/hostname: homelab-04
+        
+        service:
+          type: ClusterIP
+          port: 8080
+        
+        ingress:
+          enabled: false
+        
+        persistence:
+          enabled: true
+          storageClass: "syno-iscsi-default"
+          accessMode: ReadWriteOnce
+          size: 20Gi
+        
+        resources:
+          limits:
+            memory: 4Gi
+            cpu: 2000m
+            nvidia.com/gpu: 1
+          requests:
+            cpu: 1000m
+            memory: 2Gi
+            nvidia.com/gpu: 1
+        
+        envFrom:
+        - secretRef:
+            name: openwebui-secrets
+        
+        env:
+          OLLAMA_BASE_URL: "http://openwebui-ollama:11434"
+        
+        runtimeClassName: nvidia
+        
+        ollama:
+          enabled: true
+          gpu:
+            enabled: true
+            type: nvidia
+            number: 1
+            runtimeClassName: nvidia
+          nodeSelector:
+            kubernetes.io/hostname: homelab-04
+          persistence:
+            enabled: true
+            storageClass: "syno-iscsi-default"
+            size: 150Gi
+          service:
+            type: ClusterIP
+          resources:
+            limits:
+              memory: 8Gi
+              cpu: 4000m
+              nvidia.com/gpu: 1
+            requests:
+              cpu: 2000m
+              memory: 4Gi
+              nvidia.com/gpu: 1
+    
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: tools
+    
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
- Add OpenWebUI ArgoCD application with Ollama integration
- Configure GPU node scheduling on homelab-04
- Add External Secrets integration for configuration
- Add TLS certificate for openwebui.phillips-homelab.net
- Add Gateway listener and HTTPRoute for HTTPS access
- Configure 150GB storage for Ollama models and 20GB for OpenWebUI data