### PR TITLE
fix(observability): Tempo datasource port 3100 -> 3200

### DIFF
--- a/gitops/core/grafana-dashboards/datasources.yaml
+++ b/gitops/core/grafana-dashboards/datasources.yaml
@@ -27,7 +27,7 @@ data:
       - name: Tempo
         type: tempo
         uid: tempo
-        url: http://tempo.monitoring.svc:3100
+        url: http://tempo.monitoring.svc:3200
         access: proxy
         editable: false
         jsonData:


### PR DESCRIPTION
Tempo's HTTP API listens on 3200; 3100 was wrong (that's Loki). Follow-up to #246.