### PR TITLE
fix(exchange-rails): inject SECRET_KEY_BASE so Rails can boot

### DIFF
--- a/gitops/tools/apps/exchange-rails/deployment.yaml
+++ b/gitops/tools/apps/exchange-rails/deployment.yaml
@@ -32,6 +32,11 @@ spec:
               value: "1"
             - name: RAILS_SERVE_STATIC_FILES
               value: "1"
+            # Dev-only fixture key (same one previously hardcoded in the
+            # repo's Dockerfile). Rotate + move to ExternalSecret before
+            # anything resembling production.
+            - name: SECRET_KEY_BASE
+              value: "3e67b12a1e011e3ba5d76dc6a16632c12ad5fd0034942acff8d71ce671273718dba4b304642cfda8ada3d8fe17d3789b9302d54ab058bc0f84cf30ce8908d684"
             # DATABASE_URL composed from CNPG-published app secret.
             # CNPG creates `exchange-rails-pg-app` with these fields.
             - name: DATABASE_URL


### PR DESCRIPTION
## Why
The image just pushed (`exchange/rails:dev`, built from `Dockerfile.reviews`) doesn't bake `SECRET_KEY_BASE` like the original `Dockerfile` did. Rails refuses to boot in `production` without one:

```
Missing 'secret_key_base' for 'production' environment, set this string with 'bin/rails credentials:edit'
  from /app/app/models/app_token.rb:2:in '<class:AppToken>'
```

## What
Set `SECRET_KEY_BASE` in the Deployment env using the same dev-fixture value that was previously committed to the repo's Dockerfile (already in git history; not new exposure).

## Follow-up
Rotate + move to ExternalSecret (1Password → cluster) before this is anything beyond skunkworks dev.