### PR TITLE
forgejo-db: expand CNPG pg storage 10Gi → 30Gi (forgejo outage recovery)

### DIFF
--- a/gitops/tools/apps/forgejo-db/cluster.yaml
+++ b/gitops/tools/apps/forgejo-db/cluster.yaml
@@ -8,7 +8,7 @@ spec:
 
   storage:
     storageClass: syno-iscsi-default
-    size: 10Gi
+    size: 30Gi
 
   bootstrap:
     initdb:


### PR DESCRIPTION
forgejo is down: CNPG fenced `forgejo-pg` with `no free disk space for WALs`, so the app sits at `0/1`.

## Root cause
WAL archiving to Garage (`s3://forgejo-backups`) has been failing since the cluster was created on **2026-05-02** (`ContinuousArchiving: False`, `barman-cloud-wal-archive: exit status 4`). With archiving broken, Postgres can never recycle WAL segments, so `pg_wal` grew unbounded until it filled the **10Gi** PVC. Verified there are **zero** archived WAL segments in the bucket — only two ~931B base-backup markers and two stale/aborted multipart uploads. The repos themselves live on the separate 200Gi `gitea-shared-storage`, so they were never the cause.

Ruled out (tested live with the real creds): Garage health, bucket existence, key RWO permission, ExternalSecret sync, region, connectivity, and small + 16MB multipart writes — all good.

## This change
Expands `forgejo-pg` storage **10Gi → 30Gi** so CNPG can start Postgres again (recovery headroom). `syno-iscsi-default` has `allowVolumeExpansion: true`; CNPG resizes the PVC on sync.

## ⚠️ Follow-up (required)
This is necessary but **not sufficient** — if WAL archiving stays broken, even 30Gi will refill. After Postgres restarts, capture the real `archive_command` stderr and fix archiving so the WAL backlog drains. Also abort the two stale multipart uploads (~82MiB) in the bucket.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased PostgreSQL database storage capacity from 10Gi to 30Gi for improved availability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->