### PR TITLE
fix(varnish): substring match auth cookies so _exchange_session is caught

### DIFF
--- a/gitops/tools/apps/varnish/configmap.yaml
+++ b/gitops/tools/apps/varnish/configmap.yaml
@@ -31,7 +31,12 @@ data:
             return (pass);
         }
 
-        if (req.http.Cookie ~ "(^|;\s*)(_session|session|auth|token|csrf|logged_in)=") {
+        # Substring match (not anchored to cookie-name start) so Rails-style
+        # prefixed names like `_exchange_session=` get caught. The old anchored
+        # form only matched cookies whose NAME began with the marker, which
+        # missed every app-prefixed session cookie. Mirrors tatl's
+        # hasAuthCookie substring semantics.
+        if (req.http.Cookie ~ "(session|auth|token|csrf|logged_in)=") {
             return (pass);
         }
 

--- a/gitops/tools/apps/varnish/deployment.yaml
+++ b/gitops/tools/apps/varnish/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         app.kubernetes.io/name: varnish
       annotations:
         # Bump when default.vcl changes to force a rolling restart.
-        tatl.dev/vcl-hash: "v3"
+        tatl.dev/vcl-hash: "v4"
     spec:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
## Why
Mac agent caught it: the auth-cookie regex was anchored to the start of the cookie name, so it matched `session=` and `_session=` but missed every Rails-style app-prefixed cookie like `_exchange_session=`. Authenticated requests were getting cached because Varnish didn't recognize the session cookie as auth.

Tatl's `hasAuthCookie` does substring matching; this brings the VCL into parity.

## What
```
- if (req.http.Cookie ~ "(^|;\s*)(_session|session|auth|token|csrf|logged_in)=") {
+ if (req.http.Cookie ~ "(session|auth|token|csrf|logged_in)=") {
```

Bump `tatl.dev/vcl-hash` v3→v4.

## Test plan
- [ ] New varnish pod with `vcl-hash: v4` Ready
- [ ] Authenticated request with `Cookie: _exchange_session=...` → backend (not cache)
- [ ] perf-workout against auth'd routes shows real Rails timings, not cached responses

## Mirror note
Mac agent is also fixing tatl-operator's `25-varnish.yaml` copy in parallel. Both copies will be in sync after both PRs land. Worth deduping the copies eventually so we don't keep playing this game.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved session and authentication cookie detection in the caching layer for more reliable handling with Rails-based applications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AlverezYari/phillips-homelab/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->