### PR TITLE
feat(gpu): time-slice the GPU + Jellyfin GPU access + adopt device plugin

### DIFF
--- a/gitops/core/apps/nvidia-device-plugin.yml
+++ b/gitops/core/apps/nvidia-device-plugin.yml
@@ -1,0 +1,37 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nvidia-device-plugin
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  project: default
+  # Adopting the live install (drift item #4 in the cluster-drift-to-gitops
+  # memory). This PR also: (a) switches nodeSelector → nodeAffinity Exists
+  # (drift memory's other ask for this resource), and (b) introduces a
+  # time-slicing ConfigMap so the single RTX 2080 SUPER advertises as 4
+  # replicas — letting Ollama and Jellyfin (and future GPU consumers)
+  # share the card.
+  ignoreDifferences:
+    # Daemonset controller maintains the deprecated.daemonset.template.generation
+    # annotation, plus the kubectl-rollout-restart timestamp.
+    - group: apps
+      kind: DaemonSet
+      jsonPointers:
+        - /metadata/annotations
+        - /spec/template/metadata/annotations
+  source:
+    path: gitops/core/apps/nvidia-device-plugin
+    repoURL: https://github.com/AlverezYari/phillips-homelab.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true
+      - ServerSideDiff=true

--- a/gitops/core/apps/nvidia-device-plugin/configmap.yaml
+++ b/gitops/core/apps/nvidia-device-plugin/configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nvidia-device-plugin-config
+  namespace: kube-system
+data:
+  config.yaml: |
+    version: v1
+    flags:
+      migStrategy: none
+    sharing:
+      timeSlicing:
+        # Advertise the single physical GPU as N "replicas" — k8s scheduler
+        # treats them as independent units, the NVIDIA runtime time-slices
+        # CUDA contexts between them. 4 is comfortable for our mixed workload
+        # (Ollama + Jellyfin + room for future GPU consumers); raise/lower
+        # as needed without disrupting existing workloads.
+        resources:
+          - name: nvidia.com/gpu
+            replicas: 4

--- a/gitops/core/apps/nvidia-device-plugin/daemonset.yaml
+++ b/gitops/core/apps/nvidia-device-plugin/daemonset.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-device-plugin-daemonset
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      name: nvidia-device-plugin-ds
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        name: nvidia-device-plugin-ds
+    spec:
+      priorityClassName: system-node-critical
+      runtimeClassName: nvidia
+      tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Exists
+      # Use Exists rather than a version-pinned label so future Talos
+      # extension version bumps don't break GPU scheduling. The label is
+      # set by the siderolabs/nvidia-open-gpu-kernel-modules-lts extension
+      # (presence-only check is enough — the value tracks Talos version).
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: extensions.talos.dev/nvidia-open-gpu-kernel-modules-lts
+                    operator: Exists
+      containers:
+        - name: nvidia-device-plugin-ctr
+          image: nvcr.io/nvidia/k8s-device-plugin:v0.16.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config-file=/etc/nvidia/k8s-device-plugin/config.yaml
+          env:
+            - name: FAIL_ON_INIT_ERROR
+              value: "false"
+            - name: NVIDIA_DRIVER_ROOT
+              value: /
+            - name: PASS_DEVICE_SPECS
+              value: "true"
+            - name: DEVICE_LIST_STRATEGY
+              value: envvar
+            - name: DEVICE_ID_STRATEGY
+              value: uuid
+            - name: NVIDIA_VISIBLE_DEVICES
+              value: all
+            - name: NVIDIA_DRIVER_CAPABILITIES
+              value: all
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              add:
+                - SYS_ADMIN
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /var/lib/kubelet/device-plugins
+              name: device-plugin
+            - mountPath: /dev
+              name: dev
+            - mountPath: /etc/nvidia/k8s-device-plugin
+              name: config
+              readOnly: true
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+        - name: dev
+          hostPath:
+            path: /dev
+        - name: config
+          configMap:
+            name: nvidia-device-plugin-config

--- a/gitops/core/apps/nvidia-device-plugin/kustomization.yaml
+++ b/gitops/core/apps/nvidia-device-plugin/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - configmap.yaml
+  - daemonset.yaml

--- a/gitops/tools/apps/jellyfin.yml
+++ b/gitops/tools/apps/jellyfin.yml
@@ -21,7 +21,11 @@ spec:
 
         nodeSelector:
           kubernetes.io/hostname: homelab-04
