### PR TITLE
feat(gateways): tatl listener + cert + httproute + DNS

### DIFF
--- a/gitops/core/apps/blocky/configmap.yaml
+++ b/gitops/core/apps/blocky/configmap.yaml
@@ -47,6 +47,7 @@ data:
         openwebui.phillips-homelab.net: 192.168.10.211
         blocky.phillips-homelab.net: 192.168.10.211
         code.phillips-homelab.net: 192.168.10.211
+        tatl.phillips-homelab.net: 192.168.10.211
         # Synology NAS
         nas.phillips-homelab.net: 192.168.10.195
 

--- a/gitops/core/apps/certs.yml
+++ b/gitops/core/apps/certs.yml
@@ -129,3 +129,16 @@ spec:
     kind: ClusterIssuer
   secretName: code-tls
 ---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: tatl-tls
+  namespace: gateways
+spec:
+  dnsNames:
+  - tatl.phillips-homelab.net
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  secretName: tatl-tls
+---

--- a/gitops/core/apps/gateways.yml
+++ b/gitops/core/apps/gateways.yml
@@ -139,6 +139,20 @@ spec:
   - group: ""
     kind: Service
 ---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-tatl-service
+  namespace: tatl
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: gateways
+  to:
+  - group: ""
+    kind: Service
+---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -227,6 +241,14 @@ spec:
       certificateRefs:
       - kind: Secret
         name: code-tls
+  - name: https-11
+    protocol: HTTPS
+    port: 443
+    hostname: tatl.phillips-homelab.net
+    tls:
+      certificateRefs:
+      - kind: Secret
+        name: tatl-tls
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -413,3 +435,21 @@ spec:
     - name: forgejo-http
       namespace: forgejo
       port: 3000
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: https-app-route-11
+  namespace: gateways
+spec:
+  parentRefs:
+  - name: tls-gateway
+    sectionName: https-11
+    namespace: gateways
+  hostnames:
+  - tatl.phillips-homelab.net
+  rules:
+  - backendRefs:
+    - name: tatl
+      namespace: tatl
+      port: 8080


### PR DESCRIPTION
## Summary
Cluster prereqs so `helm install tatl ...` lands cleanly in a fresh `tatl` namespace. No tatl chart or workload here — only the Gateway / cert-manager / Blocky scaffolding tatl will hook into.

- `certs.yml`: `tatl-tls` Certificate via `letsencrypt-prod` for `tatl.phillips-homelab.net`
- `gateways.yml`: `https-11` listener on `tls-gateway`, `https-app-route-11` HTTPRoute → Service `tatl/tatl:8080`, `allow-tatl-service` ReferenceGrant in `tatl` ns
- `blocky/configmap.yaml`: `tatl.phillips-homelab.net` → `192.168.10.211` (Cilium Gateway VIP)

## Test plan
- [ ] `kubectl create namespace tatl` **before** Argo sync (ReferenceGrant target ns must exist)
- [ ] Manual `homelab-core` Argo sync after merge (`kubectl patch application homelab-core -n argocd --type merge -p '{"operation":{"sync":{}}}'`)
- [ ] `kubectl -n gateways get certificate tatl-tls` → Ready
- [ ] `kubectl -n gateways get gateway tls-gateway -o jsonpath='{.status.listeners[?(@.name=="https-11")].conditions}'` → Programmed=True
- [ ] `kubectl -n gateways get httproute https-app-route-11` → Accepted, ResolvedRefs (will fail until the `tatl` Service exists — expected pre-helm-install)
- [ ] `dig @192.168.10.x tatl.phillips-homelab.net` returns `192.168.10.211`
- [ ] Note: CNPG Cluster + Redis prereqs intentionally omitted; will be applied imperatively

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added infrastructure for the tatl service accessible via tatl.phillips-homelab.net with local DNS resolution, automated HTTPS certificate provisioning, and secure gateway configuration for routing user traffic to the service backend.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AlverezYari/phillips-homelab/pull/236)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->