### PR TITLE
feat(pixelflut): add easy-novnc sidecar for browser canvas viewing

### DIFF
--- a/gitops/tools/apps/pixelflut/deployment.yaml
+++ b/gitops/tools/apps/pixelflut/deployment.yaml
@@ -39,3 +39,22 @@ spec:
               memory: 128Mi
             limits:
               memory: 512Mi
+        - name: novnc
+          image: geek1011/easy-novnc:latest
+          args:
+            - --addr
+            - "0.0.0.0:8080"
+            - --host
+            - "127.0.0.1"
+            - --port
+            - "5900"
+          ports:
+            - name: web
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              memory: 128Mi

--- a/gitops/tools/apps/pixelflut/service.yaml
+++ b/gitops/tools/apps/pixelflut/service.yaml
@@ -16,3 +16,7 @@ spec:
       port: 5900
       targetPort: vnc
       protocol: TCP
+    - name: web
+      port: 8080
+      targetPort: web
+      protocol: TCP


### PR DESCRIPTION
## Summary

Adds `geek1011/easy-novnc` as a sidecar container in the breakwater Pod. easy-novnc is a tiny Go binary that bridges a TCP VNC server (here, breakwater's port 5900 on localhost) to a noVNC web client served on HTTP — open the URL in a browser, hit Connect, see the live canvas. No VNC client install required.

- Adds a second container in `deployment.yaml` (~25m CPU, 32Mi mem)
- Adds a third Service port (`web` → 8080) on the existing LoadBalancer
- Same LB IP, two new endpoints: `http://<LB>:8080` for browser viewing

## Test plan

- [ ] Both containers Running 1/1
- [ ] `kubectl -n pixelflut get svc breakwater` shows port 8080 mapped
- [ ] `http://<LB-IP>:8080` loads noVNC; Connect button shows the canvas
- [ ] Original VNC on `<LB-IP>:5900` still works
- [ ] Pixelflut TCP on `<LB-IP>:1234` still works