### PR TITLE
Add tipoff app to gitops (Argo-managed; migrate as PreSync hook)

### DIFF
--- a/gitops/tools/apps/tipoff.yml
+++ b/gitops/tools/apps/tipoff.yml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tipoff
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    # After tipoff-db (wave 0) so the CNPG cluster + tipoff-pg-app secret
+    # exist before the migrate hook and workloads run.
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: tipoff
+  project: default
+  source:
+    path: gitops/tools/apps/tipoff
+    repoURL: https://github.com/AlverezYari/phillips-homelab.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - ServerSideDiff=true

--- a/gitops/tools/apps/tipoff/cronjob-novig-props.yaml
+++ b/gitops/tools/apps/tipoff/cronjob-novig-props.yaml
@@ -1,0 +1,66 @@
+# Novig player-points props CronJob.
+#
+# Walks Pinnacle-sourced event rows and queries Novig's GraphQL for
+# each event's POINTS markets, emitting one line per priced Over/Under
+# side per player. Depends on the novig game ingest having populated
+# the matching event row (props.go looks up novig event by external_id).
+#
+# Cadence: 3-min offset within the 5-min slot — 1 min before the
+# novig game ingest at minute 4. Uses the *previous* cycle's novig
+# event row, which is fine because the row only changes when starts_at
+# shifts.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: tipoff-ingest-novig-props
+  labels:
+    app.kubernetes.io/name: tipoff-ingest-novig-props
+    app.kubernetes.io/component: ingest
+    tipoff.io/source: novig-props
+spec:
+  schedule: "3-59/5 * * * *"   # 3,8,13,...  3-min offset from pinnacle */5
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  startingDeadlineSeconds: 60
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 240
+      ttlSecondsAfterFinished: 3600
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: tipoff-ingest-novig-props
+            tipoff.io/source: novig-props
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: feed
+              image: tipoff
+              args: ["ingest", "novig-props"]
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: tipoff-pg-app
+                      key: uri
+                - name: LOG_LEVEL
+                  value: info
+              resources:
+                requests:
+                  cpu: 25m
+                  memory: 32Mi
+                limits:
+                  cpu: 500m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 65532
+                runAsGroup: 65532
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault

--- a/gitops/tools/apps/tipoff/cronjob-novig.yaml
+++ b/gitops/tools/apps/tipoff/cronjob-novig.yaml
@@ -1,0 +1,64 @@
+# Novig ingest CronJob.
+#
+# Reads upcoming Pinnacle-sourced events from the db and looks each up
+# against Novig's Hasura GraphQL by description match. Same secondary-
+# source pattern as polymarket — depends on Pinnacle having run first.
+#
+# Cadence matches the others (every 5 min, offset 4 min from Pinnacle
+# and 2 min after Polymarket) so all three sources get fresh snapshots
+# within the same cycle without thundering at the upstream.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: tipoff-ingest-novig
+  labels:
+    app.kubernetes.io/name: tipoff-ingest-novig
+    app.kubernetes.io/component: ingest
+    tipoff.io/source: novig
+spec:
+  schedule: "4-59/5 * * * *"   # 4,9,14,...  4-min offset from pinnacle */5
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  startingDeadlineSeconds: 60
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 240
+      ttlSecondsAfterFinished: 3600
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: tipoff-ingest-novig
+            tipoff.io/source: novig
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: feed
+              image: tipoff
+              args: ["ingest", "novig"]
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: tipoff-pg-app
+                      key: uri
+                - name: LOG_LEVEL
+                  value: info
+              resources:
+                requests:
+                  cpu: 25m
+                  memory: 32Mi
+                limits:
+                  cpu: 500m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 65532
+                runAsGroup: 65532
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault

--- a/gitops/tools/apps/tipoff/cronjob-pinnacle-props.yaml
+++ b/gitops/tools/apps/tipoff/cronjob-pinnacle-props.yaml
@@ -1,0 +1,67 @@
+# Pinnacle player-points props CronJob.
+#
+# Walks the matchups list for type=special + units=Points +
+# special.category=Player Props and emits one line row per priced
+# Over/Under side per player. Depends on the game ingest having run
+# first because props attach to the pre-existing event row.
+#
+# Cadence: 1-min offset from the pinnacle game ingest (which runs at
+# minute 0,5,10,...) so the parent game event is in the db before
+# props look it up. On first deploy the first run will skip every
+# game (no parent events yet) and log it loudly — subsequent cycles
+# self-heal.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: tipoff-ingest-pinnacle-props
+  labels:
+    app.kubernetes.io/name: tipoff-ingest-pinnacle-props
+    app.kubernetes.io/component: ingest
+    tipoff.io/source: pinnacle-props
+spec:
+  schedule: "1-59/5 * * * *"   # 1,6,11,...  1-min offset from pinnacle */5
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  startingDeadlineSeconds: 60
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 240
+      ttlSecondsAfterFinished: 3600
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: tipoff-ingest-pinnacle-props
+            tipoff.io/source: pinnacle-props
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: feed
+              image: tipoff   # rewritten by kustomization.yaml
+              args: ["ingest", "pinnacle-props"]
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: tipoff-pg-app
+                      key: uri
+                - name: LOG_LEVEL
+                  value: info
+              resources:
+                requests:
+                  cpu: 25m
+                  memory: 32Mi
+                limits:
+                  cpu: 500m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 65532
+                runAsGroup: 65532
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault

