### PR TITLE
feat(buildkit): in-cluster amd64 builder pinned to hl-4

### DIFF
--- a/gitops/tools/apps/buildkit.yml
+++ b/gitops/tools/apps/buildkit.yml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: buildkit
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: buildkit
+  project: default
+  source:
+    path: gitops/tools/apps/buildkit
+    repoURL: 'https://github.com/AlverezYari/phillips-homelab.git'
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/gitops/tools/apps/buildkit/deployment.yaml
+++ b/gitops/tools/apps/buildkit/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: buildkit
+  namespace: buildkit
+  labels:
+    app.kubernetes.io/name: buildkit
+    app.kubernetes.io/component: builder
+spec:
+  replicas: 1
+  strategy:
+    # Buildkit holds a single-writer PVC; recreate on update so we
+    # don't deadlock on the RWO claim.
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: buildkit
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: buildkit
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: homelab-04
+      containers:
+        - name: buildkit
+          image: moby/buildkit:v0.18.1
+          args:
+            - --addr
+            - tcp://0.0.0.0:1234
+            - --addr
+            - unix:///run/buildkit/buildkitd.sock
+          ports:
+            - containerPort: 1234
+              name: grpc
+          securityContext:
+            privileged: true
+          readinessProbe:
+            exec:
+              command: ["buildctl", "debug", "workers"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 1234
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: "1"
+              memory: 2Gi
+            limits:
+              cpu: "8"
+              memory: 16Gi
+          volumeMounts:
+            - name: cache
+              mountPath: /var/lib/buildkit
+            - name: run
+              mountPath: /run/buildkit
+      volumes:
+        - name: cache
+          persistentVolumeClaim:
+            claimName: buildkit-cache
+        - name: run
+          emptyDir: {}

--- a/gitops/tools/apps/buildkit/kustomization.yaml
+++ b/gitops/tools/apps/buildkit/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: buildkit
+
+resources:
+  - namespace.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml

--- a/gitops/tools/apps/buildkit/namespace.yaml
+++ b/gitops/tools/apps/buildkit/namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: buildkit
+  labels:
+    # Rootful buildkit needs privileged. Scoping to this namespace
+    # keeps the rest of the cluster on restricted PSA.
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/audit: privileged

--- a/gitops/tools/apps/buildkit/pvc.yaml
+++ b/gitops/tools/apps/buildkit/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: buildkit-cache
+  namespace: buildkit
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: syno-iscsi-default
+  resources:
+    requests:
+      storage: 20Gi

--- a/gitops/tools/apps/buildkit/service.yaml
+++ b/gitops/tools/apps/buildkit/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: buildkit
+  namespace: buildkit
+  labels:
+    app.kubernetes.io/name: buildkit
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: buildkit
+  ports:
+    - name: grpc
+      port: 1234
+      targetPort: 1234
+      protocol: TCP


### PR DESCRIPTION
## Summary
Stands up a rootful `moby/buildkit` Pod on `homelab-04` so Mac agents (and anyone else on arm64) can run native amd64 image builds without QEMU emulation. Mac builds were segfaulting on Ruby C-extension compiles under emulation; this unblocks them.

**Topology:**
```
Mac docker buildx
  └─ kubectl port-forward (Mac side)
     └─ Service/buildkit :1234 (buildkit ns)
        └─ Pod/buildkit on homelab-04 (16c / 63Gi, currently idle)
           └─ PVC buildkit-cache 20Gi syno-iscsi-default
```

**Resources:**
- `Namespace/buildkit` — labeled `pod-security.kubernetes.io/enforce: privileged` (rest of cluster stays `restricted`)
- `Deployment/buildkit` — `moby/buildkit:v0.18.1`, `nodeSelector: kubernetes.io/hostname=homelab-04`, privileged, `Recreate` strategy (RWO PVC), requests 1c/2Gi limits 8c/16Gi
- `PVC/buildkit-cache` — 20Gi syno-iscsi-default for `/var/lib/buildkit` (gem cache, layer cache)
- `Service/buildkit` — ClusterIP `:1234`, no Gateway/Ingress (port-forward only)

## Mac handoff (post-merge)
```bash
# Terminal 1 (keep open while building)
kubectl port-forward -n buildkit svc/buildkit 1234:1234

# Terminal 2, one-time builder setup
docker buildx create --name homelab --driver remote \
  tcp://localhost:1234
docker buildx use homelab
docker buildx inspect --bootstrap

# Then for the Rails build (or any future amd64 build)
cd ~/path/to/quanthub-on-rails
docker buildx build --platform linux/amd64 --push \
  -t zot.phillips-homelab.net/exchange/rails:$(git rev-parse --short HEAD) \
  -t zot.phillips-homelab.net/exchange/rails:dev \
  .
```
Auth: `--push` forwards the Mac's `~/.docker/config.json` zot creds over the buildkit channel — no secret-mounting needed on the builder side.

## Test plan
- [ ] Argo `buildkit` Application Synced/Healthy
- [ ] `kubectl -n buildkit get pod` Running on `homelab-04`, Ready
- [ ] `kubectl -n buildkit exec deploy/buildkit -- buildctl debug workers` shows worker
- [ ] From Mac (after port-forward): `docker buildx inspect homelab` shows `linux/amd64` platform
- [ ] Rails amd64 build completes natively (no QEMU segfaults), pushes to zot
- [ ] `curl -sk https://zot.phillips-homelab.net/v2/exchange/rails/tags/list` shows `dev` + sha tag

## Notes
- No Gateway/Ingress exposure on purpose — only reachable via port-forward. Add a Tailscale-fronted external endpoint later if multiple machines need it.
- Privileged container is the cost of rootful buildkit. Rootless was rejected for speed (FUSE overlay overhead). Containment is per-namespace via PSA labels.
- `:dev` tag in zot will roll automatically; existing exchange-rails Deployment uses `imagePullPolicy: Always`.