### PR TITLE
fix(filebrowser): bump memory 512Mi -> 2Gi to handle large uploads

### DIFF
--- a/gitops/tools/apps/filebrowser.yml
+++ b/gitops/tools/apps/filebrowser.yml
@@ -42,10 +42,10 @@ spec:
         
         resources:
           limits:
-            memory: 512Mi
+            memory: 2Gi
             cpu: 500m
           requests:
-            memory: 256Mi
+            memory: 1Gi
             cpu: 100m
     
   destination:


### PR DESCRIPTION
Filebrowser was getting OOMKilled (exit 137) mid-upload — it buffers in memory and 512Mi wasn't enough for multi-GB files.

Bumps request 256Mi → 1Gi, limit 512Mi → 2Gi.

Longer term we may swap to Filestash (chunked/streaming uploads, S3 backend support) but this is the unblock.

## Test plan
- [ ] Upload completes against files.phillips-homelab.net

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased memory allocation for the filebrowser service to improve performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->