### PR TITLE
feat(observability): add Tempo + OTel Collector for tracing

### DIFF
--- a/gitops/core/apps/opentelemetry-collector.yml
+++ b/gitops/core/apps/opentelemetry-collector.yml
@@ -1,0 +1,124 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: opentelemetry-collector
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  project: default
+  ignoreDifferences:
+  - group: apps
+    kind: Deployment
+    jsonPointers:
+    - /spec/template/metadata/annotations
+  source:
+    repoURL: https://open-telemetry.github.io/opentelemetry-helm-charts
+    chart: opentelemetry-collector
+    targetRevision: 0.156.0
+    helm:
+      values: |
+        # Gateway-style collector: single Deployment that apps ship OTLP to.
+        # No agent DaemonSet in Phase 1 -- Vector still owns logs->Loki, and
+        # we only need a trace pipeline to start.
+        mode: deployment
+        replicaCount: 1
+
+        # Override the long default name (`{{release}}-opentelemetry-collector`)
+        # so apps can target `otel-collector.monitoring.svc:4317`.
+        fullnameOverride: otel-collector
+
+        image:
+          repository: otel/opentelemetry-collector-k8s
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+
+        # Use a clean config (don't merge with chart presets which assume
+        # tail-sampling / k8s-attrs we don't want yet).
+        presets:
+          logsCollection:
+            enabled: false
+          kubernetesAttributes:
+            enabled: false
+        config:
+          receivers:
+            otlp:
+              protocols:
+                grpc:
+                  endpoint: 0.0.0.0:4317
+                http:
+                  endpoint: 0.0.0.0:4318
+          processors:
+            batch:
+              # Tempo accepts batches; tune later from real volume.
+              send_batch_size: 1024
+              timeout: 5s
+            memory_limiter:
+              check_interval: 5s
+              limit_percentage: 80
+              spike_limit_percentage: 25
+          exporters:
+            otlp/tempo:
+              endpoint: tempo.monitoring.svc:4317
+              tls:
+                insecure: true
+            debug:
+              verbosity: basic
+          extensions:
+            health_check:
+              endpoint: 0.0.0.0:13133
+          service:
+            extensions: [health_check]
+            telemetry:
+              metrics:
+                level: basic
+            pipelines:
+              traces:
+                receivers: [otlp]
+                processors: [memory_limiter, batch]
+                exporters: [otlp/tempo]
+
+        # Expose OTLP via a ClusterIP service named `otel-collector`.
+        service:
+          enabled: true
+          type: ClusterIP
+        ports:
+          otlp:
+            enabled: true
+            containerPort: 4317
+            servicePort: 4317
+            protocol: TCP
+          otlp-http:
+            enabled: true
+            containerPort: 4318
+            servicePort: 4318
+            protocol: TCP
+          # Disable defaults we don't need.
+          jaeger-compact:
+            enabled: false
+          jaeger-thrift:
+            enabled: false
+          jaeger-grpc:
+            enabled: false
+          zipkin:
+            enabled: false
+          metrics:
+            enabled: false
+
+        serviceMonitor:
+          enabled: false
+  syncPolicy:
+    automated: {}
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - RespectIgnoreDifferences=true

--- a/gitops/core/apps/tempo.yml
+++ b/gitops/core/apps/tempo.yml
@@ -1,0 +1,93 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tempo
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  project: default
+  # Same drift-ignore pattern as loki.yml: the chart re-renders ConfigMap
+  # data and template-checksum annotations on each sync.
+  ignoreDifferences:
+  - group: ""
+    kind: ConfigMap
+    jsonPointers:
+    - /data
+  - group: apps
+    kind: StatefulSet
+    jsonPointers:
+    - /spec/template/metadata/annotations
+  source:
+    repoURL: https://grafana.github.io/helm-charts
+    chart: tempo
+    targetRevision: 1.24.4
+    helm:
+      values: |
+        # grafana/tempo (single-binary). Reuses the existing
+        # garage-s3-credentials Secret that Loki already consumes -- one
+        # Garage key (loki-key) with RW access to both `chunks`/`ruler`
+        # (Loki) and `tempo-traces` (Tempo).
+        tempo:
+          receivers:
+            otlp:
+              protocols:
+                grpc:
+                  endpoint: 0.0.0.0:4317
+                http:
+                  endpoint: 0.0.0.0:4318
+          storage:
+            trace:
+              backend: s3
+              s3:
+                bucket: tempo-traces
+                endpoint: garage.garage.svc:3900
+                region: garage
+                insecure: true
+                forcepathstyle: true
+          retention: 336h  # 14 days
+          metricsGenerator:
+            enabled: false
+          extraEnv:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: garage-s3-credentials
+                  key: access_key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: garage-s3-credentials
+                  key: secret_access_key
+
+        persistence:
+          enabled: true
+          storageClassName: syno-iscsi-default
+          size: 10Gi
+
+        replicas: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            cpu: "1"
+            memory: 2Gi
+
+        service:
+          type: ClusterIP
+
+        serviceMonitor:
+          enabled: false
+
+        ingress:
+          enabled: false
+  syncPolicy:
+    automated: {}
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - RespectIgnoreDifferences=true

--- a/gitops/core/grafana-dashboards/datasources.yaml
+++ b/gitops/core/grafana-dashboards/datasources.yaml
@@ -24,3 +24,14 @@ data:
         editable: false
         jsonData:
           maxLines: 1000
+      - name: Tempo
+        type: tempo
+        uid: tempo
+        url: http://tempo.monitoring.svc:3100
+        access: proxy
+        editable: false
+        jsonData:
+          nodeGraph:
+            enabled: true
+          serviceMap:
+            datasourceUid: prometheus


### PR DESCRIPTION
## Summary
- Add `grafana/tempo` (monolithic) backed by a new Garage `tempo-traces` bucket (reuses `loki-key` creds — same single-key pattern as Loki).
- Add an OTel Collector in gateway/Deployment mode (`otel-collector.monitoring.svc:4317/4318`) with an OTLP→batch→Tempo pipeline.
- Wire Tempo into Grafana as a datasource alongside Prometheus/Loki; `serviceMap` keyed to the existing Prometheus (VM) datasource.

Loki, Vector, VictoriaMetrics, and Grafana chart versions are untouched — this PR is strictly additive.

## Test plan
- [ ] After merge, manually sync `core-apps` (per project rule: `kubectl patch app core-apps -n argocd --type merge -p '{"operation":{"sync":{}}}'`).
- [ ] `kubectl -n monitoring get pods -l app.kubernetes.io/name=tempo` → 1/1 Running.
- [ ] `kubectl -n monitoring get pods -l app.kubernetes.io/name=opentelemetry-collector` → 1/1 Running.
- [ ] `kubectl -n monitoring logs deploy/otel-collector | grep -i error` → empty.
- [ ] Grafana → Explore → Tempo datasource shows up and "Test" succeeds.
- [ ] Send a trace via `grpcurl`/`otlp-cli` to `otel-collector.monitoring.svc:4317` and verify it appears in Tempo (Phase 2 will instrument Tatl properly).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deployed OpenTelemetry Collector for centralized collection of telemetry data.
  * Configured Grafana Tempo for distributed tracing with persistent storage.
  * Integrated Tempo into Grafana as a data source, enabling trace visualization and service dependency analysis.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AlverezYari/phillips-homelab/pull/246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->