### PR TITLE
fix(varnish): widen cold-path backend timeouts to match tatl-operator

### DIFF
--- a/gitops/tools/apps/varnish/configmap.yaml
+++ b/gitops/tools/apps/varnish/configmap.yaml
@@ -13,8 +13,11 @@ data:
         .host = "tatl.tatl.svc.cluster.local";
         .port = "8080";
         .connect_timeout = 5s;
-        .first_byte_timeout = 30s;
-        .between_bytes_timeout = 10s;
+        # Cold /xx/ pages with multiple LLM chunks can legitimately run
+        # 30-60s before tatl writes the first byte. Bumped from 30s so
+        # Varnish doesn't 503 a real-but-slow cold translation.
+        .first_byte_timeout = 90s;
+        .between_bytes_timeout = 30s;
     }
 
     sub vcl_recv {

--- a/gitops/tools/apps/varnish/deployment.yaml
+++ b/gitops/tools/apps/varnish/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         app.kubernetes.io/name: varnish
       annotations:
         # Bump when default.vcl changes to force a rolling restart.
-        tatl.dev/vcl-hash: "v1"
+        tatl.dev/vcl-hash: "v2"
     spec:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
## Why
Source of truth drift: `tatl-operator/deploy/k8s/talos/25-varnish.yaml` (commit a9808d9) shipped widened cold-path timeouts, but ArgoCD reads varnish manifests from this repo. Argo `selfHeal: true` has been reverting any imperative `kubectl apply` fix the Mac agent attempted within seconds. Real-but-slow cold translations were getting 503'd at 30s.

## What
- `first_byte_timeout`: 30s → **90s**
- `between_bytes_timeout`: 10s → **30s**
- `tatl.dev/vcl-hash`: `v1` → `v2` to force pod re-roll on the new ConfigMap

## Test plan
- [ ] Merge, manual sync of `varnish` Argo app (auto-sync should pick it up within minutes)
- [ ] New varnish pod up, old terminated
- [ ] `kubectl -n tatl exec deploy/varnish -- cat /etc/varnish/default.vcl | grep first_byte_timeout` shows `90s`
- [ ] Cold `/de/properties/...` request that previously 503'd at 30s now completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- Increased backend connection timeout values to improve reliability for slower network conditions, extending both initial connection and data transfer thresholds
- Enabled automatic pod restart behavior through configuration version tracking, ensuring service deployments automatically reflect updates to default settings without manual intervention

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AlverezYari/phillips-homelab/pull/241)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->