### PR TITLE
fix(varnish): bypass cache + cookie manipulation on auth endpoints

### DIFF
--- a/gitops/tools/apps/varnish/configmap.yaml
+++ b/gitops/tools/apps/varnish/configmap.yaml
@@ -23,6 +23,14 @@ data:
     sub vcl_recv {
         set req.backend_hint = tatl;
 
+        # Auth endpoints: always pass, never touch cookies. Without this,
+        # the cookie-strip below kills CSRF on first GET /login, and the
+        # Set-Cookie strip in vcl_backend_response can kill the session
+        # cookie if Rails ever emits Cache-Control: public on these paths.
+        if (req.url ~ "^/(login|session|logout|sign_in|sign_out|users/sign_)") {
+            return (pass);
+        }
+
         if (req.http.Cookie ~ "(^|;\s*)(_session|session|auth|token|csrf|logged_in)=") {
             return (pass);
         }

--- a/gitops/tools/apps/varnish/deployment.yaml
+++ b/gitops/tools/apps/varnish/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         app.kubernetes.io/name: varnish
       annotations:
         # Bump when default.vcl changes to force a rolling restart.
-        tatl.dev/vcl-hash: "v2"
+        tatl.dev/vcl-hash: "v3"
     spec:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
## Why
Mac agent measured cluster perf and found logged-out endpoints are 3-5x faster than Colima, but auth'd pages (which is where the N+1 fixes live) couldn't be measured because login wasn't completing through the proxy chain.

Two failure modes in the current VCL:
1. **First GET `/login`** (no cookies yet) → `unset req.http.Cookie` runs → response goes through `vcl_backend_response`, which strips `Set-Cookie` when `Cache-Control: public`. If Rails ever flags login form pages as public, CSRF cookie gets killed. User can't POST login.
2. **POST `/session`** (login submit) → backend creates session, returns `Set-Cookie: session=...`. Same Set-Cookie strip can swallow it.

## What
Top-of-`vcl_recv` URL-prefix match for auth routes:

```vcl
if (req.url ~ "^/(login|session|logout|sign_in|sign_out|users/sign_)") {
    return (pass);
}
```

`return (pass)` skips cache and skips the rest of `vcl_recv` (so cookie strip doesn't run). Backend response goes through `vcl_backend_response` flagged uncacheable; `Set-Cookie` strip there only fires on `Cache-Control: public`, which Rails wouldn't emit on auth endpoints anyway — but the pass also makes the intent explicit.

Bumps `tatl.dev/vcl-hash` v2→v3 to force pod re-roll.

## What this doesn't fix
- Cookie `Secure` flag blocking port-forward HTTP testing — that's separate, pod-side. If you want curl to complete login over `kubectl port-forward` instead of through the HTTPS gateway, the Mac agent's other proposal (disable Secure in prod_k8s) still stands.
- Drift with `tatl-operator/deploy/k8s/talos/25-varnish.yaml`. That copy is out of date again after this PR. Recommend deleting it and pointing tatl-operator's docs at this repo as the gitops home.

## Test plan
- [ ] Merge, varnish app auto-syncs
- [ ] New pod with `vcl-hash: v3` Ready
- [ ] `kubectl -n tatl exec deploy/varnish -- cat /etc/varnish/default.vcl | grep -A2 "users/sign_"` shows the bypass block
- [ ] Through `https://tatl.phillips-homelab.net/login` (or whichever path the Rails app uses): can complete login, subsequent requests carry session cookie, X-Cache: MISS on auth'd pages
- [ ] perf-workout runs through gateway against logged-in pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication endpoints now properly bypass caching and cookie-handling to prevent interference with login, logout, session management, and user sign-in operations, improving overall reliability.

* **Chores**
  * Configuration deployment version updated to activate authentication endpoint improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AlverezYari/phillips-homelab/pull/242)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->