### PR TITLE
stock-bot: add Streamlit dashboard (material feed)

### DIFF
--- a/gitops/tools/apps/stock-bot/dashboard-deployment.yaml
+++ b/gitops/tools/apps/stock-bot/dashboard-deployment.yaml
@@ -1,0 +1,86 @@
+# Streamlit dashboard Deployment — the "material feed" consumption view.
+#
+# Read-only over Postgres (opens a read-only session; SELECT-only queries).
+# Uses the same stock-bot-pg-app secret as serve; a dedicated read-only role
+# is a later hardening step.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stock-bot-dash
+  labels:
+    app.kubernetes.io/name: stock-bot-dash
+    app.kubernetes.io/component: dashboard
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: stock-bot-dash
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: stock-bot-dash
+        app.kubernetes.io/component: dashboard
+    spec:
+      containers:
+        - name: dash
+          image: stock-bot-dash
+          ports:
+            - name: http
+              containerPort: 8501
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: stock-bot-pg-app
+                  key: uri
+          startupProbe:
+            httpGet:
+              path: /_stcore/health
+              port: http
+            periodSeconds: 2
+            failureThreshold: 45   # 90s for first boot (pip-free, but cold pull)
+          livenessProbe:
+            httpGet:
+              path: /_stcore/health
+              port: http
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /_stcore/health
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          # Streamlit writes config/cache under $HOME (=/tmp); mount it writable
+          # so the root filesystem can stay read-only.
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            requests:
+              cpu: 50m
+              memory: 192Mi
+            limits:
+              cpu: "1"
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/gitops/tools/apps/stock-bot/dashboard-service.yaml
+++ b/gitops/tools/apps/stock-bot/dashboard-service.yaml
@@ -1,0 +1,21 @@
+# ClusterIP Service for the Streamlit dashboard, exposed on the tailnet at
+# http://stock-bot-dash:8501 (MagicDNS) via the tailscale-operator proxy.
+apiVersion: v1
+kind: Service
+metadata:
+  name: stock-bot-dash
+  labels:
+    app.kubernetes.io/name: stock-bot-dash
+    app.kubernetes.io/component: dashboard
+  annotations:
+    tailscale.com/expose: "true"
+    tailscale.com/hostname: stock-bot-dash
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: stock-bot-dash
+  ports:
+    - name: http
+      port: 8501
+      targetPort: http
+      protocol: TCP

--- a/gitops/tools/apps/stock-bot/kustomization.yaml
+++ b/gitops/tools/apps/stock-bot/kustomization.yaml
@@ -17,16 +17,21 @@ resources:
   - cronjob-digest.yaml
   - serve-deployment.yaml
   - serve-service.yaml
+  - dashboard-deployment.yaml
+  - dashboard-service.yaml
 
-# Single point of override for the image tag. Bump newTag to deploy a new
+# Single point of override for the image tags. Bump newTag to deploy a new
 # build; Argo syncs it. (`migrate up` runs as a PreSync hook, so a tag
 # carrying new migrations applies them before the workloads roll.)
-# `latest` is a placeholder until the first image build — bump to a real
-# immutable tag after that.
+# The scout image (Go) runs the cronjobs + serve API; stock-bot-dash (Python)
+# is the Streamlit dashboard, versioned independently.
 images:
   - name: stock-bot
     newName: zot.phillips-homelab.net/stock-bot
     newTag: 2bab22e
+  - name: stock-bot-dash
+    newName: zot.phillips-homelab.net/stock-bot-dash
+    newTag: ffde963
 
 labels:
   - includeSelectors: false


### PR DESCRIPTION
First consumption view (stock-bot PR #7). Adds `stock-bot-dash` Deployment + tailscale-exposed Service → **http://stock-bot-dash:8501** on the tailnet. Python Streamlit image (`stock-bot-dash:ffde963`, pushed to Zot), read-only over Postgres via the `stock-bot-pg-app` secret (opens a read-only session, SELECT-only). Kustomize build validated locally. Follow-up hardening: dedicated read-only DB role.