### PR TITLE
stock-bot: deploy ab6e31f (enforce materiality enum)

### DIFF
--- a/gitops/tools/apps/stock-bot/kustomization.yaml
+++ b/gitops/tools/apps/stock-bot/kustomization.yaml
@@ -26,7 +26,7 @@ resources:
 images:
   - name: stock-bot
     newName: zot.phillips-homelab.net/stock-bot
-    newTag: 2d3b113
+    newTag: ab6e31f
 
 labels:
   - includeSelectors: false


### PR DESCRIPTION
Bumps stock-bot image `2d3b113` → `ab6e31f`. Carries [stock-bot PR #5](https://github.com/AlverezYari/stock-bot/pull/5): triage rejects out-of-enum materiality and retries. Image pushed to Zot (`sha256:1fb6ec51…`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated stock-bot service image reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->