### PR TITLE
fix: Remove GPU request from OpenWebUI container to avoid resource co…

### DIFF
--- a/gitops/tools/apps/openwebui.yml
+++ b/gitops/tools/apps/openwebui.yml
@@ -37,11 +37,9 @@ spec:
           limits:
             memory: 4Gi
             cpu: 2000m
-            nvidia.com/gpu: 1
           requests:
             cpu: 1000m
             memory: 2Gi
-            nvidia.com/gpu: 1
         
         envFrom:
         - secretRef:
@@ -49,8 +47,6 @@ spec:
         
         env:
           OLLAMA_BASE_URL: "http://openwebui-ollama:11434"
-        
-        runtimeClassName: nvidia
         
         ollama:
           enabled: true


### PR DESCRIPTION
…nflict

- Only Ollama container should request GPU, not the OpenWebUI web interface
- Remove nvidia runtime class from OpenWebUI container
- This resolves pod scheduling conflict on homelab-04