### PR TITLE
feat(tatl): Varnish HTTP cache in front of tatl

### DIFF
--- a/gitops/core/apps/gateways.yml
+++ b/gitops/core/apps/gateways.yml
@@ -450,6 +450,6 @@ spec:
   - tatl.phillips-homelab.net
   rules:
   - backendRefs:
-    - name: tatl
+    - name: varnish
       namespace: tatl
-      port: 8080
+      port: 80

--- a/gitops/tools/apps/varnish.yml
+++ b/gitops/tools/apps/varnish.yml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: varnish
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: tatl
+  project: default
+  source:
+    path: gitops/tools/apps/varnish
+    repoURL: 'https://github.com/AlverezYari/phillips-homelab.git'
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/gitops/tools/apps/varnish/configmap.yaml
+++ b/gitops/tools/apps/varnish/configmap.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: varnish-vcl
+  namespace: tatl
+  labels:
+    app.kubernetes.io/name: varnish
+data:
+  default.vcl: |
+    vcl 4.1;
+
+    backend tatl {
+        .host = "tatl.tatl.svc.cluster.local";
+        .port = "8080";
+        .connect_timeout = 5s;
+        .first_byte_timeout = 30s;
+        .between_bytes_timeout = 10s;
+    }
+
+    sub vcl_recv {
+        set req.backend_hint = tatl;
+
+        if (req.http.Cookie ~ "(^|;\s*)(_session|session|auth|token|csrf|logged_in)=") {
+            return (pass);
+        }
+
+        unset req.http.Cookie;
+    }
+
+    sub vcl_backend_response {
+        # tatl's cacheControl shim emits "public, max-age=…" on cacheable paths.
+        # Strip Set-Cookie so the built-in VCL doesn't mark the response uncacheable
+        # (Rails attaches a CSRF Set-Cookie to every response).
+        if (beresp.http.Cache-Control ~ "public") {
+            unset beresp.http.Set-Cookie;
+        }
+    }
+
+    sub vcl_deliver {
+        if (obj.hits > 0) {
+            set resp.http.X-Cache = "HIT";
+            set resp.http.X-Cache-Hits = obj.hits;
+        } else {
+            set resp.http.X-Cache = "MISS";
+        }
+    }

--- a/gitops/tools/apps/varnish/deployment.yaml
+++ b/gitops/tools/apps/varnish/deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: varnish
+  namespace: tatl
+  labels:
+    app.kubernetes.io/name: varnish
+    app.kubernetes.io/component: http-cache
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: varnish
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: varnish
+      annotations:
+        # Bump when default.vcl changes to force a rolling restart.
+        tatl.dev/vcl-hash: "v1"
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: varnish
+          image: varnish:7.6-alpine
+          args:
+            - varnishd
+            - -F
+            - -f
+            - /etc/varnish/default.vcl
+            - -a
+            - "0.0.0.0:80"
+            - -s
+            - "malloc,256m"
+            - -p
+            - "default_ttl=600"
+          ports:
+            - containerPort: 80
+              name: http
+          readinessProbe:
+            tcpSocket:
+              port: 80
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          resources:
+            requests: { cpu: 100m, memory: 256Mi }
+            limits:   { cpu: 500m, memory: 512Mi }
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: vcl
+              mountPath: /etc/varnish
+              readOnly: true
+            - name: workdir
+              mountPath: /var/lib/varnish
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: vcl
+          configMap:
+            name: varnish-vcl
+        - name: workdir
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/gitops/tools/apps/varnish/kustomization.yaml
+++ b/gitops/tools/apps/varnish/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: tatl
+
+resources:
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml

--- a/gitops/tools/apps/varnish/service.yaml
+++ b/gitops/tools/apps/varnish/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: varnish
+  namespace: tatl
+  labels:
+    app.kubernetes.io/name: varnish
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: varnish
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: TCP


### PR DESCRIPTION
## Summary
Adds Varnish as an HTTP response cache in front of tatl via gitops (kustomize app under `gitops/tools/apps/varnish/`) and flips the `tatl.phillips-homelab.net` HTTPRoute backend from `tatl:8080` → `varnish:80`.

Request path becomes: `gateway → varnish:80 → tatl.tatl.svc.cluster.local:8080 → origin`

VCL highlights (copied from tatl-operator `deploy/k8s/talos/25-varnish.yaml`):
- Auth-cookie bypass for real session/CSRF/token cookies; non-auth cookies (analytics, GDPR) stripped so they don't fragment the cache
- Strips `Set-Cookie` on responses tatl emits with `Cache-Control: public` (Rails attaches CSRF Set-Cookie to every response, otherwise nothing caches)
- `X-Cache: HIT/MISS` + `X-Cache-Hits` exposed for observability

## Notes
- `tatl` ns is shared with CNPG/Redis/tatl — no `namespace.yaml` in the kustomize dir on purpose (don't want a future prune deleting the shared ns). `CreateNamespace=true` handles first-create.
- `tatl.dev/vcl-hash` Deployment annotation must be bumped manually when `default.vcl` changes to trigger pod restart.
- Cache is RAM-only (`malloc,256m`) — pod restart = cold cache. Fine for now.

## Test plan
- [ ] After merge, wait for `varnish` Argo Application to be `Synced/Healthy` **before** triggering homelab-core sync (otherwise HTTPRoute briefly points at a Service that doesn't exist yet)
- [ ] Manual `homelab-core` sync to flip the route
- [ ] `kubectl -n tatl get deploy varnish` Ready=1/1, `kubectl -n tatl get svc varnish` has endpoints
- [ ] `curl -I https://tatl.phillips-homelab.net/fr/properties` once → `X-Cache: MISS`
- [ ] `curl -I https://tatl.phillips-homelab.net/fr/properties` again → `X-Cache: HIT`

## Follow-ups (filed elsewhere, not here)
- Have tatl strip `Set-Cookie` itself on `Cache-Control: public` responses so the VCL override can be removed
- Optional varnish-exporter sidecar + Grafana panel for X-Cache hit rate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Deployed Varnish HTTP caching service for improved application performance
  * Updated request routing to direct traffic through the caching layer
  * Configured cache with intelligent cookie handling to preserve authentication and sessions while maximizing cache efficiency
  * Added cache hit/miss response headers for monitoring

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AlverezYari/phillips-homelab/pull/237)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->