-        
+
+        # Run with the NVIDIA container runtime so /dev/nvidia* + libs are
+        # plumbed through, enabling NVENC/NVDEC for hardware transcoding.
+        runtimeClassName: nvidia
+
         persistence:
           config:
             enabled: true
@@ -48,9 +52,11 @@ spec:
           limits:
             memory: 8Gi
             cpu: 4000m
+            nvidia.com/gpu: 1
           requests:
             cpu: 2000m
             memory: 4Gi
+            nvidia.com/gpu: 1
         
         env:
           TZ: "America/Chicago"


### PR DESCRIPTION
## Summary

Fixes the Oppenheimer-stuck-buffering thing AND clears drift item #4. Three concerns in one PR because they're inseparable — adopting the device plugin without time-slicing wouldn't have helped, and adding GPU bits to Jellyfin without time-slicing would have starved Ollama.

## What's in the box

### 1. Adopt `nvidia-device-plugin-daemonset` into gitops
- Lives at `gitops/core/apps/nvidia-device-plugin/`
- Was \`kubectl apply\`'d ~254+ days ago (memory item #4)
- Argo Application at `gitops/core/apps/nvidia-device-plugin.yml`

### 2. Fix the fragile nodeSelector (also drift memory item #4's other ask)
- **Before**: \`nodeSelector: extensions.talos.dev/nvidia-open-gpu-kernel-modules-lts: 580.126.20-v1.12.6\` (pinned to specific Talos version, breaks on every patch)
- **After**: \`nodeAffinity\` with \`operator: Exists\` (presence-only check tracks Talos version automatically)

### 3. GPU time-slicing via ConfigMap

```yaml
sharing:
  timeSlicing:
    resources:
      - name: nvidia.com/gpu
        replicas: 4
```

Single RTX 2080 SUPER advertises as **4 \`nvidia.com/gpu\` replicas**. NVIDIA driver context-switches between consumers. For your "Ollama mostly idle + occasional Jellyfin transcode" pattern this is essentially free — the two workloads almost never spike together.

### 4. Jellyfin chart values pick up GPU access

```diff
nodeSelector:
  kubernetes.io/hostname: homelab-04

+runtimeClassName: nvidia

resources:
  limits:
    memory: 8Gi
    cpu: 4000m
+   nvidia.com/gpu: 1
  requests:
    cpu: 2000m
    memory: 4Gi
+   nvidia.com/gpu: 1
```

## Why Oppenheimer was stuck

The ffmpeg command in the live Jellyfin logs:

\`\`\`
-codec:v:0 libx264 -preset veryfast -crf 23
\`\`\`

Software H.264 encode. With a 4K HEVC HDR Dolby Vision source the pipeline was:
1. CPU decode HEVC 4K
2. CPU tonemap HDR → SDR (\`tonemapx=tonemap=bt2390\`)
3. CPU encode H.264

All on a Pod that didn't even ask for the GPU. Smaller files just direct-played without transcoding.

## Rollout sequence

1. Argo applies the new ConfigMap + DaemonSet
2. nvidia-device-plugin pod rolls (~10s GPU unavailability on homelab-04 — Ollama may briefly disconnect, will reconnect)
3. Node advertises \`nvidia.com/gpu: 4\`
4. Jellyfin pod restarts (chart values changed → triggers a roll)
5. Jellyfin pod comes up with GPU mounted

## **You** (one-time UI step):

After the rollout, in Jellyfin: **Dashboard → Playback → Transcoding → Hardware acceleration: NVENC** (and tick the appropriate decoder boxes — HEVC, H.264, etc.). Helm doesn't seed Jellyfin's UI-level config, that lives on the config PVC.

## Test plan

- [ ] nvidia-device-plugin Argo App reaches Synced/Healthy after merge
- [ ] \`kubectl describe node homelab-04 | grep nvidia.com/gpu\` shows allocatable: **4**
- [ ] Ollama pod stays Running (no GPU contention thanks to time-slicing)
- [ ] Jellyfin pod restarts and reaches Running 1/1 with the GPU mounted
- [ ] \`kubectl -n media exec deploy/jellyfin -- nvidia-smi\` shows the RTX 2080 SUPER
- [ ] After enabling NVENC in Jellyfin UI: stream Oppenheimer, watch ffmpeg log for \`hevc_cuvid\` / \`h264_nvenc\` instead of \`libx264\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NVIDIA GPU device plugin infrastructure support to enable GPU-accelerated workloads across the cluster
  * Configured GPU time-slicing for efficient resource sharing among multiple containers
  * Enabled GPU acceleration in Jellyfin for hardware-accelerated video transcoding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->