### PR TITLE
forgejo-db: set S3 region=garage to fix WAL archiving

### DIFF
--- a/gitops/tools/apps/forgejo-db/externalsecret.yaml
+++ b/gitops/tools/apps/forgejo-db/externalsecret.yaml
@@ -10,6 +10,14 @@ spec:
   target:
     name: forgejo-garage-backup
     creationPolicy: Owner
+    # Inject the (non-secret) S3 region as a static key. barman's boto3 must
+    # sign with Garage's region ("garage") or HeadBucket returns 400 and WAL
+    # archiving fails. The ObjectStore CRD only accepts region as a secretRef.
+    template:
+      engineVersion: v2
+      mergePolicy: Merge
+      data:
+        region: garage
   data:
   - secretKey: ACCESS_KEY_ID
     remoteRef:

--- a/gitops/tools/apps/forgejo-db/objectstore.yaml
+++ b/gitops/tools/apps/forgejo-db/objectstore.yaml
@@ -14,6 +14,9 @@ spec:
       secretAccessKey:
         name: forgejo-garage-backup
         key: ACCESS_SECRET_KEY
+      region:
+        name: forgejo-garage-backup
+        key: region
     wal:
       compression: gzip
   retentionPolicy: "7d"


### PR DESCRIPTION
Follow-up to #258. The PVC expansion recovered the forgejo outage, but **WAL archiving is still broken**, so Postgres cannot recycle WAL and the 9.8GB/623-file backlog will slowly refill the disk. This fixes the underlying cause.

## Root cause (confirmed)
barman runs `barman-cloud-check-wal-archive` (an S3 `HeadBucket`) before archiving. The ObjectStore had **no region** configured, so boto3 signs the request with the wrong region scope and Garage rejects it:

```
barman-cloud-check-wal-archive ERROR: An error occurred (400) when calling the HeadBucket operation: Bad Request
... unexpected failure invoking barman-cloud-wal-archive: exit status 4
```

Reproduced directly against Garage with the real creds:

| region | boto3 head_bucket |
|--------|-------------------|
| `None` (barman default) | **400 Bad Request** |
| `us-east-1` | **400 Bad Request** |
| `garage` | ✅ OK |

## Fix
Set `s3Credentials.region` on the ObjectStore to `garage`. The CRD only accepts region as a `secretKeyRef`, and the value is **not sensitive**, so it is injected into the synced Secret via an ESO `template` (`mergePolicy: Merge`, so the fetched access keys are preserved) rather than added to 1Password.

## After merge / sync
- ObjectStore reconciles, `ContinuousArchiving` should flip to `True`.
- The 623-file WAL backlog drains to `s3://forgejo-backups`, freeing most of the 9.8GB in `pg_wal`.
- A fresh base backup should succeed (prior ones left only stale `backup.info` markers + ~82MiB of aborted multipart uploads, which can then be cleaned up).