### PR TITLE
Add stock-bot app + CNPG db (data-pull milestone)

### DIFF
--- a/gitops/tools/apps/stock-bot-db.yml
+++ b/gitops/tools/apps/stock-bot-db.yml
@@ -1,0 +1,52 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: stock-bot-db
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: stock-bot
+  project: default
+  ignoreDifferences:
+  - group: postgresql.cnpg.io
+    kind: Cluster
+    jsonPointers:
+    - /spec/affinity
+    - /spec/bootstrap/initdb/encoding
+    - /spec/bootstrap/initdb/localeCType
+    - /spec/bootstrap/initdb/localeCollate
+    - /spec/enablePDB
+    - /spec/enableSuperuserAccess
+    - /spec/failoverDelay
+    - /spec/imageName
+    - /spec/logLevel
+    - /spec/maxSyncReplicas
+    - /spec/minSyncReplicas
+    - /spec/monitoring
+    - /spec/postgresGID
+    - /spec/postgresUID
+    - /spec/postgresql
+    - /spec/primaryUpdateMethod
+    - /spec/primaryUpdateStrategy
+    - /spec/replicationSlots
+    - /spec/smartShutdownTimeout
+    - /spec/startDelay
+    - /spec/stopDelay
+    - /spec/switchoverDelay
+  source:
+    path: gitops/tools/apps/stock-bot-db
+    repoURL: https://github.com/AlverezYari/phillips-homelab.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - ServerSideDiff=true

--- a/gitops/tools/apps/stock-bot-db/cluster.yaml
+++ b/gitops/tools/apps/stock-bot-db/cluster.yaml
@@ -1,0 +1,23 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: stock-bot-pg
+  namespace: stock-bot
+spec:
+  instances: 1
+
+  storage:
+    storageClass: syno-iscsi-default
+    size: 20Gi
+
+  bootstrap:
+    initdb:
+      database: stock-bot
+      owner: stock-bot
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 512Mi

--- a/gitops/tools/apps/stock-bot-db/kustomization.yaml
+++ b/gitops/tools/apps/stock-bot-db/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: stock-bot
+
+resources:
+  - namespace.yaml
+  - cluster.yaml
+  - pg-tailnet-service.yaml

--- a/gitops/tools/apps/stock-bot-db/namespace.yaml
+++ b/gitops/tools/apps/stock-bot-db/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: stock-bot

--- a/gitops/tools/apps/stock-bot-db/pg-tailnet-service.yaml
+++ b/gitops/tools/apps/stock-bot-db/pg-tailnet-service.yaml
@@ -1,0 +1,34 @@
+# Tailnet-exposed Postgres endpoint for dev access.
+#
+# CNPG already creates the stock-bot-pg-rw Service that routes to the
+# current primary, but that Service is owned/reconciled by the CNPG
+# operator — annotating it for the tailscale-operator would fight CNPG's
+# reconcile loop. So we stand up a separate plain ClusterIP Service that
+# selects the CNPG primary directly (cnpg.io/cluster + instanceRole:
+# primary) and carry the tailscale-operator expose annotations here. This
+# is the same operator-proxy mechanism tipoff's serve-service uses
+# (tailscale.com/expose + tailscale.com/hostname) — no subnet router.
+#
+# Result: a dev machine on the tailnet reaches Postgres at
+# stock-bot-pg:5432 (MagicDNS) via the operator proxy.
+apiVersion: v1
+kind: Service
+metadata:
+  name: stock-bot-pg-tailnet
+  namespace: stock-bot
+  labels:
+    app.kubernetes.io/name: stock-bot-pg-tailnet
+    app.kubernetes.io/component: db
+  annotations:
+    tailscale.com/expose: "true"
+    tailscale.com/hostname: stock-bot-pg
+spec:
+  type: ClusterIP
+  selector:
+    cnpg.io/cluster: stock-bot-pg
+    cnpg.io/instanceRole: primary
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+      protocol: TCP

