### PR TITLE
fix(synology-csi): switch fork → upstream synology/synology-csi:v1.2.1

### DIFF
--- a/gitops/core/apps/synology-csi/controller.yaml
+++ b/gitops/core/apps/synology-csi/controller.yaml
@@ -81,7 +81,7 @@ spec:
         env:
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
-        image: ghcr.io/alverezyari/synology-csi:v1.2.0.2
+        image: synology/synology-csi:v1.2.1
         imagePullPolicy: IfNotPresent
         name: csi-plugin
         securityContext:

--- a/gitops/core/apps/synology-csi/node.yaml
+++ b/gitops/core/apps/synology-csi/node.yaml
@@ -52,7 +52,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: ghcr.io/alverezyari/synology-csi:v1.2.0.2
+        image: synology/synology-csi:v1.2.1
         imagePullPolicy: IfNotPresent
         name: csi-plugin
         securityContext:

--- a/gitops/core/apps/synology-csi/snapshotter.yaml
+++ b/gitops/core/apps/synology-csi/snapshotter.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
-        image: ghcr.io/alverezyari/synology-csi:v1.2.0.2
+        image: synology/synology-csi:v1.2.1
         imagePullPolicy: IfNotPresent
         name: csi-plugin
         securityContext:


### PR DESCRIPTION
## Summary

Switches the csi-plugin container image from Casey's private fork (`ghcr.io/alverezyari/synology-csi:v1.2.0.2`) to upstream (`synology/synology-csi:v1.2.1`, released Oct 2025).

The fork's repo is inaccessible via `gh api` (404 — private/deleted), so we have no way to audit what's in it vs upstream. Switching back to upstream:
- Eliminates that unknown
- Gets us on a maintained, signed image
- Matches the version Synology themselves test against

**Sidecars stay on the same 2021-era versions** because upstream v1.2.1's deploy/kubernetes manifests pin the exact same versions we already have — Synology hasn't bumped them. This PR matches their validated combination exactly.

## Files changed

```
gitops/core/apps/synology-csi/controller.yaml  | 2 +-
gitops/core/apps/synology-csi/node.yaml        | 2 +-
gitops/core/apps/synology-csi/snapshotter.yaml | 2 +-
3 files changed, 3 insertions(+), 3 deletions(-)
```

## Rollout impact

- `synology-csi-controller` (StatefulSet, 1 pod) restarts → ~60s pause in PVC provisioning
- `synology-csi-node` (DaemonSet, 4 pods) rolling restart → ~30s per node when new mount requests on that node would queue (existing mounts unaffected — kubelet retains them)
- `synology-csi-snapshotter` (StatefulSet, 1 pod) restarts → impact only if a snapshot is in flight (none active)

## Test plan

- [ ] Argo `synology-csi` Application reaches Synced/Healthy
- [ ] All CSI pods on `synology/synology-csi:v1.2.1` (verify with `kubectl -n synology-csi get pods -o jsonpath='{range .items[*]}{.metadata.name}: {.spec.containers[?(@.name=="csi-plugin")].image}{"\n"}{end}'`)
- [ ] No CSI logs show errors after the rollout
- [ ] Existing PVCs remain Bound and pods can still mount volumes
- [ ] Smoke test: create + delete a small test PVC end-to-end

## Not in this PR (separate decisions)

- **Sidecar bumps beyond upstream's pinned versions** — would go off-script. Doesn't affect mkfs/mount path anyway. Skipped.
- **Slow-mkfs root cause** — different problem (Synology LUN init / mkfs.ext4 / iSCSI throughput, not CSI image). Separate diagnostic plan if needed.