### PR TITLE
feat(tatl): exchange-rails CNPG cluster + Deployment scaffold

### DIFF
--- a/gitops/tools/apps/exchange-rails.yml
+++ b/gitops/tools/apps/exchange-rails.yml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: exchange-rails
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: tatl
+  project: default
+  source:
+    path: gitops/tools/apps/exchange-rails
+    repoURL: 'https://github.com/AlverezYari/phillips-homelab.git'
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/gitops/tools/apps/exchange-rails/cluster.yaml
+++ b/gitops/tools/apps/exchange-rails/cluster.yaml
@@ -1,0 +1,23 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: exchange-rails-pg
+  namespace: tatl
+spec:
+  instances: 1
+
+  storage:
+    storageClass: syno-iscsi-default
+    size: 10Gi
+
+  bootstrap:
+    initdb:
+      database: quanthub_on_rails_production
+      owner: quanthub_on_rails
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 512Mi

--- a/gitops/tools/apps/exchange-rails/deployment.yaml
+++ b/gitops/tools/apps/exchange-rails/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: exchange-rails
+  namespace: tatl
+  labels:
+    app.kubernetes.io/name: exchange-rails
+    app.kubernetes.io/component: origin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: exchange-rails
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: exchange-rails
+    spec:
+      containers:
+        - name: rails
+          image: zot.phillips-homelab.net/exchange/rails:dev
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3000
+              name: http
+          env:
+            - name: PORT
+              value: "3000"
+            - name: RAILS_ENV
+              value: production
+            - name: RAILS_LOG_TO_STDOUT
+              value: "1"
+            - name: RAILS_SERVE_STATIC_FILES
+              value: "1"
+            # DATABASE_URL composed from CNPG-published app secret.
+            # CNPG creates `exchange-rails-pg-app` with these fields.
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: exchange-rails-pg-app
+                  key: uri
+            # Rails also reads this env var as fallback in database.yml
+            - name: QUANTHUB_ON_RAILS_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: exchange-rails-pg-app
+                  key: password
+          readinessProbe:
+            tcpSocket:
+              port: 3000
+            initialDelaySeconds: 15
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 15
+          resources:
+            requests: { cpu: 200m, memory: 512Mi }
+            limits:   { cpu: "1",  memory: 1Gi }

--- a/gitops/tools/apps/exchange-rails/kustomization.yaml
+++ b/gitops/tools/apps/exchange-rails/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: tatl
+
+resources:
+  - cluster.yaml
+  - deployment.yaml
+  - service.yaml

--- a/gitops/tools/apps/exchange-rails/service.yaml
+++ b/gitops/tools/apps/exchange-rails/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: exchange-rails
+  namespace: tatl
+  labels:
+    app.kubernetes.io/name: exchange-rails
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: exchange-rails
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000
+      protocol: TCP


### PR DESCRIPTION
## Summary
Lays down the in-cluster pieces for the skunkworks Exchange Rails origin (`quanthub-on-rails`) so it can run in `tatl` ns as soon as the image is in zot.

**Resources (all in `tatl` ns):**
- `Cluster/exchange-rails-pg` — CNPG, 1 instance, 10Gi on `syno-iscsi-default`. Bootstraps DB `quanthub_on_rails_production` owned by user `quanthub_on_rails`. CNPG self-generates creds into Secret `exchange-rails-pg-app`.
- `Deployment/exchange-rails` — pulls `zot.phillips-homelab.net/exchange/rails:dev`, reads `DATABASE_URL` from CNPG's app secret, listens on `:3000`.
- `Service/exchange-rails` — ClusterIP `:3000`.

**Notes / intentional omissions:**
- No `ExternalSecret` for DB password — CNPG generates it. Matches forgejo-db's pattern (their ExternalSecret is only for Garage backup creds, not DB).
- No `objectstore.yaml` / `scheduledbackup.yaml` — skunkworks, skipping backup. Add later if it sticks.
- No `namespace.yaml` — `tatl` ns is shared with tatl/varnish/CNPG/redis; don't want a future prune deleting it.
- `imagePullPolicy: Always` so floating `:dev` tag actually rolls. Pin to sha when the workflow stabilizes.
- `securityContext` is permissive (no restricted PSA settings) — the upstream Dockerfile uses `ruby:3.2.1-buster` and likely won't pass `restricted` without runtime user fixes. Leaving as a follow-up.

## DB seeding (manual, after merge)
```bash
# on Mac, with kubectl context = phillips-homelab
pg_dump -Fc quanthub_on_rails_development | \
  kubectl -n tatl exec -i exchange-rails-pg-1 -- \
  pg_restore -d quanthub_on_rails_production --no-owner --role=quanthub_on_rails
```

## ⚠ DO NOT MERGE YET
The `:dev` image isn't in zot yet — Mac build is in flight. Once `curl -sk https://zot.phillips-homelab.net/v2/exchange/rails/tags/list` shows `dev`, this is safe to merge.

If merged early: the CNPG Cluster comes up fine (no image dependency), but the `Deployment` will `ImagePullBackOff` until the image lands. Not destructive, just noisy.

## Test plan
- [ ] Wait for `exchange/rails:dev` to be pushed to zot (Mac build)
- [ ] Merge this PR
- [ ] `kubectl -n tatl get cluster exchange-rails-pg` → Cluster in healthy state, 1/1
- [ ] `kubectl -n tatl get secret exchange-rails-pg-app` exists with `uri` + `password` keys
- [ ] `kubectl -n tatl get deploy exchange-rails` → 1/1 Ready (after seed, before may fail Rails boot if migrations expect data)
- [ ] Run the `pg_dump | pg_restore` one-shot above
- [ ] `kubectl -n tatl exec -it deploy/exchange-rails -- bundle exec rails db:migrate` (if needed)
- [ ] `kubectl -n tatl exec -it deploy/exchange-rails -- curl -s localhost:3000/` returns a Rails response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployed new exchange-rails application with integrated PostgreSQL database, service networking, and automated health monitoring to ensure reliable operation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AlverezYari/phillips-homelab/pull/238)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->