### PR TITLE
fix(talos): put Blocky first in node DNS upstreams

### DIFF
--- a/cluster/talos/omni/phillips-homelab/patches/nameservers.yml
+++ b/cluster/talos/omni/phillips-homelab/patches/nameservers.yml
@@ -1,5 +1,0 @@
-machine:
-  network:
-    nameservers:
-      - 1.1.1.1
-      - 8.8.8.8

--- a/cluster/talos/omni/phillips-homelab/template.yaml
+++ b/cluster/talos/omni/phillips-homelab/template.yaml
@@ -18,8 +18,6 @@ patches:
     file: patches/extraManifests.yml
   - name: metrics-server
     file: patches/metrics-server.yml
-  - name: nameservers
-    file: patches/nameservers.yml
 ---
 kind: ControlPlane
 machines:
@@ -93,6 +91,9 @@ kind: Machine
 name: 169b5237-8624-af49-8f83-98bd808f9e04
 install:
   disk: /dev/nvme0n1
+patches:
+  - name: nameservers-local
+    file: patches/nameservers-local.yml
 ---
 kind: Machine
 name: 76567b10-4884-4b1d-abc5-345a60522d43


### PR DESCRIPTION
## Summary

Talos hostDNS on every node was returning NXDOMAIN for `*.phillips-homelab.net`. The kubelet uses hostDNS for image pulls, so anything sourcing from `zot.phillips-homelab.net` (today: `lighttheham`) couldn't pull.

Verified via `talosctl get resolvers`:

| Node | Upstreams (in order) |
| --- | --- |
| h01/h02/h04 | `1.1.1.1, 8.8.8.8, 192.168.10.210, 1.1.1.1` |
| h03 | `1.1.1.1, 8.8.8.8` |

Two problems:

1. The cluster-level `nameservers` patch (`[1.1.1.1, 8.8.8.8]`) and per-machine `nameservers-local` patch (`[192.168.10.210, 1.1.1.1]`) **append** in Omni's config merge — Blocky ended up third. Talos hostDNS queries upstreams in order; Cloudflare answered NXDOMAIN for the private zone before Blocky was ever consulted. Public names worked because Cloudflare answered them.
2. homelab-03's Machine block never had the `nameservers-local` patch at all, so Blocky wasn't even in its list.

## Changes

- Drop the cluster-level `patches/nameservers.yml` (public-only).
- Add the existing `nameservers-local` patch to homelab-03's Machine block (`169b5237-...`).

End state: every node uses `nameservers-local` (`[192.168.10.210, 1.1.1.1]`). Blocky primary, Cloudflare fallback.

## Test plan

- [ ] Apply via Omni
- [ ] `talosctl get resolvers` on all four nodes shows `[192.168.10.210, 1.1.1.1]`
- [ ] From a hostNetwork pod: `nslookup zot.phillips-homelab.net 127.0.0.53` returns `192.168.10.211`
- [ ] Force a fresh `lighttheham` pod; image pulls succeed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized DNS nameserver configuration from global to per-machine settings
  * Added metrics-server patch to the cluster configuration
  * Updated nameserver assignments for specific infrastructure nodes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->