### PR TITLE
fix(exchange-rails): correct ESO remoteRef to RAILS_SECRET_KEY_BASE

### DIFF
--- a/gitops/tools/apps/exchange-rails-secrets.yml
+++ b/gitops/tools/apps/exchange-rails-secrets.yml
@@ -12,5 +12,5 @@ spec:
   data:
   - secretKey: secret_key_base
     remoteRef:
-      key: exchange-rails-config
-      property: secret_key_base
+      key: RAILS_SECRET_KEY_BASE
+      property: SECRET_KEY_BASE


### PR DESCRIPTION
## Summary
- ESO `exchange-rails-secrets` in `tatl` was pointed at 1Password item `exchange-rails-config` / property `secret_key_base`, which doesn't exist in the `phillips-homelab` vault — sync was failing with `key not found in 1Password Vaults`.
- Corrected to the real item: `key: RAILS_SECRET_KEY_BASE`, `property: SECRET_KEY_BASE`.
- K8s `secretKey: secret_key_base` is unchanged, so the exchange-rails Deployment's `secretKeyRef` keeps resolving without a rollout-side edit.

## Test plan
- [ ] Argo syncs `tool-apps`
- [ ] `kubectl -n tatl get externalsecret exchange-rails-secrets` shows `Ready=True`
- [ ] `kubectl -n tatl get secret exchange-rails-secrets -o jsonpath='{.data.secret_key_base}'` is populated
- [ ] exchange-rails pods come up clean (no boot-time `SECRET_KEY_BASE` errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal secret configuration management for the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AlverezYari/phillips-homelab/pull/248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->