### PR TITLE
feat(tipoff-db): add CNPG Postgres for Tipoff PoC

### DIFF
--- a/gitops/tools/apps/tipoff-db.yml
+++ b/gitops/tools/apps/tipoff-db.yml
@@ -1,0 +1,52 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tipoff-db
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: tipoff
+  project: default
+  ignoreDifferences:
+  - group: postgresql.cnpg.io
+    kind: Cluster
+    jsonPointers:
+    - /spec/affinity
+    - /spec/bootstrap/initdb/encoding
+    - /spec/bootstrap/initdb/localeCType
+    - /spec/bootstrap/initdb/localeCollate
+    - /spec/enablePDB
+    - /spec/enableSuperuserAccess
+    - /spec/failoverDelay
+    - /spec/imageName
+    - /spec/logLevel
+    - /spec/maxSyncReplicas
+    - /spec/minSyncReplicas
+    - /spec/monitoring
+    - /spec/postgresGID
+    - /spec/postgresUID
+    - /spec/postgresql
+    - /spec/primaryUpdateMethod
+    - /spec/primaryUpdateStrategy
+    - /spec/replicationSlots
+    - /spec/smartShutdownTimeout
+    - /spec/startDelay
+    - /spec/stopDelay
+    - /spec/switchoverDelay
+  source:
+    path: gitops/tools/apps/tipoff-db
+    repoURL: https://github.com/AlverezYari/phillips-homelab.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - ServerSideDiff=true

--- a/gitops/tools/apps/tipoff-db/cluster.yaml
+++ b/gitops/tools/apps/tipoff-db/cluster.yaml
@@ -1,0 +1,23 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: tipoff-pg
+  namespace: tipoff
+spec:
+  instances: 1
+
+  storage:
+    storageClass: syno-iscsi-default
+    size: 20Gi
+
+  bootstrap:
+    initdb:
+      database: tipoff
+      owner: tipoff
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 512Mi

--- a/gitops/tools/apps/tipoff-db/kustomization.yaml
+++ b/gitops/tools/apps/tipoff-db/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: tipoff
+
+resources:
+  - namespace.yaml
+  - cluster.yaml
+  - vmpodscrape.yaml

--- a/gitops/tools/apps/tipoff-db/namespace.yaml
+++ b/gitops/tools/apps/tipoff-db/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tipoff

--- a/gitops/tools/apps/tipoff-db/vmpodscrape.yaml
+++ b/gitops/tools/apps/tipoff-db/vmpodscrape.yaml
@@ -1,0 +1,13 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMPodScrape
+metadata:
+  name: tipoff-pg
+  namespace: tipoff
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: tipoff-pg
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s


### PR DESCRIPTION
## Summary
- Adds a CNPG Postgres cluster (`tipoff-pg`) in a new `tipoff` namespace for a PoC project with Josh.
- 20Gi single-instance on `syno-iscsi-default`, db+owner `tipoff`. VMPodScrape included.
- No backups / ObjectStore / ExternalSecret — intentional PoC scope; mirror `forgejo-db` to wire backups when it graduates.

## Test plan
- [ ] Argo `tool-apps` picks up new `tipoff-db.yml` and syncs healthy
- [ ] `tipoff-pg-1` pod reaches Running, CNPG Cluster status = Cluster in healthy state
- [ ] PVC `syno-iscsi-default` provisions 20Gi and binds
- [ ] `tipoff-pg-app` secret exists (creds for Josh's app)
- [ ] VictoriaMetrics scrape target appears for `cnpg.io/cluster=tipoff-pg`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added database deployment infrastructure with automated synchronization and self-healing capabilities
  * Configured persistent storage allocation and resource management for the database
  * Enabled metrics collection for database monitoring and observability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AlverezYari/phillips-homelab/pull/250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->