### PR TITLE
stock-bot: deploy 2bab22e (closed category vocabulary)

### DIFF
--- a/gitops/tools/apps/stock-bot/kustomization.yaml
+++ b/gitops/tools/apps/stock-bot/kustomization.yaml
@@ -26,7 +26,7 @@ resources:
 images:
   - name: stock-bot
     newName: zot.phillips-homelab.net/stock-bot
-    newTag: ab6e31f
+    newTag: 2bab22e
 
 labels:
   - includeSelectors: false


### PR DESCRIPTION
Bumps stock-bot image `ab6e31f` → `2bab22e`. Carries [stock-bot PR #6](https://github.com/AlverezYari/stock-bot/pull/6): triage category constrained to an 11-value enum so the data is dashboard-ready. Image pushed to Zot (`sha256:206c58a4…`).