### PR TITLE
chore(registry): bump zot chart 0.1.91 → 0.1.112 + drop dead Blocky DNS

### DIFF
--- a/gitops/core/apps/blocky/configmap.yaml
+++ b/gitops/core/apps/blocky/configmap.yaml
@@ -47,8 +47,6 @@ data:
         openwebui.phillips-homelab.net: 192.168.10.211
         blocky.phillips-homelab.net: 192.168.10.211
         code.phillips-homelab.net: 192.168.10.211
-        # Registry mirror
-        dockerhub.phillips-homelab.net: 192.168.10.195
         # Synology NAS
         nas.phillips-homelab.net: 192.168.10.195
 

--- a/gitops/tools/apps/zot.yml
+++ b/gitops/tools/apps/zot.yml
@@ -9,7 +9,7 @@ spec:
   source:
     repoURL: https://zotregistry.dev/helm-charts
     chart: zot
-    targetRevision: 0.1.91
+    targetRevision: 0.1.112
     helm:
       values: |
         replicaCount: 1


### PR DESCRIPTION
## Summary

Two small unrelated cleanups bundled because they're both registry-adjacent:

### 1. Zot chart bump 0.1.91 → 0.1.112
Picks up the upstream resolution of the auth+probes issues that originally prompted PRs [#58](https://github.com/project-zot/helm-charts/pull/58) and [#66](https://github.com/project-zot/helm-charts/pull/66) (both closed without merge — maintainers rolled their own fix in PR #61 and PR #69). 21 versions of incremental fixes since.

### 2. Drop dead Blocky DNS entry
\`dockerhub.phillips-homelab.net → 192.168.10.195\` was pointed at a Synology-side registry service that was never wired into any Talos containerd mirror config. Nothing in the cluster ever pulled from it. Vestigial.

## What this is **not**

Pull-through caching for `docker.io / ghcr.io / quay.io` — that's a separate beat. Zot's sync extension turns out not to fit the containerd transparent-mirror pattern (Zot expects explicit destination path prefixes; containerd doesn't insert them). The right shape is a small Distribution-in-proxy-mode deployment, likely pinned to homelab-04 (it has the headroom). Tracked as a follow-up.

## Test plan

- [ ] Argo `zot-registry` Application stays Synced/Healthy after chart bump
- [ ] `kubectl -n zot get pods` shows pod still Running 1/1 after rollout
- [ ] `https://zot.phillips-homelab.net/v2/_catalog` (or whatever you use) still serves
- [ ] DNS for `dockerhub.phillips-homelab.net` no longer resolves via Blocky (will fall through to upstream — should NXDOMAIN since it's a fake homelab subdomain)

## Rollback

Revert this PR. Chart version revert is one-line; DNS entry revert is two lines.