### PR TITLE
chore(forgejo): disable open registration

### DIFF
--- a/gitops/tools/apps/forgejo.yml
+++ b/gitops/tools/apps/forgejo.yml
@@ -69,6 +69,8 @@ spec:
               ADAPTER: memory
             session:
               PROVIDER: memory
+            service:
+              DISABLE_REGISTRATION: true
           additionalConfigFromEnvs:
             - name: GITEA__database__PASSWD
               valueFrom:


### PR DESCRIPTION
Single-operator instance now (Casey has a personal admin user, gitea_admin is break-glass). No public signup needed.

Setting via helm values rather than via Site Admin UI because Forgejo's Configuration screen is read-only — service settings only persist via app.ini, which for us means helm values re-rendered by Argo.

\`\`\`diff
gitea:
  config:
    session:
      PROVIDER: memory
+   service:
+     DISABLE_REGISTRATION: true
\`\`\`

## Test plan

- [ ] PR merges, Argo's forgejo Application picks up the new chart render
- [ ] Pod rolls (configure-gitea init writes new app.ini)
- [ ] Visit \`/user/sign_up\` on Forgejo — should now be unavailable / hidden
- [ ] \`/user/login\` still works for existing accounts