### PR TITLE
fix(forgejo): drop oci:// prefix on Helm repoURL

### DIFF
--- a/gitops/tools/apps/forgejo.yml
+++ b/gitops/tools/apps/forgejo.yml
@@ -14,7 +14,7 @@ spec:
   project: default
   source:
     chart: forgejo
-    repoURL: oci://code.forgejo.org/forgejo-helm
+    repoURL: code.forgejo.org/forgejo-helm
     targetRevision: 17.0.1
     helm:
       values: |


### PR DESCRIPTION
## Summary

The Forgejo Argo Application was failing with:

```
Failed to load target state: failed to generate manifest for source 1 of 1: rpc error: code = Unknown desc = failed to resolve revision "17.0.1": cannot get digest for revision 17.0.1: code.forgejo.org/forgejo-helm:17.0.1: not found
```

With the `oci://` prefix, Argo CD treats the entire `repoURL` as a literal OCI artifact reference, ignores the `chart:` field, and tries to fetch `<repoURL>:<targetRevision>` directly. Dropping the prefix lets Argo correctly compose `<repoURL>/<chart>:<targetRevision>` (matching the format used by other helm Argo Apps in this repo, e.g. grafana).

## Test plan

- [ ] `forgejo` Argo Application transitions from "Failed to load target state" to Synced/Healthy
- [ ] Forgejo pod starts and reaches Ready