### PR TITLE
perf(exchange-rails): scale to 5 replicas, bump CPU/mem

### DIFF
--- a/gitops/tools/apps/exchange-rails/deployment.yaml
+++ b/gitops/tools/apps/exchange-rails/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: exchange-rails
     app.kubernetes.io/component: origin
 spec:
-  replicas: 1
+  replicas: 5
   selector:
     matchLabels:
       app.kubernetes.io/name: exchange-rails
@@ -61,5 +61,5 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 15
           resources:
-            requests: { cpu: 200m, memory: 512Mi }
-            limits:   { cpu: "1",  memory: 1Gi }
+            requests: { cpu: 500m, memory: 1Gi }
+            limits:   { cpu: "2",  memory: 2Gi }


### PR DESCRIPTION
## Why
Now that varnish substring-matches auth cookies and actually forwards logged-in traffic to Rails (#244), the single 200m/512Mi replica is the bottleneck. Scaling up to absorb real concurrency from perf-workout against auth'd routes.

## What
| Field | Before | After |
|---|---|---|
| replicas | 1 | **5** |
| cpu request | 200m | **500m** |
| memory request | 512Mi | **1Gi** |
| cpu limit | 1 | **2** |
| memory limit | 1Gi | **2Gi** |

## Capacity check
- 5 × 500m = 2.5 CPU reserved (4 nodes × 16-ish cores = ~60+ available)
- 5 × 1Gi = 5Gi reserved (cluster currently <25% mem on every node)
- Burst ceiling: 10 CPU / 10Gi total. Well within node limits.

## Test plan
- [ ] Argo syncs; new ReplicaSet rolls out 5 pods (RollingUpdate default — ≥4 ready throughout)
- [ ] `kubectl -n tatl get pod -l app.kubernetes.io/name=exchange-rails` shows 5/5 Ready
- [ ] Pods spread across nodes (default scheduler best-effort; not strictly enforced — note for follow-up if hot-spotting matters)
- [ ] perf-workout against auth'd routes shows lower p95/p99 latency under concurrency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved application availability and fault tolerance by scaling deployment to multiple concurrent instances.
  * Enhanced resource allocation to optimize performance and stability under increased load.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AlverezYari/phillips-homelab/pull/245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->