--- a/gitops/tools/apps/stock-bot-secrets.yml
+++ b/gitops/tools/apps/stock-bot-secrets.yml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: stock-bot-secrets
+  namespace: stock-bot
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: staging
+  target:
+    name: stock-bot-secrets
+    creationPolicy: Owner
+  data:
+  - secretKey: alpaca_api_key
+    remoteRef:
+      key: stock-bot-alpaca
+      property: api_key
+  - secretKey: alpaca_secret_key
+    remoteRef:
+      key: stock-bot-alpaca
+      property: secret_key

--- a/gitops/tools/apps/stock-bot.yml
+++ b/gitops/tools/apps/stock-bot.yml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: stock-bot
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    # After stock-bot-db (wave 0) so the CNPG cluster + stock-bot-pg-app
+    # secret exist before the migrate hook and workloads run.
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: stock-bot
+  project: default
+  source:
+    path: gitops/tools/apps/stock-bot
+    repoURL: https://github.com/AlverezYari/phillips-homelab.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - ServerSideDiff=true
+      - RespectIgnoreDifferences=true

--- a/gitops/tools/apps/stock-bot/cronjob-digest.yaml
+++ b/gitops/tools/apps/stock-bot/cronjob-digest.yaml
@@ -1,0 +1,76 @@
+# Digest CronJob.
+#
+# Rolls up new material events + IPO matches since the last digest, stores it,
+# and (if DIGEST_NTFY_URL is set) pushes it to a notification topic. Runs daily
+# after the morning triage/ipo cycles have populated.
+#
+# Deterministic — no LLM call here (the per-event reading happened in triage),
+# so no Ollama env and a short deadline.
+#
+# SUSPENDED: the `digest` subcommand ships in a later image than the one
+# currently pinned (it's in stock-bot PR #2). Flip `suspend: false` once an
+# image carrying `scout digest` is deployed. Mirrors the tipoff pattern of
+# staging a cronjob with suspend until verified.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: stock-bot-digest
+  labels:
+    app.kubernetes.io/name: stock-bot-digest
+    app.kubernetes.io/component: digest
+spec:
+  suspend: true
+  schedule: "0 7 * * *"   # daily at 07:00, after the 06:00 ipo + morning triage
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  startingDeadlineSeconds: 60
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 120
+      ttlSecondsAfterFinished: 3600
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: stock-bot-digest
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: digest
+              image: stock-bot
+              args: ["digest"]
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: stock-bot-pg-app
+                      key: uri
+                - name: LOG_LEVEL
+                  value: info
+                - name: DIGEST_PERIOD
+                  value: daily
+                - name: DIGEST_LOOKBACK_HOURS
+                  value: "24"
+                # Optional delivery: set to an ntfy/webhook topic URL to push the
+                # digest. Unset = store in the digests table only. If the topic
+                # is private, source this from an ExternalSecret instead.
+                # - name: DIGEST_NTFY_URL
+                #   value: https://ntfy.phillips-homelab.net/stock-bot
+              resources:
+                requests:
+                  cpu: 25m
+                  memory: 32Mi
+                limits:
+                  cpu: 500m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 65532
+                runAsGroup: 65532
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault

--- a/gitops/tools/apps/stock-bot/cronjob-digest.yaml
+++ b/gitops/tools/apps/stock-bot/cronjob-digest.yaml
@@ -7,10 +7,6 @@
 # Deterministic — no LLM call here (the per-event reading happened in triage),
 # so no Ollama env and a short deadline.
 #
-# SUSPENDED: the `digest` subcommand ships in a later image than the one
-# currently pinned (it's in stock-bot PR #2). Flip `suspend: false` once an
-# image carrying `scout digest` is deployed. Mirrors the tipoff pattern of
-# staging a cronjob with suspend until verified.
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -19,7 +15,6 @@ metadata:
     app.kubernetes.io/name: stock-bot-digest
     app.kubernetes.io/component: digest
 spec:
-  suspend: true
   schedule: "0 7 * * *"   # daily at 07:00, after the 06:00 ipo + morning triage
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3

