### PR TITLE
feat(forgejo): self-hosted Forgejo for GitHub mirroring

### DIFF
--- a/gitops/core/apps/blocky/configmap.yaml
+++ b/gitops/core/apps/blocky/configmap.yaml
@@ -46,6 +46,7 @@ data:
         files.phillips-homelab.net: 192.168.10.211
         openwebui.phillips-homelab.net: 192.168.10.211
         blocky.phillips-homelab.net: 192.168.10.211
+        code.phillips-homelab.net: 192.168.10.211
         # Registry mirror
         dockerhub.phillips-homelab.net: 192.168.10.195
         # Synology NAS

--- a/gitops/core/apps/certs.yml
+++ b/gitops/core/apps/certs.yml
@@ -116,3 +116,16 @@ spec:
     kind: ClusterIssuer
   secretName: glance-tls
 ---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: code-tls
+  namespace: gateways
+spec:
+  dnsNames:
+  - code.phillips-homelab.net
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  secretName: code-tls
+---

--- a/gitops/core/apps/gateways.yml
+++ b/gitops/core/apps/gateways.yml
@@ -125,6 +125,20 @@ spec:
   - group: ""
     kind: Service
 ---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-forgejo-service
+  namespace: forgejo
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: gateways
+  to:
+  - group: ""
+    kind: Service
+---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -205,6 +219,14 @@ spec:
       certificateRefs:
       - kind: Secret
         name: glance-tls
+  - name: https-10
+    protocol: HTTPS
+    port: 443
+    hostname: code.phillips-homelab.net
+    tls:
+      certificateRefs:
+      - kind: Secret
+        name: code-tls
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -373,3 +395,21 @@ spec:
     - name: glance
       namespace: glance
       port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: https-app-route-10
+  namespace: gateways
+spec:
+  parentRefs:
+  - name: tls-gateway
+    sectionName: https-10
+    namespace: gateways
+  hostnames:
+  - code.phillips-homelab.net
+  rules:
+  - backendRefs:
+    - name: forgejo-http
+      namespace: forgejo
+      port: 3000

--- a/gitops/tools/apps/forgejo-db.yml
+++ b/gitops/tools/apps/forgejo-db.yml
@@ -1,0 +1,60 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: forgejo-db
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: forgejo
+  project: default
+  ignoreDifferences:
+  - group: postgresql.cnpg.io
+    kind: Cluster
+    jsonPointers:
+    - /spec/affinity
+    - /spec/bootstrap/initdb/encoding
+    - /spec/bootstrap/initdb/localeCType
+    - /spec/bootstrap/initdb/localeCollate
+    - /spec/enablePDB
+    - /spec/enableSuperuserAccess
+    - /spec/failoverDelay
+    - /spec/imageName
+    - /spec/logLevel
+    - /spec/maxSyncReplicas
+    - /spec/minSyncReplicas
+    - /spec/monitoring
+    - /spec/postgresGID
+    - /spec/postgresUID
+    - /spec/postgresql
+    - /spec/primaryUpdateMethod
+    - /spec/primaryUpdateStrategy
+    - /spec/replicationSlots
+    - /spec/smartShutdownTimeout
+    - /spec/startDelay
+    - /spec/stopDelay
+    - /spec/switchoverDelay
+    jqPathExpressions:
+    - '.spec.plugins[]?.enabled'
+  - group: external-secrets.io
+    kind: ExternalSecret
+    jsonPointers:
+    - /spec/refreshInterval
+    - /spec/target/deletionPolicy
+    - /spec/data
+  source:
+    path: gitops/tools/apps/forgejo-db
+    repoURL: https://github.com/AlverezYari/phillips-homelab.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - ServerSideDiff=true

--- a/gitops/tools/apps/forgejo-db/cluster.yaml
+++ b/gitops/tools/apps/forgejo-db/cluster.yaml
@@ -1,0 +1,29 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: forgejo-pg
+  namespace: forgejo
+spec:
+  instances: 1
+
+  storage:
+    storageClass: syno-iscsi-default
+    size: 10Gi
+
+  bootstrap:
+    initdb:
+      database: forgejo
+      owner: forgejo
+
+  plugins:
+  - name: barman-cloud.cloudnative-pg.io
+    isWALArchiver: true
+    parameters:
+      barmanObjectName: forgejo-backups
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 512Mi

--- a/gitops/tools/apps/forgejo-db/externalsecret.yaml
+++ b/gitops/tools/apps/forgejo-db/externalsecret.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: forgejo-garage-backup
+  namespace: forgejo
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: staging
+  target:
+    name: forgejo-garage-backup
+    creationPolicy: Owner
+  data:
+  - secretKey: ACCESS_KEY_ID
+    remoteRef:
+      key: forgejo-garage-backup
+      property: access_key_id
+  - secretKey: ACCESS_SECRET_KEY
+    remoteRef:
+      key: forgejo-garage-backup
+      property: secret_access_key

--- a/gitops/tools/apps/forgejo-db/kustomization.yaml
+++ b/gitops/tools/apps/forgejo-db/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: forgejo
+
+resources:
+  - namespace.yaml
+  - externalsecret.yaml
+  - objectstore.yaml
+  - cluster.yaml
+  - scheduledbackup.yaml
+  - vmpodscrape.yaml

--- a/gitops/tools/apps/forgejo-db/namespace.yaml
+++ b/gitops/tools/apps/forgejo-db/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: forgejo