--- a/gitops/tools/apps/tipoff/cronjob-pinnacle.yaml
+++ b/gitops/tools/apps/tipoff/cronjob-pinnacle.yaml
@@ -1,0 +1,66 @@
+# Pinnacle ingest CronJob.
+#
+# Schedule: every 5 minutes during testing. NBA lines move every hour
+# during the postseason and less often otherwise, so this is overkill
+# in steady state — dial back to */15 or */30 once we trust the
+# pipeline. Defining the cadence here keeps it in one place.
+#
+# concurrencyPolicy: Forbid prevents two ingest runs from racing if a
+# pull hangs near the boundary. The ingest is idempotent (UPSERT on
+# event, append-only on line) so a late run is safe, but Forbid keeps
+# raw_payload from accumulating duplicate-second snapshots.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: tipoff-ingest-pinnacle
+  labels:
+    app.kubernetes.io/name: tipoff-ingest-pinnacle
+    app.kubernetes.io/component: ingest
+    tipoff.io/source: pinnacle
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  startingDeadlineSeconds: 60
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 240
+      ttlSecondsAfterFinished: 3600
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: tipoff-ingest-pinnacle
+            tipoff.io/source: pinnacle
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: feed
+              image: tipoff   # rewritten by kustomization.yaml
+              args: ["ingest", "pinnacle"]
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: tipoff-pg-app
+                      key: uri
+                - name: LOG_LEVEL
+                  value: info
+              resources:
+                requests:
+                  cpu: 25m
+                  memory: 32Mi
+                limits:
+                  cpu: 500m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 65532       # distroless `nonroot` UID — needed for runAsNonRoot verification under PSS restricted
+                runAsGroup: 65532
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault

--- a/gitops/tools/apps/tipoff/cronjob-polymarket.yaml
+++ b/gitops/tools/apps/tipoff/cronjob-polymarket.yaml
@@ -1,0 +1,66 @@
+# Polymarket ingest CronJob.
+#
+# Polymarket depends on Pinnacle having populated the event table for
+# tonight's games (see internal/ingest/polymarket/ingest.go), so this
+# runs 2 minutes after each Pinnacle slot. The dependency is logged
+# loudly if missed but never crashes — Polymarket simply finds no work
+# and exits cleanly.
+#
+# Cadence matches Pinnacle. Polymarket markets move faster than
+# sportsbook lines on liquid playoff games, so this is the right
+# frequency for CLV-quality data.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: tipoff-ingest-polymarket
+  labels:
+    app.kubernetes.io/name: tipoff-ingest-polymarket
+    app.kubernetes.io/component: ingest
+    tipoff.io/source: polymarket
+spec:
+  schedule: "2-59/5 * * * *"   # 2,7,12,17,... — 2 min offset from pinnacle's */5
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  startingDeadlineSeconds: 60
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 240
+      ttlSecondsAfterFinished: 3600
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: tipoff-ingest-polymarket
+            tipoff.io/source: polymarket
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: feed
+              image: tipoff
+              args: ["ingest", "polymarket"]
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: tipoff-pg-app
+                      key: uri
+                - name: LOG_LEVEL
+                  value: info
+              resources:
+                requests:
+                  cpu: 25m
+                  memory: 32Mi
+                limits:
+                  cpu: 500m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 65532
+                runAsGroup: 65532
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault

--- a/gitops/tools/apps/tipoff/kustomization.yaml
+++ b/gitops/tools/apps/tipoff/kustomization.yaml
@@ -1,0 +1,33 @@
+# tipoff application workload (the app side; the CNPG database lives in
+# the sibling tipoff-db app). Vendored from the tipoff repo's
+# deploy/base — this gitops copy is the source of truth for what runs in
+# the cluster. FanDuel ingest is intentionally not here yet; it lands in
+# a follow-up once its Tailscale exit-node egress is wired.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: tipoff
+
+resources:
+  - migrate-job.yaml
+  - cronjob-pinnacle.yaml
+  - cronjob-pinnacle-props.yaml
+  - cronjob-polymarket.yaml
+  - cronjob-novig.yaml
+  - cronjob-novig-props.yaml
+  - serve-deployment.yaml
+  - serve-service.yaml
+
+# Single point of override for the image tag. Bump this to deploy a new
+# build; Argo syncs it. (`feed migrate up` runs as a PreSync hook, so a
+# tag carrying new migrations applies them before the workloads roll.)
+images:
+  - name: tipoff
+    newName: zot.phillips-homelab.net/tipoff
+    newTag: props-8a85365
+
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/part-of: tipoff
+      app.kubernetes.io/managed-by: kustomize

--- a/gitops/tools/apps/tipoff/migrate-job.yaml
+++ b/gitops/tools/apps/tipoff/migrate-job.yaml
@@ -1,0 +1,46 @@
+# Schema migration Job, run as an Argo CD PreSync hook.
+#
+# As a hook (rather than a plain Job) it re-runs on every sync and is
+# recreated before each run, so bumping the image to a tag with new
+# migrations applies them automatically — no manual delete+apply. The
+# CronJobs and serve Deployment depend on it having run; PreSync ordering
+# guarantees that within a sync. `feed migrate up` is idempotent.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tipoff-migrate
+  labels:
+    app.kubernetes.io/name: tipoff-migrate
+    app.kubernetes.io/component: migrate
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  backoffLimit: 3
+  activeDeadlineSeconds: 120
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tipoff-migrate
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: migrate
+          image: tipoff # rewritten by kustomization.yaml
+          args: ["migrate", "up"]
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: tipoff-pg-app
+                  key: uri
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault

--- a/gitops/tools/apps/tipoff/serve-deployment.yaml
+++ b/gitops/tools/apps/tipoff/serve-deployment.yaml
@@ -1,0 +1,86 @@
+# HTTP API Deployment.
+#
+# Reads from Postgres, exposes /healthz, /readyz, /v1/events, /v1/lines/latest,
+# /v1/events/{id}/lines. Liveness uses /healthz (always 200 — only restart on
+# total brokenness); readiness uses /readyz (drops traffic when DB is wedged).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tipoff-serve
+  labels:
+    app.kubernetes.io/name: tipoff-serve
+    app.kubernetes.io/component: api
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tipoff-serve
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tipoff-serve
+        app.kubernetes.io/component: api
+    spec:
+      containers:
+        - name: feed
+          image: tipoff
+          args: ["serve"]
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: tipoff-pg-app
+                  key: uri
+            - name: HTTP_ADDR
+              value: ":8080"
+            - name: LOG_LEVEL
+              value: info
+          # startupProbe gives the pool generous time to warm up before
+          # readiness/liveness start applying. Avoids flapping during
+          # rollouts on slow first-connect / first-DB-handshake cycles.
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 2
+            failureThreshold: 30   # 60s total before giving up on startup
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 500m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault

--- a/gitops/tools/apps/tipoff/serve-service.yaml
+++ b/gitops/tools/apps/tipoff/serve-service.yaml
@@ -1,0 +1,23 @@
+# ClusterIP Service for the feed serve API.
+#
+# Reachable from the tailnet at http://tipoff:8080 (MagicDNS) via the
+# tailscale-operator proxy — no subnet router needed.
+apiVersion: v1
+kind: Service
+metadata:
+  name: tipoff-serve
+  labels:
+    app.kubernetes.io/name: tipoff-serve
+    app.kubernetes.io/component: api
+  annotations:
+    tailscale.com/expose: "true"
+    tailscale.com/hostname: tipoff
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: tipoff-serve
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP


### PR DESCRIPTION
Promotes the manually-applied tipoff workload (5 ingest CronJobs, serve Deployment + Service) into a declarative Argo Application, mirroring the tipoff-db pattern.

- Manifests vendored from the app repo's `deploy/base` into `gitops/tools/apps/tipoff/`.
- `tipoff.yml` Application: sync-wave 1 (after tipoff-db), automated prune + selfHeal, ServerSideApply.
- `migrate-job` converted to an Argo **PreSync hook** so image bumps with new migrations apply automatically.
- Adopts the already-running resources (identical manifests) → zero disruption on first sync.
- FanDuel ingest intentionally excluded (follow-up, pending Tailscale exit-node egress).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced the tipoff application with automated data ingestion pipelines from multiple sources (Pinnacle, Polymarket, NoVig feeds)
  * Added a REST API service to access tipoff data

* **Chores**
  * Deployed Kubernetes infrastructure with automated database migrations and security hardening

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AlverezYari/phillips-homelab/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->