--- a/gitops/tools/apps/stock-bot/cronjob-edgar.yaml
+++ b/gitops/tools/apps/stock-bot/cronjob-edgar.yaml
@@ -1,0 +1,62 @@
+# EDGAR ingest CronJob.
+#
+# Polls SEC EDGAR every 30 minutes for new filings. SEC requires a
+# descriptive User-Agent with a contact address on every request; that's
+# a plain env value (not a secret), adjust the contact as needed.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: stock-bot-ingest-edgar
+  labels:
+    app.kubernetes.io/name: stock-bot-ingest-edgar
+    app.kubernetes.io/component: ingest
+    stock-bot.io/source: edgar
+spec:
+  schedule: "*/30 * * * *"   # every 30 minutes
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  startingDeadlineSeconds: 60
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 240
+      ttlSecondsAfterFinished: 3600
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: stock-bot-ingest-edgar
+            stock-bot.io/source: edgar
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: feed
+              image: stock-bot
+              args: ["ingest", "edgar"]
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: stock-bot-pg-app
+                      key: uri
+                - name: LOG_LEVEL
+                  value: info
+                - name: EDGAR_USER_AGENT
+                  value: "stock-bot/0.1 (admin@phillips-homelab.net)"
+              resources:
+                requests:
+                  cpu: 25m
+                  memory: 32Mi
+                limits:
+                  cpu: 500m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 65532
+                runAsGroup: 65532
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault

--- a/gitops/tools/apps/stock-bot/cronjob-ipo.yaml
+++ b/gitops/tools/apps/stock-bot/cronjob-ipo.yaml
@@ -1,0 +1,71 @@
+# IPO discovery CronJob.
+#
+# Discovers new S-1/F-1 registrations market-wide via SEC EDGAR full-text
+# search and has the LLM flag ones matching IPO_VERTICALS. Uses the cluster
+# Ollama (no API-key secret) and EDGAR (needs the descriptive User-Agent).
+# Runs once daily — registrations are low-frequency.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: stock-bot-ipo
+  labels:
+    app.kubernetes.io/name: stock-bot-ipo
+    app.kubernetes.io/component: ipo
+spec:
+  schedule: "0 6 * * *"   # daily at 06:00
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  startingDeadlineSeconds: 60
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 1800   # LLM calls are slow on one GPU
+      ttlSecondsAfterFinished: 3600
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: stock-bot-ipo
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: ipo
+              image: stock-bot
+              args: ["ipo"]
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: stock-bot-pg-app
+                      key: uri
+                - name: LOG_LEVEL
+                  value: info
+                - name: LLM_BACKEND
+                  value: ollama
+                - name: LLM_BASE_URL
+                  value: http://open-webui-ollama.tools.svc.cluster.local:11434/v1
+                - name: TRIAGE_MODEL
+                  value: qwen2.5:7b
+                # SEC requires a descriptive User-Agent; adjust the contact.
+                - name: EDGAR_USER_AGENT
+                  value: "stock-bot/0.1 (admin@phillips-homelab.net)"
+                # Plain-English interest verticals the LLM screens against.
+                - name: IPO_VERTICALS
+                  value: "AI infrastructure, gene therapy, defense tech, payments"
+              resources:
+                requests:
+                  cpu: 25m
+                  memory: 32Mi
+                limits:
+                  cpu: 500m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 65532
+                runAsGroup: 65532
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault

