### PR TITLE
fix(synology-csi): revert to fork image — upstream lacks iscsiadm on Talos

### DIFF
--- a/gitops/core/apps/synology-csi/controller.yaml
+++ b/gitops/core/apps/synology-csi/controller.yaml
@@ -81,7 +81,7 @@ spec:
         env:
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
-        image: synology/synology-csi:v1.2.1
+        image: ghcr.io/alverezyari/synology-csi:v1.2.0.2
         imagePullPolicy: IfNotPresent
         name: csi-plugin
         securityContext:

--- a/gitops/core/apps/synology-csi/node.yaml
+++ b/gitops/core/apps/synology-csi/node.yaml
@@ -52,7 +52,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: synology/synology-csi:v1.2.1
+        image: ghcr.io/alverezyari/synology-csi:v1.2.0.2
         imagePullPolicy: IfNotPresent
         name: csi-plugin
         securityContext:

--- a/gitops/core/apps/synology-csi/snapshotter.yaml
+++ b/gitops/core/apps/synology-csi/snapshotter.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
-        image: synology/synology-csi:v1.2.1
+        image: ghcr.io/alverezyari/synology-csi:v1.2.0.2
         imagePullPolicy: IfNotPresent
         name: csi-plugin
         securityContext:


### PR DESCRIPTION
## Summary

PR #223 switched `csi-plugin` from \`ghcr.io/alverezyari/synology-csi:v1.2.0.2\` to \`synology/synology-csi:v1.2.1\` based on the assumption that the fork was just a rebuild. **That was wrong** — the fork's whole purpose is to bundle \`iscsiadm\` for Talos compatibility.

Symptom hitting now:

\`\`\`
MountVolume.SetUp failed for volume "pvc-fcf7f454-...": rpc error: code = Internal
desc = Failed to login with target iqn [iqn.2000-01.com.synology:nas-01.pvc-...]
err: env: can't execute 'iscsiadm': No such file or directory (exit status 127)
\`\`\`

Existing mounts kept working (kubelet retains bind mounts on the node), but any new mount fails — Forgejo pod restart was the canary.

## Files

```
gitops/core/apps/synology-csi/controller.yaml   2 +-
gitops/core/apps/synology-csi/node.yaml         2 +-
gitops/core/apps/synology-csi/snapshotter.yaml  2 +-
```

All three flip from \`synology/synology-csi:v1.2.1\` back to \`ghcr.io/alverezyari/synology-csi:v1.2.0.2\`.

## Lesson learned

The "is the fork just a rebuild?" question should have been answered by **diffing image contents**, not by inferring from upstream's deploy manifests matching. Upstream manifests can match while the image binary differs.

## Follow-ups

- **Document why the fork exists** — add to memory + project notes
- **Either keep building the fork forward** (rebase on upstream v1.2.1+ with the iscsiadm bundling preserved) **or** contribute the iscsiadm bundling upstream as a Talos-compat option
- **Find a way to test "can the CSI mount fresh volumes" before rolling out an image change** — could be a CI smoke test

## Test plan

- [ ] Argo \`synology-csi\` Application stays Synced/Healthy after rollback
- [ ] All 6 CSI pods on \`ghcr.io/alverezyari/synology-csi:v1.2.0.2\`
- [ ] Stuck Forgejo pod's mount eventually completes
- [ ] Forgejo pod reaches Running 1/1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image for Synology CSI storage plugin components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->