### PR TITLE
feat(synology-csi): adopt CSI install + StorageClass into gitops

### DIFF
--- a/gitops/core/apps/syno-iscsi-default.yaml
+++ b/gitops/core/apps/syno-iscsi-default.yaml
@@ -1,0 +1,15 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: syno-iscsi-default
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: csi.san.synology.com
+parameters:
+  dsm: 192.168.10.195
+  fsType: ext4
+  location: /volume1
+  protocol: iscsi
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+allowVolumeExpansion: true

--- a/gitops/core/apps/synology-csi.yml
+++ b/gitops/core/apps/synology-csi.yml
@@ -1,0 +1,49 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: synology-csi
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: synology-csi
+  project: default
+  # Adopt the live install as-is. The CSI was originally `kubectl apply`'d
+  # with old (2021-era) sidecars and Casey's custom v1.2.0.2 image build;
+  # gitops-ifying first, sidecar/upstream bumps in a follow-up PR.
+  #
+  # client-info-secret (the DSM credentials) is intentionally NOT in this
+  # kustomize. It stays out-of-band; an ExternalSecret follow-up will move
+  # it to 1Password.
+  ignoreDifferences:
+    # CSIDriver gets server-side defaults set by the API server.
+    - group: storage.k8s.io
+      kind: CSIDriver
+      jsonPointers:
+        - /spec/requiresRepublish
+        - /spec/seLinuxMount
+        - /spec/storageCapacity
+    # StatefulSet/DaemonSet template metadata may grow kubectl rollout
+    # restart annotations that we don't want to track.
+    - group: apps
+      kind: StatefulSet
+      jsonPointers:
+        - /spec/template/metadata/annotations
+    - group: apps
+      kind: DaemonSet
+      jsonPointers:
+        - /spec/template/metadata/annotations
+  source:
+    path: gitops/core/apps/synology-csi
+    repoURL: https://github.com/AlverezYari/phillips-homelab.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - ServerSideDiff=true

--- a/gitops/core/apps/synology-csi/controller.yaml
+++ b/gitops/core/apps/synology-csi/controller.yaml
@@ -1,0 +1,106 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: synology-csi-controller
+  namespace: synology-csi
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: synology-csi-controller
+  serviceName: synology-csi-controller
+  template:
+    metadata:
+      labels:
+        app: synology-csi-controller
+    spec:
+      containers:
+      - args:
+        - --timeout=60s
+        - --csi-address=$(ADDRESS)
+        - --v=5
+        - --extra-create-metadata
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        image: registry.k8s.io/sig-storage/csi-provisioner:v3.0.0
+        imagePullPolicy: Always
+        name: csi-provisioner
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+      - args:
+        - --v=5
+        - --csi-address=$(ADDRESS)
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        image: registry.k8s.io/sig-storage/csi-attacher:v3.3.0
+        imagePullPolicy: Always
+        name: csi-attacher
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+      - args:
+        - --v=5
+        - --csi-address=$(ADDRESS)
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        image: registry.k8s.io/sig-storage/csi-resizer:v1.3.0
+        imagePullPolicy: Always
+        name: csi-resizer
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+      - args:
+        - --nodeid=NotUsed
+        - --endpoint=$(CSI_ENDPOINT)
+        - --client-info
+        - /etc/synology/client-info.yml
+        - --log-level=info
+        env:
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+        image: ghcr.io/alverezyari/synology-csi:v1.2.0.2
+        imagePullPolicy: IfNotPresent
+        name: csi-plugin
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+        - mountPath: /etc/synology
+          name: client-info
+          readOnly: true
+      hostNetwork: true
+      serviceAccountName: csi-controller-sa
+      volumes:
+      - emptyDir: {}
+        name: socket-dir
+      - name: client-info
+        secret:
+          secretName: client-info-secret

--- a/gitops/core/apps/synology-csi/csidriver.yaml
+++ b/gitops/core/apps/synology-csi/csidriver.yaml
@@ -1,0 +1,10 @@
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: csi.san.synology.com
+spec:
+  attachRequired: true
+  fsGroupPolicy: ReadWriteOnceWithFSType
+  podInfoOnMount: true
+  volumeLifecycleModes:
+    - Persistent

--- a/gitops/core/apps/synology-csi/kustomization.yaml
+++ b/gitops/core/apps/synology-csi/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - csidriver.yaml
+  - serviceaccounts.yaml
+  - rbac.yaml
+  - controller.yaml
+  - node.yaml
+  - snapshotter.yaml

