### PR TITLE
fix(cilium): split L2 announce into per-tier policies with interface selectors

### DIFF
--- a/cluster/talos/omni/phillips-homelab/manifests/L2Announcement.yml
+++ b/cluster/talos/omni/phillips-homelab/manifests/L2Announcement.yml
@@ -1,8 +1,36 @@
 apiVersion: cilium.io/v2alpha1
 kind: CiliumL2AnnouncementPolicy
 metadata:
-  name: default-l2-announcement-policy
+  name: lan-2g5-announcement-policy
   namespace: kube-system
 spec:
   externalIPs: true
   loadBalancerIPs: true
+  nodeSelector:
+    matchExpressions:
+      - key: kubernetes.io/hostname
+        operator: In
+        values:
+          - homelab-02
+          - homelab-04
+  interfaces:
+    - "^enp5s0f3u2$"
+    - "^enp12s0$"
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumL2AnnouncementPolicy
+metadata:
+  name: lan-1g-announcement-policy
+  namespace: kube-system
+spec:
+  externalIPs: true
+  loadBalancerIPs: true
+  nodeSelector:
+    matchExpressions:
+      - key: kubernetes.io/hostname
+        operator: In
+        values:
+          - homelab-01
+          - homelab-03
+  interfaces:
+    - "^eno1$"


### PR DESCRIPTION
## Summary

The single `default-l2-announcement-policy` had no `interfaces` filter, so Cilium announced LoadBalancer VIPs on every UP interface — including the `siderolink` WireGuard tunnel to Omni and, on multi-NIC nodes, both onboard and USB-C ethernet simultaneously. The dual announce caused GARP / MAC-table flapping when migrating homelab-02's primary interface from `eno1` (1G) to `enp5s0f3u2` (USB-C 2.5G); ARP responses for the gateway VIP came from both MACs and the upstream switch's MAC table couldn't settle.

This splits the announce into two policies pinned by hostname + interface name regex:

- `lan-2g5-announcement-policy` — homelab-02 (USB-C 2.5G `enp5s0f3u2`) + homelab-04 (`enp12s0`)
- `lan-1g-announcement-policy` — homelab-01, homelab-03 (onboard `eno1`, 1G)

Result on the live cluster: each LB VIP is announced from exactly one interface per node, no siderolink leakage, gateway VIP `192.168.10.211` now lives on the 2.5G NIC.

## Test plan

- [x] `cilium-dbg shell -- "db/show l2-announce"` on each node shows exactly one LAN interface, no siderolink
- [x] `arp -n 192.168.10.211` resolves to the 2.5G NIC MAC (`6c:1f:f7:c7:99:97`)
- [x] HTTPS 200 from `https://argocd.phillips-homelab.net/` via gateway
- [x] Browser access to argocd / grafana / glance verified by user

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Updates**
  * Refined network announcement policies to provide more targeted control over specific cluster nodes and their network interfaces, replacing the previous unified configuration approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->