### PR TITLE
fix(exchange-rails): switch RAILS_ENV production → prod_k8s

### DIFF
--- a/gitops/tools/apps/exchange-rails/deployment.yaml
+++ b/gitops/tools/apps/exchange-rails/deployment.yaml
@@ -27,7 +27,7 @@ spec:
             - name: PORT
               value: "3000"
             - name: RAILS_ENV
-              value: production
+              value: prod_k8s
             - name: RAILS_LOG_TO_STDOUT
               value: "1"
             - name: RAILS_SERVE_STATIC_FILES


### PR DESCRIPTION
## Why
Image `:dev` (sha `2033a7e006...`) defaults to `ENV RAILS_ENV=prod_k8s`, which activates the Redis cache_store config needed for persistent sessions (via the `REDIS_SERVICE_HOST` fallback the Mac agent added). The Deployment was hardcoding `RAILS_ENV=production`, which overrode the image default and kept us on the wrong config — login wasn't completing because sessions weren't persisting.

## What
One line: `RAILS_ENV: production` → `RAILS_ENV: prod_k8s`.

(Could have just removed the env var and let the image default apply, but keeping it explicit makes the active environment visible at the manifest level and pins it against future image changes.)

## Test plan
- [ ] Argo `exchange-rails` auto-syncs; new ReplicaSet rolls
- [ ] Pod logs show `Rails 7.2.3 application starting in prod_k8s`
- [ ] Redis connection established (no `Errno::ECONNREFUSED` for redis)
- [ ] `https://tatl.phillips-homelab.net/login` POST succeeds, session persists on next request
- [ ] perf-workout completes against auth'd routes