### PR TITLE
feat(forgejo): enable built-in SSH server + LoadBalancer

### DIFF
--- a/gitops/tools/apps/forgejo.yml
+++ b/gitops/tools/apps/forgejo.yml
@@ -46,7 +46,7 @@ spec:
             type: ClusterIP
             port: 3000
           ssh:
-            type: ClusterIP
+            type: LoadBalancer
             port: 22
 
         ingress:
@@ -57,7 +57,11 @@ spec:
             server:
               ROOT_URL: https://code.phillips-homelab.net
               DOMAIN: code.phillips-homelab.net
-              DISABLE_SSH: true
+              DISABLE_SSH: false
+              START_SSH_SERVER: true
+              SSH_LISTEN_PORT: 2222
+              SSH_PORT: 22
+              SSH_DOMAIN: code.phillips-homelab.net
               OFFLINE_MODE: false
             database:
               DB_TYPE: postgres


### PR DESCRIPTION
## Summary

Enables git-over-SSH for Forgejo so you can clone via \`git@code.phillips-homelab.net:owner/repo.git\` from anywhere on the LAN/Tailnet.

\`\`\`diff
service:
  http:
    type: ClusterIP
    port: 3000
  ssh:
-   type: ClusterIP
+   type: LoadBalancer
    port: 22

gitea:
  config:
    server:
      ROOT_URL: https://code.phillips-homelab.net
      DOMAIN: code.phillips-homelab.net
-     DISABLE_SSH: true
+     DISABLE_SSH: false
+     START_SSH_SERVER: true
+     SSH_LISTEN_PORT: 2222
+     SSH_PORT: 22
+     SSH_DOMAIN: code.phillips-homelab.net
      OFFLINE_MODE: false
\`\`\`

## What each flag does

- \`DISABLE_SSH: false\` — turn the SSH server back on
- \`START_SSH_SERVER: true\` — use Forgejo's built-in SSH server (Go), not an external sshd
- \`SSH_LISTEN_PORT: 2222\` — container port (non-root container can't bind \<1024)
- \`SSH_PORT: 22\` — the port Forgejo advertises in clone URLs (what users actually connect to)
- \`SSH_DOMAIN: code.phillips-homelab.net\` — host part of the clone URL
- \`service.ssh.type: LoadBalancer\` — Cilium grabs an IP from \`lan-cloud-pool\` (192.168.10.210–220), maps host :22 → container :2222

Internal-only by design (LAN/Tailnet) — matches the rest of the homelab pattern. External SSH is HTTPS-clone-with-PAT territory.

## Test plan

- [ ] Argo's \`forgejo\` Application reaches Synced/Healthy after merge
- [ ] Pod rolls (chart values changed → init-app-ini regenerates app.ini)
- [ ] \`kubectl -n forgejo get svc forgejo-ssh\` shows EXTERNAL-IP in 192.168.10.210–220 range
- [ ] \`ssh -T git@code.phillips-homelab.net\` (after attaching pubkey to a Forgejo user) returns "You've successfully authenticated"
- [ ] \`git clone git@code.phillips-homelab.net:<your-user>/<test-repo>.git\` works