--- a/gitops/core/apps/synology-csi/namespace.yaml
+++ b/gitops/core/apps/synology-csi/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: synology-csi

--- a/gitops/core/apps/synology-csi/node.yaml
+++ b/gitops/core/apps/synology-csi/node.yaml
@@ -1,0 +1,99 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: synology-csi-node
+  namespace: synology-csi
+spec:
+  selector:
+    matchLabels:
+      app: synology-csi-node
+  template:
+    metadata:
+      labels:
+        app: synology-csi-node
+    spec:
+      containers:
+      - args:
+        - --v=5
+        - --csi-address=$(ADDRESS)
+        - --kubelet-registration-path=$(REGISTRATION_PATH)
+        env:
+        - name: ADDRESS
+          value: /csi/csi.sock
+        - name: REGISTRATION_PATH
+          value: /var/lib/kubelet/plugins/csi.san.synology.com/csi.sock
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.3.0
+        imagePullPolicy: Always
+        name: csi-driver-registrar
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /csi
+          name: plugin-dir
+        - mountPath: /registration
+          name: registration-dir
+      - args:
+        - --nodeid=$(KUBE_NODE_NAME)
+        - --endpoint=$(CSI_ENDPOINT)
+        - --client-info
+        - /etc/synology/client-info.yml
+        - --log-level=info
+        env:
+        - name: CSI_ENDPOINT
+          value: unix://csi/csi.sock
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        image: ghcr.io/alverezyari/synology-csi:v1.2.0.2
+        imagePullPolicy: IfNotPresent
+        name: csi-plugin
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/kubelet
+          mountPropagation: Bidirectional
+          name: kubelet-dir
+        - mountPath: /csi
+          name: plugin-dir
+        - mountPath: /etc/synology
+          name: client-info
+          readOnly: true
+        - mountPath: /host
+          name: host-root
+        - mountPath: /dev
+          name: device-dir
+      hostNetwork: true
+      hostPID: true
+      serviceAccountName: csi-node-sa
+      volumes:
+      - hostPath:
+          path: /var/lib/kubelet
+          type: Directory
+        name: kubelet-dir
+      - hostPath:
+          path: /var/lib/kubelet/plugins/csi.san.synology.com/
+          type: DirectoryOrCreate
+        name: plugin-dir
+      - hostPath:
+          path: /var/lib/kubelet/plugins_registry
+          type: Directory
+        name: registration-dir
+      - name: client-info
+        secret:
+          secretName: client-info-secret
+      - hostPath:
+          path: /
+          type: Directory
+        name: host-root
+      - hostPath:
+          path: /dev
+          type: Directory
+        name: device-dir

--- a/gitops/core/apps/synology-csi/rbac.yaml
+++ b/gitops/core/apps/synology-csi/rbac.yaml
@@ -1,0 +1,246 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: synology-csi-controller-role
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumeclaims/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - csi.storage.k8s.io
+  resources:
+  - csinodeinfos
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  - volumeattachments/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: synology-csi-node-role
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: synology-csi-snapshotter-role
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents/status
+  verbs:
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: synology-csi-controller-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: synology-csi-controller-role
+subjects:
+- kind: ServiceAccount
+  name: csi-controller-sa
+  namespace: synology-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: synology-csi-node-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: synology-csi-node-role
+subjects:
+- kind: ServiceAccount
+  name: csi-node-sa
+  namespace: synology-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: synology-csi-snapshotter-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: synology-csi-snapshotter-role
+subjects:
+- kind: ServiceAccount
+  name: csi-snapshotter-sa
+  namespace: synology-csi

--- a/gitops/core/apps/synology-csi/serviceaccounts.yaml
+++ b/gitops/core/apps/synology-csi/serviceaccounts.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-controller-sa
+  namespace: synology-csi
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-node-sa
+  namespace: synology-csi
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-snapshotter-sa
+  namespace: synology-csi

