### PR TITLE
fix(blocky): add apex DNS mapping for glance

### DIFF
--- a/gitops/core/apps/blocky/configmap.yaml
+++ b/gitops/core/apps/blocky/configmap.yaml
@@ -37,6 +37,7 @@ data:
     customDNS:
       mapping:
         # Gateway services (Cilium Gateway API on .211)
+        phillips-homelab.net: 192.168.10.211
         argocd.phillips-homelab.net: 192.168.10.211
         monitoring.phillips-homelab.net: 192.168.10.211
         zot.phillips-homelab.net: 192.168.10.211


### PR DESCRIPTION
Follow-up to #212. Adds `phillips-homelab.net → 192.168.10.211` to blocky so LAN clients can resolve the apex (gateway listener `https-9` routes it to glance, but DNS was missing).