### PR TITLE
fix: fanduel cronjob restricted PodSecurity (runAsNonRoot)

### DIFF
--- a/gitops/tools/apps/tipoff/cronjob-fanduel.yaml
+++ b/gitops/tools/apps/tipoff/cronjob-fanduel.yaml
@@ -55,6 +55,16 @@ spec:
             tipoff.io/source: fanduel
         spec:
           restartPolicy: OnFailure
+          securityContext:
+            # Namespace inherits the cluster-default `restricted` PSS.
+            # Userspace tailscale needs no root; fsGroup makes the
+            # emptyDir state dir group-writable by the non-root user.
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            fsGroup: 65532
+            seccompProfile:
+              type: RuntimeDefault
           volumes:
             # tailscaled needs a writable state dir even with an
             # ephemeral key; an emptyDir keeps the container's root fs
@@ -95,6 +105,9 @@ spec:
                 failureThreshold: 30 # ~60s to come up
               securityContext:
                 allowPrivilegeEscalation: false
+                runAsNonRoot: true
+                runAsUser: 65532
+                runAsGroup: 65532
                 capabilities:
                   drop: ["ALL"]
                 seccompProfile:


### PR DESCRIPTION
fanduel ingest pod rejected by restricted PSS (ts-exit sidecar missing runAsNonRoot). Adds pod-level + sidecar non-root securityContext + fsGroup for the emptyDir state dir. Userspace tailscale needs no root.