--- a/gitops/tools/apps/forgejo-db/objectstore.yaml
+++ b/gitops/tools/apps/forgejo-db/objectstore.yaml
@@ -1,0 +1,19 @@
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: forgejo-backups
+  namespace: forgejo
+spec:
+  configuration:
+    destinationPath: s3://forgejo-backups/
+    endpointURL: http://garage.garage.svc:3900
+    s3Credentials:
+      accessKeyId:
+        name: forgejo-garage-backup
+        key: ACCESS_KEY_ID
+      secretAccessKey:
+        name: forgejo-garage-backup
+        key: ACCESS_SECRET_KEY
+    wal:
+      compression: gzip
+  retentionPolicy: "7d"

--- a/gitops/tools/apps/forgejo-db/scheduledbackup.yaml
+++ b/gitops/tools/apps/forgejo-db/scheduledbackup.yaml
@@ -1,0 +1,13 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: forgejo-pg-daily
+  namespace: forgejo
+spec:
+  schedule: "0 0 3 * * *"
+  backupOwnerReference: self
+  cluster:
+    name: forgejo-pg
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/gitops/tools/apps/forgejo-db/vmpodscrape.yaml
+++ b/gitops/tools/apps/forgejo-db/vmpodscrape.yaml
@@ -1,0 +1,13 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMPodScrape
+metadata:
+  name: forgejo-pg
+  namespace: forgejo
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: forgejo-pg
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s

--- a/gitops/tools/apps/forgejo.yml
+++ b/gitops/tools/apps/forgejo.yml
@@ -1,0 +1,84 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: forgejo
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: forgejo
+  project: default
+  source:
+    chart: forgejo
+    repoURL: oci://code.forgejo.org/forgejo-helm
+    targetRevision: 17.0.1
+    helm:
+      values: |
+        postgresql:
+          enabled: false
+        postgresql-ha:
+          enabled: false
+        valkey:
+          enabled: false
+        valkey-cluster:
+          enabled: false
+        redis:
+          enabled: false
+        redis-cluster:
+          enabled: false
+
+        replicaCount: 1
+
+        persistence:
+          enabled: true
+          create: true
+          size: 200Gi
+          accessModes:
+            - ReadWriteOnce
+          storageClass: syno-iscsi-default
+
+        service:
+          http:
+            type: ClusterIP
+            port: 3000
+          ssh:
+            type: ClusterIP
+            port: 22
+
+        ingress:
+          enabled: false
+
+        gitea:
+          config:
+            server:
+              ROOT_URL: https://code.phillips-homelab.net
+              DOMAIN: code.phillips-homelab.net
+              DISABLE_SSH: true
+              OFFLINE_MODE: false
+            database:
+              DB_TYPE: postgres
+              HOST: forgejo-pg-rw.forgejo.svc.cluster.local:5432
+              NAME: forgejo
+              USER: forgejo
+              SSL_MODE: require
+            cache:
+              ADAPTER: memory
+            session:
+              PROVIDER: memory
+          additionalConfigFromEnvs:
+            - name: GITEA__database__PASSWD
+              valueFrom:
+                secretKeyRef:
+                  name: forgejo-pg-app
+                  key: password
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true


### PR DESCRIPTION
## Summary

- Stands up Forgejo at `https://code.phillips-homelab.net` for mirroring GitHub repos locally (and as a sandbox for ArgoCD-friendly CI experiments later).
- **Internal-only access** via Blocky → Cilium Gateway (LAN/Tailnet). No public exposure for now — will evaluate usefulness internally first, then maybe add a CF tunnel public hostname later.
- CNPG-backed (`forgejo-pg`, 10Gi, daily Barman→Garage backups), modeled on the atuin pattern.
- 200Gi `syno-iscsi-default` PVC for `/data` (git repos, attachments, action logs, packages).
- Two Argo Apps: `forgejo-db` (kustomize, sync-wave 0) and `forgejo` (Helm chart `forgejo-helm/forgejo:17.0.1` via OCI, sync-wave 1, bundled postgres/valkey/redis disabled, password injected from CNPG-managed `forgejo-pg-app` secret).
- Gateway: new `https-10` listener + HTTPRoute → `forgejo-http:3000`, ReferenceGrant in `forgejo` ns, `code-tls` Certificate via `letsencrypt-prod`.
- Blocky: maps `code.phillips-homelab.net` → `192.168.10.211` (Cilium Gateway), matching the existing internal-host pattern.

## Out-of-band setup already done

- Garage bucket `forgejo-backups` + key `forgejo-backup-key` (RWO permissions confirmed via `garage bucket info`)
- 1Password item `forgejo-garage-backup` with fields `access_key_id` / `secret_access_key`

## Things that may need a follow-up patch post-deploy

- **Forgejo chart service name guess** — used `forgejo-http:3000` for the HTTPRoute backend per chart docs. If the chart actually renders it as just `forgejo`, the route 404s and we patch it. Verify with `kubectl get svc -n forgejo` after first sync.
- **OCI Helm syntax** — used `oci://` prefix on `repoURL`. Argo v3.3.9 should auto-detect; if it doesn't, alternative is registering the repo via `argocd-repo-server` config.

## Test plan

- [ ] Both `forgejo-db` and `forgejo` Argo Apps sync to Synced/Healthy
- [ ] CNPG `Cluster forgejo-pg` reports primary ready, ScheduledBackup completes once
- [ ] First Barman backup lands in Garage `forgejo-backups` bucket
- [ ] Forgejo pod comes up, connects to the CNPG DB without password issues
- [ ] `code.phillips-homelab.net` resolves via Blocky on LAN, cert-manager has issued `code-tls`, page loads over HTTPS
- [ ] Create admin user, configure first GitHub pull-mirror repo, verify clone-on-schedule works