--- a/gitops/tools/apps/stock-bot/cronjob-news.yaml
+++ b/gitops/tools/apps/stock-bot/cronjob-news.yaml
@@ -1,0 +1,69 @@
+# News ingest CronJob.
+#
+# Pulls market news from Alpaca every 4 hours. APCA_* creds come from the
+# stock-bot-secrets ExternalSecret (apps/stock-bot-secrets.yml).
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: stock-bot-ingest-news
+  labels:
+    app.kubernetes.io/name: stock-bot-ingest-news
+    app.kubernetes.io/component: ingest
+    stock-bot.io/source: news
+spec:
+  schedule: "0 */4 * * *"   # every 4 hours
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  startingDeadlineSeconds: 60
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 240
+      ttlSecondsAfterFinished: 3600
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: stock-bot-ingest-news
+            stock-bot.io/source: news
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: feed
+              image: stock-bot
+              args: ["ingest", "news"]
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: stock-bot-pg-app
+                      key: uri
+                - name: LOG_LEVEL
+                  value: info
+                - name: APCA_API_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: stock-bot-secrets
+                      key: alpaca_api_key
+                - name: APCA_API_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: stock-bot-secrets
+                      key: alpaca_secret_key
+              resources:
+                requests:
+                  cpu: 25m
+                  memory: 32Mi
+                limits:
+                  cpu: 500m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 65532
+                runAsGroup: 65532
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault

--- a/gitops/tools/apps/stock-bot/cronjob-quotes.yaml
+++ b/gitops/tools/apps/stock-bot/cronjob-quotes.yaml
@@ -1,0 +1,70 @@
+# Quotes ingest CronJob.
+#
+# Pulls daily price/volume bars from Alpaca after the US market close,
+# weekdays only. APCA_* creds come from the stock-bot-secrets
+# ExternalSecret (apps/stock-bot-secrets.yml).
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: stock-bot-ingest-quotes
+  labels:
+    app.kubernetes.io/name: stock-bot-ingest-quotes
+    app.kubernetes.io/component: ingest
+    stock-bot.io/source: quotes
+spec:
+  schedule: "0 22 * * 1-5"   # 22:00 UTC weekdays — after US market close
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  startingDeadlineSeconds: 60
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 240
+      ttlSecondsAfterFinished: 3600
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: stock-bot-ingest-quotes
+            stock-bot.io/source: quotes
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: feed
+              image: stock-bot
+              args: ["ingest", "quotes"]
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: stock-bot-pg-app
+                      key: uri
+                - name: LOG_LEVEL
+                  value: info
+                - name: APCA_API_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: stock-bot-secrets
+                      key: alpaca_api_key
+                - name: APCA_API_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: stock-bot-secrets
+                      key: alpaca_secret_key
+              resources:
+                requests:
+                  cpu: 25m
+                  memory: 32Mi
+                limits:
+                  cpu: 500m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 65532
+                runAsGroup: 65532
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault

--- a/gitops/tools/apps/stock-bot/cronjob-triage.yaml
+++ b/gitops/tools/apps/stock-bot/cronjob-triage.yaml
@@ -1,0 +1,65 @@
+# Triage CronJob.
+#
+# Classifies untriaged news + filings (noise vs substance) via the LLM. Runs
+# the local Ollama on the cluster GPU (open-webui-ollama in the tools ns) — no
+# API-key secret needed. LLM calls serialize on the single GPU, so the active
+# deadline is generous; TRIAGE_LIMIT (default 50 in-app) bounds work per run.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: stock-bot-triage
+  labels:
+    app.kubernetes.io/name: stock-bot-triage
+    app.kubernetes.io/component: triage
+spec:
+  schedule: "30 */2 * * *"   # every 2 hours, offset from the ingests
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  startingDeadlineSeconds: 60
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 1800   # LLM calls are slow on one GPU
+      ttlSecondsAfterFinished: 3600
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: stock-bot-triage
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: triage
+              image: stock-bot
+              args: ["triage"]
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: stock-bot-pg-app
+                      key: uri
+                - name: LOG_LEVEL
+                  value: info
+                - name: LLM_BACKEND
+                  value: ollama
+                - name: LLM_BASE_URL
+                  value: http://open-webui-ollama.tools.svc.cluster.local:11434/v1
+                - name: TRIAGE_MODEL
+                  value: qwen2.5:7b
+              resources:
+                requests:
+                  cpu: 25m
+                  memory: 32Mi
+                limits:
+                  cpu: 500m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 65532
+                runAsGroup: 65532
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault

--- a/gitops/tools/apps/stock-bot/kustomization.yaml
+++ b/gitops/tools/apps/stock-bot/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - cronjob-edgar.yaml
   - cronjob-triage.yaml
   - cronjob-ipo.yaml
