### PR TITLE
stock-bot: give triage the EDGAR User-Agent

### DIFF
--- a/gitops/tools/apps/stock-bot/cronjob-triage.yaml
+++ b/gitops/tools/apps/stock-bot/cronjob-triage.yaml
@@ -46,6 +46,11 @@ spec:
                   value: http://open-webui-ollama.tools.svc.cluster.local:11434/v1
                 - name: TRIAGE_MODEL
                   value: qwen2.5:7b
+                # Triage now fetches the primary-document lead for substantive
+                # filings (8-K/10-K/...), so it needs the EDGAR fair-access
+                # User-Agent like the edgar/ipo jobs — sec.gov 403s an empty UA.
+                - name: EDGAR_USER_AGENT
+                  value: "stock-bot/0.1 (admin@phillips-homelab.net)"
               resources:
                 requests:
                   cpu: 25m


### PR DESCRIPTION
Triage now fetches each substantive filing's primary-document lead (deploy of stock-bot PR #4), but the triage cronjob was missing `EDGAR_USER_AGENT`. With an empty User-Agent, sec.gov returns **403**, so every filing silently fell back to metadata-only and classified as `noise` — defeating the whole fix. Diagnosed from an in-cluster probe: empty UA → 403, our UA → 200. Adds the same fair-access UA the edgar/ipo jobs already set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added environment variable configuration to the triage job, enabling proper identification in external requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->