### PR TITLE
atuin: set S3 region=garage to fix WAL archiving

### DIFF
--- a/gitops/tools/apps/atuin/externalsecret.yaml
+++ b/gitops/tools/apps/atuin/externalsecret.yaml
@@ -10,6 +10,14 @@ spec:
   target:
     name: atuin-garage-backup
     creationPolicy: Owner
+    # Inject the (non-secret) S3 region as a static key. barman's boto3 must
+    # sign with Garage's region ("garage") or HeadBucket returns 400 and WAL
+    # archiving fails. The ObjectStore CRD only accepts region as a secretRef.
+    template:
+      engineVersion: v2
+      mergePolicy: Merge
+      data:
+        region: garage
   data:
   - secretKey: ACCESS_KEY_ID
     remoteRef:

--- a/gitops/tools/apps/atuin/objectstore.yaml
+++ b/gitops/tools/apps/atuin/objectstore.yaml
@@ -14,6 +14,9 @@ spec:
       secretAccessKey:
         name: atuin-garage-backup
         key: ACCESS_SECRET_KEY
+      region:
+        name: atuin-garage-backup
+        key: region
     wal:
       compression: gzip
   retentionPolicy: "7d"


### PR DESCRIPTION
Same root cause and fix as #259, found by auditing all Garage-backed CNPG/barman stores.

`atuin-pg` WAL archiving to Garage has been failing with:
```
barman-cloud-check-wal-archive ERROR: An error occurred (400) when calling the HeadBucket operation: Bad Request
... unexpected failure invoking barman-cloud-wal-archive: exit status 4
```
The `atuin-backups` ObjectStore had **no S3 region**, so boto3 signs the `HeadBucket` precondition with the wrong region scope and Garage returns 400 — blocking all WAL archiving (`ContinuousArchiving=False`). Not yet critical (atuin disk at 16%), but it leaks the same way forgejo did.

## Fix
Set `s3Credentials.region` to `garage`, injected into the synced Secret via an ESO `template` (`mergePolicy: Merge`), identical to the forgejo fix.

## Audit result
All barman-plugin Garage stores checked: `forgejo` (fixed in #259) and `atuin` (this PR) were the only two affected. The `tatl`/`tipoff` CNPG clusters do not use the barman plugin and are archiving fine.

## After merge
Sync, then restart the instance so the plugin reloads the region (`kubectl cnpg restart` / `cnpg.io/restartedAt` annotation) — the sidecar caches creds and won't pick it up otherwise. Then `ContinuousArchiving` flips to True and the WAL backlog drains.