+  - cronjob-digest.yaml
   - serve-deployment.yaml
   - serve-service.yaml
 

--- a/gitops/tools/apps/stock-bot/kustomization.yaml
+++ b/gitops/tools/apps/stock-bot/kustomization.yaml
@@ -1,0 +1,32 @@
+# stock-bot application workload (the app side; the CNPG database lives
+# in the sibling stock-bot-db app). Each command runs the same image with
+# a different arg: ingest pulls from upstream data sources on a cron,
+# serve exposes the HTTP API.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: stock-bot
+
+resources:
+  - migrate-job.yaml
+  - cronjob-quotes.yaml
+  - cronjob-news.yaml
+  - cronjob-edgar.yaml
+  - serve-deployment.yaml
+  - serve-service.yaml
+
+# Single point of override for the image tag. Bump newTag to deploy a new
+# build; Argo syncs it. (`migrate up` runs as a PreSync hook, so a tag
+# carrying new migrations applies them before the workloads roll.)
+# `latest` is a placeholder until the first image build — bump to a real
+# immutable tag after that.
+images:
+  - name: stock-bot
+    newName: zot.phillips-homelab.net/stock-bot
+    newTag: latest
+
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/part-of: stock-bot
+      app.kubernetes.io/managed-by: kustomize

--- a/gitops/tools/apps/stock-bot/kustomization.yaml
+++ b/gitops/tools/apps/stock-bot/kustomization.yaml
@@ -12,6 +12,8 @@ resources:
   - cronjob-quotes.yaml
   - cronjob-news.yaml
   - cronjob-edgar.yaml
+  - cronjob-triage.yaml
+  - cronjob-ipo.yaml
   - serve-deployment.yaml
   - serve-service.yaml
 
@@ -23,7 +25,7 @@ resources:
 images:
   - name: stock-bot
     newName: zot.phillips-homelab.net/stock-bot
-    newTag: latest
+    newTag: 2c968d5
 
 labels:
   - includeSelectors: false

--- a/gitops/tools/apps/stock-bot/kustomization.yaml
+++ b/gitops/tools/apps/stock-bot/kustomization.yaml
@@ -26,7 +26,7 @@ resources:
 images:
   - name: stock-bot
     newName: zot.phillips-homelab.net/stock-bot
-    newTag: 2c968d5
+    newTag: 8b8a1c0
 
 labels:
   - includeSelectors: false

--- a/gitops/tools/apps/stock-bot/migrate-job.yaml
+++ b/gitops/tools/apps/stock-bot/migrate-job.yaml
@@ -1,0 +1,46 @@
+# Schema migration Job, run as an Argo CD PreSync hook.
+#
+# As a hook (rather than a plain Job) it re-runs on every sync and is
+# recreated before each run, so bumping the image to a tag with new
+# migrations applies them automatically — no manual delete+apply. The
+# CronJobs and serve Deployment depend on it having run; PreSync ordering
+# guarantees that within a sync. `migrate up` is idempotent.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stock-bot-migrate
+  labels:
+    app.kubernetes.io/name: stock-bot-migrate
+    app.kubernetes.io/component: migrate
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  backoffLimit: 3
+  activeDeadlineSeconds: 120
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: stock-bot-migrate
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: migrate
+          image: stock-bot # rewritten by kustomization.yaml
+          args: ["migrate", "up"]
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: stock-bot-pg-app
+                  key: uri
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault

