### PR TITLE
feat(synology-csi): manage client-info-secret via ExternalSecret

### DIFF
--- a/gitops/core/apps/synology-csi.yml
+++ b/gitops/core/apps/synology-csi.yml
@@ -35,6 +35,13 @@ spec:
       kind: DaemonSet
       jsonPointers:
         - /spec/template/metadata/annotations
+    # ESO mutates these post-admission with defaults; matches atuin pattern.
+    - group: external-secrets.io
+      kind: ExternalSecret
+      jsonPointers:
+        - /spec/refreshInterval
+        - /spec/target/deletionPolicy
+        - /spec/data
   source:
     path: gitops/core/apps/synology-csi
     repoURL: https://github.com/AlverezYari/phillips-homelab.git

--- a/gitops/core/apps/synology-csi/externalsecret.yaml
+++ b/gitops/core/apps/synology-csi/externalsecret.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: client-info-secret
+  namespace: synology-csi
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: staging
+  target:
+    name: client-info-secret
+    creationPolicy: Owner
+  data:
+  - secretKey: client-info.yml
+    remoteRef:
+      key: synology-csi-client-info
+      property: client-info-yml

--- a/gitops/core/apps/synology-csi/kustomization.yaml
+++ b/gitops/core/apps/synology-csi/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - csidriver.yaml
   - serviceaccounts.yaml
   - rbac.yaml
+  - externalsecret.yaml
   - controller.yaml
   - node.yaml
   - snapshotter.yaml


### PR DESCRIPTION
## Summary

Removes the last out-of-band piece of the synology-csi install: the `client-info-secret` (DSM credentials). Replaces it with an ExternalSecret pulling from 1Password.

**Pre-flight (already done)**: The live Secret was annotated with `external-secrets.io/managed=true` so ESO adopts it cleanly via `creationPolicy: Owner`. CSI pods don't restart — they keep reading the same Secret name + key (`client-info.yml`).

**1Password item shape (already created)**:
- Vault: `phillips-homelab` (matches atuin)
- Item: `synology-csi-client-info` (Login type)
- Field: `client-info-yml` — multiline, holds the rendered yaml blob (clients[0].host/port/https/username/password)

## Files

- `gitops/core/apps/synology-csi/externalsecret.yaml` — the new ExternalSecret
- `gitops/core/apps/synology-csi/kustomization.yaml` — adds it to resources
- `gitops/core/apps/synology-csi.yml` — adds ESO `ignoreDifferences` matching the atuin pattern (admission webhook mutates `/spec/refreshInterval`, `/spec/target/deletionPolicy`, `/spec/data` with defaults)

## Test plan

- [ ] PR merges; Argo's `synology-csi` Application picks it up (automated sync)
- [ ] ESO creates/adopts `client-info-secret` (verify with `kubectl -n synology-csi get externalsecret client-info-secret -o jsonpath='{.status.conditions[-1].type}={.status.conditions[-1].reason}'` → `Ready=SecretSynced`)
- [ ] Secret content unchanged (verify identical to current value via diff if curious)
- [ ] CSI pods stay Running 1/1 (no restarts triggered by Secret update — kubelet reads Secret on pod start, won't restart pods just because Secret was updated)
- [ ] An existing PVC still mounts a new pod successfully (smoke test that DSM auth still works)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added external secret management for Synology CSI, enabling automatic retrieval and synchronization of client configuration from a centralized secret store.

* **Chores**
  * Updated configuration to properly handle external secret resource synchronization and configuration drift detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->