### PR TITLE
feat(grafana): expose Service on tailnet via tailscale-operator

### DIFF
--- a/gitops/core/apps/grafana.yml
+++ b/gitops/core/apps/grafana.yml
@@ -59,6 +59,10 @@ spec:
           type: pvc
           enabled: true
           size: 5Gi
+        service:
+          annotations:
+            tailscale.com/expose: "true"
+            tailscale.com/hostname: grafana
         sidecar:
           dashboards:
             enabled: true


### PR DESCRIPTION
## Summary
- Adds `tailscale.com/expose: "true"` + `tailscale.com/hostname: grafana` to the grafana Helm chart's `service.annotations`.
- The tailscale-operator will provision a proxy node, making Grafana reachable on the tailnet at `https://grafana.<tailnet>.ts.net` (and `http://grafana` via MagicDNS).
- Unblocks tailnet members (e.g. shared external users) from hitting Grafana without standing up a subnet router or split-DNS for `*.phillips-homelab.net`.

## Notes
- `grafana.ini` still has `server.domain` / `root_url` pointing at `monitoring.phillips-homelab.net`. Browse-only use is fine; any absolute-link redirect will still send the user back to the internal hostname. If that becomes annoying for tailnet users we can switch those to the ts.net hostname.
- Existing internal LAN/Blocky path (`monitoring.phillips-homelab.net` → Cilium Gateway `.211`) is untouched.

## Test plan
- [ ] ArgoCD syncs the grafana Application; Service shows the two new annotations
- [ ] `kubectl -n monitoring get svc grafana -o yaml` reflects the annotations
- [ ] tailscale-operator creates a proxy StatefulSet/pod in the `tailscale` namespace for grafana
- [ ] New `grafana` node appears in the Tailscale admin Machines list
- [ ] From a tailnet client: `https://grafana.<tailnet>.ts.net` (or `http://grafana`) loads the Grafana login

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Updated Grafana service configuration to enable Tailscale connectivity with hostname `grafana`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AlverezYari/phillips-homelab/pull/249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->