### PR TITLE
feat(glance): add homepage at apex phillips-homelab.net

### DIFF
--- a/gitops/core/apps/certs.yml
+++ b/gitops/core/apps/certs.yml
@@ -103,3 +103,16 @@ spec:
     kind: ClusterIssuer
   secretName: blocky-tls
 ---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: glance-tls
+  namespace: gateways
+spec:
+  dnsNames:
+  - phillips-homelab.net
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  secretName: glance-tls
+---

--- a/gitops/core/apps/gateways.yml
+++ b/gitops/core/apps/gateways.yml
@@ -111,6 +111,20 @@ spec:
   - group: ""
     kind: Service
 ---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-glance-service
+  namespace: glance
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: gateways
+  to:
+  - group: ""
+    kind: Service
+---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -183,6 +197,14 @@ spec:
       certificateRefs:
       - kind: Secret
         name: blocky-tls
+  - name: https-9
+    protocol: HTTPS
+    port: 443
+    hostname: phillips-homelab.net
+    tls:
+      certificateRefs:
+      - kind: Secret
+        name: glance-tls
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -332,4 +354,22 @@ spec:
   - backendRefs:
     - name: blocky-ui
       namespace: blocky
+      port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: https-app-route-9
+  namespace: gateways
+spec:
+  parentRefs:
+  - name: tls-gateway
+    sectionName: https-9
+    namespace: gateways
+  hostnames:
+  - phillips-homelab.net
+  rules:
+  - backendRefs:
+    - name: glance
+      namespace: glance
       port: 80

--- a/gitops/tools/apps/glance.yml
+++ b/gitops/tools/apps/glance.yml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: glance
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: glance
+  project: default
+  source:
+    path: gitops/tools/apps/glance
+    repoURL: 'https://github.com/AlverezYari/phillips-homelab.git'
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/gitops/tools/apps/glance/configmap.yaml
+++ b/gitops/tools/apps/glance/configmap.yaml
@@ -1,0 +1,73 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: glance-config
+  namespace: glance
+data:
+  glance.yml: |
+    server:
+      port: 8080
+      host: 0.0.0.0
+
+    theme:
+      background-color: 240 8 9
+      primary-color: 43 50 70
+      contrast-multiplier: 1.1
+
+    pages:
+      - name: Home
+        columns:
+          - size: small
+            widgets:
+              - type: clock
+                hour-format: 12h
+
+              - type: weather
+                location: Austin, Texas, United States
+                units: imperial
+                hour-format: 12h
+
+          - size: full
+            widgets:
+              - type: bookmarks
+                groups:
+                  - title: Infra
+                    links:
+                      - title: ArgoCD
+                        url: https://argocd.phillips-homelab.net
+                      - title: Monitoring
+                        url: https://monitoring.phillips-homelab.net
+                      - title: Zot Registry
+                        url: https://zot.phillips-homelab.net
+                      - title: Blocky
+                        url: https://blocky.phillips-homelab.net
+                  - title: Apps
+                    links:
+                      - title: Home Assistant
+                        url: https://home-assistant.phillips-homelab.net
+                      - title: Jellyfin
+                        url: https://jellyfin.phillips-homelab.net
+                      - title: Files
+                        url: https://files.phillips-homelab.net
+                      - title: OpenWebUI
+                        url: https://openwebui.phillips-homelab.net
+
+              - type: rss
+                limit: 10
+                collapse-after: 5
+                cache: 3h
+                feeds:
+                  - url: https://kubernetes.io/feed.xml
+                    title: Kubernetes Blog
+                  - url: https://www.cncf.io/feed/
+                    title: CNCF
+
+          - size: small
+            widgets:
+              - type: releases
+                cache: 1d
+                repositories:
+                  - glanceapp/glance
+                  - argoproj/argo-cd
+                  - 0xerr0r/blocky
+                  - cilium/cilium

--- a/gitops/tools/apps/glance/deployment.yaml
+++ b/gitops/tools/apps/glance/deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: glance
+  namespace: glance
+  labels:
+    app: glance
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: glance
+  template:
+    metadata:
+      labels:
+        app: glance
+    spec:
+      containers:
+        - name: glance
+          image: glanceapp/glance:latest
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /app/config/glance.yml
+              subPath: glance.yml
+              readOnly: true
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: glance-config

--- a/gitops/tools/apps/glance/kustomization.yaml
+++ b/gitops/tools/apps/glance/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: glance
+
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml

--- a/gitops/tools/apps/glance/namespace.yaml
+++ b/gitops/tools/apps/glance/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: glance
+  labels:
+    name: glance

--- a/gitops/tools/apps/glance/service.yaml
+++ b/gitops/tools/apps/glance/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: glance
+  namespace: glance
+  labels:
+    app: glance
+spec:
+  type: ClusterIP
+  selector:
+    app: glance
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+      protocol: TCP


### PR DESCRIPTION
## Summary
- Hand-rolled `glanceapp/glance` deployment in `gitops/tools/apps/glance/` (own ConfigMap, mirrors blocky pattern)
- Apex `phillips-homelab.net` routed via 9th HTTPS listener on `tls-gateway` + HTTPRoute + ReferenceGrant
- `glance-tls` Certificate added so cert-manager provisions the apex cert via letsencrypt-prod

## Test plan
- [ ] ArgoCD `tool-apps` syncs the new `glance` Application
- [ ] ArgoCD `glance` Application reaches Healthy/Synced
- [ ] cert-manager issues `glance-tls` Secret in `gateways` ns
- [ ] `tls-gateway` listener `https-9` Accepted=True / ResolvedRefs=True
- [ ] `https://phillips-homelab.net` loads the glance UI (DNS A record for apex must point at the gateway LB IP)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Glance dashboard application with configurable widgets including clock, weather, bookmarks, RSS feeds, and GitHub releases monitoring
  * Enabled HTTPS/TLS encryption for the application domain
  * Configured automated deployment and routing infrastructure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->