### PR TITLE
stock-bot: deploy 2d3b113 (triage reads filing content + LLM retry)

### DIFF
--- a/gitops/tools/apps/stock-bot/kustomization.yaml
+++ b/gitops/tools/apps/stock-bot/kustomization.yaml
@@ -26,7 +26,7 @@ resources:
 images:
   - name: stock-bot
     newName: zot.phillips-homelab.net/stock-bot
-    newTag: 8b8a1c0
+    newTag: 2d3b113
 
 labels:
   - includeSelectors: false


### PR DESCRIPTION
Bumps the stock-bot image tag 8b8a1c0 → 2d3b113.

Carries [stock-bot PR #4](https://github.com/AlverezYari/stock-bot/pull/4):
- **Filing triage reads document content** — fetches the primary-doc lead so 8-Ks are judged on real disclosure instead of the useless `"8-K — 8-K"` title (verified live: 8-Ks now classified accurately by content vs. blanket `noise` before).
- **Form 4 fast-path** — deterministic `minor` verdicts, no LLM call, unblocking the LLM cap for substantive forms.
- **LLM semantic validate-and-retry** — fixes the IPO `screen_ipo returned empty summary` failures (reproduced + verified fixed against the cluster qwen2.5:7b).

Image already pushed to Zot (`sha256:57d4cb1c…`). Argo auto-syncs main; `migrate up` PreSync hook is a no-op (no new migrations).