### PR TITLE
fix(network): move Cilium LB pool out of node-IP range

### DIFF
--- a/cluster/talos/omni/phillips-homelab/manifests/gateways.yml
+++ b/cluster/talos/omni/phillips-homelab/manifests/gateways.yml
@@ -4,8 +4,13 @@ kind: Gateway
 metadata:
   name: tls-gateway
   namespace: gateways
+  annotations:
+    lbipam.cilium.io/ips: "192.168.10.211"
 spec:
   gatewayClassName: cilium
+  infrastructure:
+    annotations:
+      lbipam.cilium.io/ips: "192.168.10.211"
   listeners:
   - name: https-1
     protocol: HTTPS

--- a/cluster/talos/omni/phillips-homelab/manifests/ip-pool.yml
+++ b/cluster/talos/omni/phillips-homelab/manifests/ip-pool.yml
@@ -5,5 +5,5 @@ metadata:
   namespace: kube-system
 spec:
   blocks:
-  - start: "192.168.10.191"
-    stop: "192.168.10.194"
+  - start: "192.168.10.210"
+    stop: "192.168.10.220"

--- a/cluster/talos/omni/phillips-homelab/patches/extraManifests.yml
+++ b/cluster/talos/omni/phillips-homelab/patches/extraManifests.yml
@@ -8,6 +8,7 @@ cluster:
    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.0/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.0/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
    - https://raw.githubusercontent.com/AlverezYari/phillips-homelab/refs/heads/main/cluster/talos/omni/phillips-homelab/manifests/L2Announcement.yml
+   - https://raw.githubusercontent.com/AlverezYari/phillips-homelab/refs/heads/main/cluster/talos/omni/phillips-homelab/manifests/ip-pool.yml
    - https://raw.githubusercontent.com/AlverezYari/phillips-homelab/refs/heads/main/cluster/talos/omni/phillips-homelab/manifests/argocd-kustomized/final-argocd.yaml
    - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/main/deploy/standalone-install.yaml
    - https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml

--- a/cluster/talos/omni/phillips-homelab/patches/nameservers-local.yml
+++ b/cluster/talos/omni/phillips-homelab/patches/nameservers-local.yml
@@ -1,5 +1,5 @@
 machine:
   network:
     nameservers:
-      - 192.168.10.191
+      - 192.168.10.210
       - 1.1.1.1

--- a/gitops/core/apps/blocky/configmap.yaml
+++ b/gitops/core/apps/blocky/configmap.yaml
@@ -36,15 +36,15 @@ data:
     # Custom DNS mappings (local overrides)
     customDNS:
       mapping:
-        # Gateway services (Cilium Gateway API on .194)
-        argocd.phillips-homelab.net: 192.168.10.194
-        monitoring.phillips-homelab.net: 192.168.10.194
-        zot.phillips-homelab.net: 192.168.10.194
-        home-assistant.phillips-homelab.net: 192.168.10.194
-        jellyfin.phillips-homelab.net: 192.168.10.194
-        files.phillips-homelab.net: 192.168.10.194
-        openwebui.phillips-homelab.net: 192.168.10.194
-        blocky.phillips-homelab.net: 192.168.10.194
+        # Gateway services (Cilium Gateway API on .211)
+        argocd.phillips-homelab.net: 192.168.10.211
+        monitoring.phillips-homelab.net: 192.168.10.211
+        zot.phillips-homelab.net: 192.168.10.211
+        home-assistant.phillips-homelab.net: 192.168.10.211
+        jellyfin.phillips-homelab.net: 192.168.10.211
+        files.phillips-homelab.net: 192.168.10.211
+        openwebui.phillips-homelab.net: 192.168.10.211
+        blocky.phillips-homelab.net: 192.168.10.211
         # Registry mirror
         dockerhub.phillips-homelab.net: 192.168.10.195
         # Synology NAS

--- a/gitops/core/apps/blocky/service.yaml
+++ b/gitops/core/apps/blocky/service.yaml
@@ -9,8 +9,7 @@ metadata:
   labels:
     app: blocky
   annotations:
-    # Request a specific IP from Cilium LB pool if needed
-    # io.cilium/lb-ipam-ips: "192.168.10.194"
+    lbipam.cilium.io/ips: "192.168.10.210"
 spec:
   type: LoadBalancer
   selector:

--- a/gitops/tools/apps/jellyfin.yml
+++ b/gitops/tools/apps/jellyfin.yml
@@ -37,6 +37,8 @@ spec:
         service:
           type: LoadBalancer
           port: 8096
+          annotations:
+            lbipam.cilium.io/ips: "192.168.10.212"
         
         ingress:
           main:


### PR DESCRIPTION
## Summary
- Moves the Cilium LB IP pool from `192.168.10.191-194` (which fully overlapped all four node IPs) to `192.168.10.210-220`, eliminating the ARP race that was already present and started biting once homelab-04 reclaimed `.194` as a node IP
- Pins each LB service to a deterministic IP via `lbipam.cilium.io/ips` annotations
- Brings `ip-pool.yml` into the bootstrap manifest list (it had drifted as a one-off `kubectl apply` 13 months ago)

## IP migration
| Service | Old IP | New IP |
|---|---|---|
| `blocky/blocky-dns` | `.191` (collided with homelab-01) | `.210` |
| `gateways/cilium-gateway-tls-gateway` | `.194` (collided with homelab-04) | `.211` |
| `media/jellyfin` | `.193` (collided with homelab-03) | `.212` |
| `kube-system/cilium-ingress` | `.192` (collided with homelab-02) | `.213` (live-annotated; gitops follow-up — Cilium-operator-owned) |

Coordinated changes:
- `nameservers-local.yml`: nodes' resolver `.191` → `.210`
- Blocky configmap: gateway-routed hostname mappings `.194` → `.211`
- `gateways.yml`: pin Gateway via `spec.infrastructure.annotations`

## Out-of-band changes
- UDM Pro DHCP DNS server: `.191` → `.210` (LAN clients pick up on lease renewal)
- `omnictl cluster template sync` was already run during the migration to push the new nameservers to the nodes

## Test plan
- [x] `dig argocd.phillips-homelab.net @192.168.10.210` returns the new gateway IP
- [x] Blocky LB reachable at `.210`
- [ ] After merge: ArgoCD reverts the live-applied Blocky configmap drift (it was reverted mid-migration since gitops still had `.194`); this PR makes gitops the source of truth
- [ ] After merge: `https://argocd.phillips-homelab.net` resolves and loads
- [ ] After merge: `kubectl apply -f cluster/talos/omni/phillips-homelab/manifests/ip-pool.yml` to shrink the live pool to only `.210-220`
- [ ] After merge: `omnictl cluster template sync` to push the `extraManifests.yml` URL change

## Follow-ups
- Carry the per-machine `nameservers-local` patch onto homelab-03 (it's missing — pre-existing drift in the template, not introduced here)
- Move `cilium-ingress` IP pinning into Cilium helm values (currently a live `kubectl annotate` since the Service is owned by Cilium operator, not gitops)