--- a/gitops/tools/apps/stock-bot/serve-deployment.yaml
+++ b/gitops/tools/apps/stock-bot/serve-deployment.yaml
@@ -1,0 +1,86 @@
+# HTTP API Deployment.
+#
+# Reads from Postgres, exposes /healthz and /readyz. Liveness uses
+# /healthz (always 200 — only restart on total brokenness); readiness
+# uses /readyz (drops traffic when DB is wedged).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stock-bot-serve
+  labels:
+    app.kubernetes.io/name: stock-bot-serve
+    app.kubernetes.io/component: api
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: stock-bot-serve
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: stock-bot-serve
+        app.kubernetes.io/component: api
+    spec:
+      containers:
+        - name: feed
+          image: stock-bot
+          args: ["serve"]
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: stock-bot-pg-app
+                  key: uri
+            - name: HTTP_ADDR
+              value: ":8080"
+            - name: LOG_LEVEL
+              value: info
+          # startupProbe gives the pool generous time to warm up before
+          # readiness/liveness start applying. Avoids flapping during
+          # rollouts on slow first-connect / first-DB-handshake cycles.
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 2
+            failureThreshold: 30   # 60s total before giving up on startup
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 500m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault

--- a/gitops/tools/apps/stock-bot/serve-service.yaml
+++ b/gitops/tools/apps/stock-bot/serve-service.yaml
@@ -1,0 +1,23 @@
+# ClusterIP Service for the serve API.
+#
+# Reachable from the tailnet at http://stock-bot:8080 (MagicDNS) via the
+# tailscale-operator proxy — no subnet router needed.
+apiVersion: v1
+kind: Service
+metadata:
+  name: stock-bot-serve
+  labels:
+    app.kubernetes.io/name: stock-bot-serve
+    app.kubernetes.io/component: api
+  annotations:
+    tailscale.com/expose: "true"
+    tailscale.com/hostname: stock-bot
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: stock-bot-serve
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP


### PR DESCRIPTION
## Summary

Adds GitOps manifests for a new app, **stock-bot**, following the existing `tipoff` pattern. Two ArgoCD Applications, auto-discovered by the `tool-apps` app-of-apps (`gitops/tools/tool-apps.yml`, source path `gitops/tools/apps`) — no list edit needed.

### stock-bot-db (sync-wave 0)
- CNPG `Cluster` **stock-bot-pg**: 1 instance, 20Gi `syno-iscsi-default`, initdb database/owner `stock-bot`.
- Tailnet Service exposing the CNPG primary on the tailnet via the tailscale-operator (`tailscale.com/expose`), reachable at MagicDNS `stock-bot-pg:5432` so a dev machine can hit Postgres over Tailscale. Standalone ClusterIP selecting `cnpg.io/instanceRole: primary` (CNPG owns the `-rw` Service, so we don't annotate that one).
- Same syncPolicy + CNPG `ignoreDifferences` block as `tipoff-db`.

### stock-bot (sync-wave 1)
- `migrate` Job as an Argo PreSync hook (`migrate up`).
- Ingest CronJobs: **quotes** (`0 22 * * 1-5`, post US close, weekdays), **news** (`0 */4 * * *`), **edgar** (`*/30 * * * *`). Quotes+news pull Alpaca creds (`APCA_API_KEY_ID`/`APCA_API_SECRET_KEY`); edgar sets a plain `EDGAR_USER_AGENT`.
- `serve` Deployment + ClusterIP Service exposed on the tailnet (`stock-bot:8080`).
- `stock-bot-secrets` ExternalSecret (ClusterSecretStore `staging`) mapping Alpaca `api_key`/`secret_key` from 1Password item `stock-bot-alpaca`.

All workloads use the distroless securityContext (UID/GID 65532, readOnlyRootFilesystem, drop ALL, seccomp RuntimeDefault).

### Notes
- **Image tag is a placeholder** (`newName: zot.phillips-homelab.net/stock-bot`, `newTag: latest`) pending the first image build — bump `newTag` to a real immutable tag in `gitops/tools/apps/stock-bot/kustomization.yaml` after that.
- Merging brings up **stock-bot-pg** (exposed on the tailnet for dev) and the app workloads.

Validated locally: `kubectl kustomize` builds clean for both directories (3 + 6 docs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Stock-bot application now deployed with PostgreSQL database backend.
  * Three automated data ingestion workflows: EDGAR ingestion (every 30 minutes), news ingestion (every 4 hours), and market quotes ingestion (weekdays at 22:00 UTC).
  * API server with integrated health monitoring for the stock-bot application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->