### PR TITLE
fix(argocd): bump v3.3.8 -> v3.3.9 (GHSA-3v3m-wc6v-x4x3)

### DIFF
--- a/gitops/core/apps/argocd/kustomization.yml
+++ b/gitops/core/apps/argocd/kustomization.yml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 namespace: argocd
 resources:
-  - github.com/argoproj/argo-cd/manifests/cluster-install?ref=v3.3.8
+  - github.com/argoproj/argo-cd/manifests/cluster-install?ref=v3.3.9
 
 patches:
   - path: params.yml


### PR DESCRIPTION
## Summary

- Bumps the Argo CD kustomize ref from v3.3.8 → v3.3.9 to patch [GHSA-3v3m-wc6v-x4x3](https://github.com/argoproj/argo-cd/security/advisories/GHSA-3v3m-wc6v-x4x3) (CVSS 9.6, Critical).
- The CVE allows authenticated users to extract plaintext Kubernetes Secret data via the ServerSideDiff endpoint. We actively use `ServerSideDiff=true` on atuin and the CNPG-related apps, so we are within the affected configuration surface.
- v3.3.9 is a clean patch release — bug fixes only (#27495, #27553, #27265, #27521, #27602, #27509) plus the upstream fork merge for the security fix. No breaking changes, no migration steps.

## Test plan

- [ ] Argo CD self-Application syncs cleanly (it already uses `ServerSideApply=true` for the CRD-size workaround from the v3.2→v3.3 upgrade)
- [ ] `kubectl -n argocd get deploy argocd-server -o jsonpath='{.spec.template.spec.containers[0].image}'` reports `quay.io/argoproj/argocd:v3.3.9`
- [ ] All Argo Applications stay Synced/Healthy post-upgrade

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Argo CD to version 3.3.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->