### PR TITLE
feat(pixelflut): collaborative pixel canvas (breakwater)

### DIFF
--- a/gitops/tools/apps/pixelflut.yml
+++ b/gitops/tools/apps/pixelflut.yml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: pixelflut
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: pixelflut
+  project: default
+  source:
+    path: gitops/tools/apps/pixelflut
+    repoURL: https://github.com/AlverezYari/phillips-homelab.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/gitops/tools/apps/pixelflut/deployment.yaml
+++ b/gitops/tools/apps/pixelflut/deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: breakwater
+  namespace: pixelflut
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: breakwater
+  template:
+    metadata:
+      labels:
+        app: breakwater
+    spec:
+      containers:
+        - name: breakwater
+          image: sbernauer/breakwater:latest
+          args:
+            - --width
+            - "1280"
+            - --height
+            - "720"
+            - --vnc-listen-address
+            - "0.0.0.0:5900"
+          ports:
+            - name: pixelflut
+              containerPort: 1234
+              protocol: TCP
+            - name: vnc
+              containerPort: 5900
+              protocol: TCP
+            - name: metrics
+              containerPort: 9100
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              memory: 512Mi

--- a/gitops/tools/apps/pixelflut/kustomization.yaml
+++ b/gitops/tools/apps/pixelflut/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: pixelflut
+
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml

--- a/gitops/tools/apps/pixelflut/namespace.yaml
+++ b/gitops/tools/apps/pixelflut/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pixelflut

--- a/gitops/tools/apps/pixelflut/service.yaml
+++ b/gitops/tools/apps/pixelflut/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: breakwater
+  namespace: pixelflut
+spec:
+  type: LoadBalancer
+  selector:
+    app: breakwater
+  ports:
+    - name: pixelflut
+      port: 1234
+      targetPort: pixelflut
+      protocol: TCP
+    - name: vnc
+      port: 5900
+      targetPort: vnc
+      protocol: TCP


### PR DESCRIPTION
Hey Emie! This is your first Argo app to deploy. Here's what's in the box and what to do.

## What this deploys

A [Pixelflut](https://wiki.cccgoe.de/wiki/Pixelflut) server called [breakwater](https://github.com/sbernauer/breakwater). Many people open a TCP connection to the same server and send pixel commands; everyone sees a shared live canvas.

- **1280×720 canvas**, ephemeral (no PVC — canvas resets on pod restart)
- **One LoadBalancer Service** with two ports on the LAN, no gateway/cert/DNS plumbing required for v1:
  - `1234/TCP` — the Pixelflut protocol (draw)
  - `5900/TCP` — VNC (view the canvas)
- IP comes from `lan-cloud-pool` (192.168.10.210–.220, currently 7 free)

## The pattern (study notes)

Look at this PR alongside [`gitops/tools/apps/glance/`](https://github.com/AlverezYari/phillips-homelab/tree/main/gitops/tools/apps/glance) — same shape:

```
gitops/tools/apps/pixelflut.yml         <- Argo Application (the "manage this app" pointer)
gitops/tools/apps/pixelflut/
├── namespace.yaml                       <- the k8s namespace
├── deployment.yaml                      <- the breakwater Pod spec
├── service.yaml                         <- the LoadBalancer
└── kustomization.yaml                   <- ties them together
```

Argo watches `tools/apps/`. When this PR merges, Argo notices the new `pixelflut.yml` Application and creates everything inside it.

## How to deploy (your part!)

1. Eyeball the diff. Especially look at:
   - `deployment.yaml` — image is `sbernauer/breakwater:latest`. We can pin to a specific tag later for repeatability.
   - `service.yaml` — `type: LoadBalancer` is what triggers Cilium to grab a LAN IP for it.
2. **Mark this PR ready-for-review** (the "Ready for review" button at the bottom of the GitHub PR page) and then **Squash and merge**.
3. Argo will detect the new files within ~3 minutes (or you can hard-refresh `tool-apps` in the Argo UI).

## After it deploys

```fish
# Find the LoadBalancer IP (will be one of 192.168.10.210-220)
kubectl -n pixelflut get svc breakwater

# Draw a single red pixel at (100, 50) — instant!
echo "PX 100 50 ff0000" | nc <LB_IP> 1234

# Send 100 random pink pixels
for i in (seq 100); echo "PX (random 0 1279) (random 0 719) ff66cc"; end | nc <LB_IP> 1234

# View the canvas: any VNC client to <LB_IP>:5900
# - macOS: Finder → Cmd+K → vnc://<LB_IP>:5900
# - Linux: TigerVNC, Remmina, etc.
# - Windows: TightVNC viewer
```

## Bonus: handy `pflut` helper

If you want a one-liner per pixel, drop this into your shell config:

```fish
function pflut --argument-names ip x y color
    echo "PX $x $y $color" | nc $ip 1234
end
# usage:  pflut 192.168.10.215 100 50 ff0000
```

## Test plan

- [ ] PR merges, Argo creates Application `pixelflut`
- [ ] Pod `pixelflut/breakwater-*` reaches Running 1/1
- [ ] `kubectl -n pixelflut get svc breakwater` shows an EXTERNAL-IP in 192.168.10.210-220 range
- [ ] `nc <LB_IP> 1234` accepts a connection and sends pixels
- [ ] VNC client to `<LB_IP>:5900` shows the live canvas

## Next-up ideas (skip for v1)

- Pin the image tag instead of `:latest`
- Add a noVNC sidecar so you can view the canvas in a browser at `pixelflut.phillips-homelab.net`
- Add a PVC to make the canvas survive pod restarts
- Wire breakwater's Prometheus metrics (port 9100) into VictoriaMetrics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployed pixelflut application providing Pixelflut drawing protocol service (port 1234) and VNC remote access (port 5900), both exposed via load balancer
  * Integrated with Argo CD for automated deployment management, synchronization, and self-healing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->