--- a/gitops/core/apps/synology-csi/snapshotter.yaml
+++ b/gitops/core/apps/synology-csi/snapshotter.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: synology-csi-snapshotter
+  namespace: synology-csi
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: synology-csi-snapshotter
+  serviceName: synology-csi-snapshotter
+  template:
+    metadata:
+      labels:
+        app: synology-csi-snapshotter
+    spec:
+      containers:
+      - args:
+        - --v=5
+        - --csi-address=$(ADDRESS)
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        image: registry.k8s.io/sig-storage/csi-snapshotter:v4.2.1
+        imagePullPolicy: Always
+        name: csi-snapshotter
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+      - args:
+        - --nodeid=NotUsed
+        - --endpoint=$(CSI_ENDPOINT)
+        - --client-info
+        - /etc/synology/client-info.yml
+        - --log-level=info
+        env:
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+        image: ghcr.io/alverezyari/synology-csi:v1.2.0.2
+        imagePullPolicy: IfNotPresent
+        name: csi-plugin
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+        - mountPath: /etc/synology
+          name: client-info
+          readOnly: true
+      hostNetwork: true
+      serviceAccountName: csi-snapshotter-sa
+      volumes:
+      - emptyDir: {}
+        name: socket-dir
+      - name: client-info
+        secret:
+          secretName: client-info-secret


### PR DESCRIPTION
## Summary

Adopts the existing live `synology-csi` install (originally a `kubectl apply` drift item) and the `syno-iscsi-default` StorageClass into gitops. **Adopt-as-is**: every manifest matches what's currently running, so Argo's first sync is a no-op.

\`\`\`
$ kubectl diff -f gitops/core/apps/synology-csi/   # empty
$ kubectl diff -f gitops/core/apps/syno-iscsi-default.yaml   # empty
\`\`\`

## What's adopted

- Namespace `synology-csi`
- CSIDriver `csi.san.synology.com`
- 3 ServiceAccounts (`csi-controller-sa`, `csi-node-sa`, `csi-snapshotter-sa`)
- 3 ClusterRoles + matching ClusterRoleBindings
- StatefulSet `synology-csi-controller` (4 containers: provisioner v3.0.0, attacher v3.3.0, resizer v1.3.0, csi-plugin `ghcr.io/alverezyari/synology-csi:v1.2.0.2`)
- DaemonSet `synology-csi-node` (2 containers: driver-registrar v2.3.0 + csi-plugin)
- StatefulSet `synology-csi-snapshotter` (2 containers: snapshotter v4.2.1 + csi-plugin)
- StorageClass `syno-iscsi-default` (default class)

## Intentionally NOT in this PR (follow-ups)

- **`client-info-secret`** (DSM credentials) — stays out-of-band for now. Follow-up PR will replace it with an ExternalSecret pulling from 1Password (matching the pattern used by `garage-secrets.yml`, `atuin/externalsecret.yaml`, etc.). Item shape: a single field containing the rendered `client-info.yml` blob.
- **Sidecar version bumps** — provisioner v3.0.0, attacher v3.3.0, resizer v1.3.0, snapshotter v4.2.1, registrar v2.3.0 are all **2021-era releases** running against k8s v1.35.4. This is a strong candidate root cause for the slow-mkfs symptoms. Bump in a follow-up with current versions (v5.x for provisioner/attacher, v1.13 for resizer, v8.x for snapshotter, v2.13 for registrar).
- **Move off Casey's fork** — `ghcr.io/alverezyari/synology-csi:v1.2.0.2` is a custom build between upstream v1.2.0 (Aug 2024) and v1.2.1 (Oct 2025). After we have a stable gitops baseline, evaluate switching to upstream `synology/synology-csi:v1.2.1` for the security/maintenance benefits unless the fork has unique behavior we depend on.
- **Talos extension version pinning** — `siderolabs/iscsi-tools` and `siderolabs/util-linux-tools` are referenced unpinned in `cluster/talos/omni/phillips-homelab/template.yaml`. They're implicitly pinned via `talos.version: v1.12.6`, so the drift concern is overstated, but explicit pinning would be tidier.

## Test plan

- [x] `kubectl diff -f` against kustomize output: empty
- [ ] Argo creates Application `synology-csi` and reaches Synced/Healthy
- [ ] No CSI pods restart during sync (StatefulSets/DaemonSet untouched)
- [ ] `syno-iscsi-default` StorageClass adopted by `homelab-core` Application
- [ ] Existing PVCs (forgejo, atuin, etc.) keep mounting normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Synology NAS storage integration as default storage provisioner for persistent volumes
  * Enabled automatic volume provisioning with iSCSI protocol support

* **Chores**
  * Deployed Container Storage Interface driver components with automated lifecycle management
  * Configured necessary permissions and service accounts for storage operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->