### PR TITLE
core: route stock-bot dashboard at stockbot.phillips-homelab.net

### DIFF
--- a/gitops/core/apps/blocky/configmap.yaml
+++ b/gitops/core/apps/blocky/configmap.yaml
@@ -48,6 +48,7 @@ data:
         blocky.phillips-homelab.net: 192.168.10.211
         code.phillips-homelab.net: 192.168.10.211
         tatl.phillips-homelab.net: 192.168.10.211
+        stockbot.phillips-homelab.net: 192.168.10.211
         # Synology NAS
         nas.phillips-homelab.net: 192.168.10.195
 

--- a/gitops/core/apps/certs.yml
+++ b/gitops/core/apps/certs.yml
@@ -142,3 +142,16 @@ spec:
     kind: ClusterIssuer
   secretName: tatl-tls
 ---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: stockbot-tls
+  namespace: gateways
+spec:
+  dnsNames:
+  - stockbot.phillips-homelab.net
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  secretName: stockbot-tls
+---

--- a/gitops/core/apps/gateways.yml
+++ b/gitops/core/apps/gateways.yml
@@ -153,6 +153,20 @@ spec:
   - group: ""
     kind: Service
 ---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-stock-bot-service
+  namespace: stock-bot
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: gateways
+  to:
+  - group: ""
+    kind: Service
+---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -249,6 +263,14 @@ spec:
       certificateRefs:
       - kind: Secret
         name: tatl-tls
+  - name: https-12
+    protocol: HTTPS
+    port: 443
+    hostname: stockbot.phillips-homelab.net
+    tls:
+      certificateRefs:
+      - kind: Secret
+        name: stockbot-tls
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -453,3 +475,21 @@ spec:
     - name: varnish
       namespace: tatl
       port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: https-app-route-12
+  namespace: gateways
+spec:
+  parentRefs:
+  - name: tls-gateway
+    sectionName: https-12
+    namespace: gateways
+  hostnames:
+  - stockbot.phillips-homelab.net
+  rules:
+  - backendRefs:
+    - name: stock-bot-dash
+      namespace: stock-bot
+      port: 8501


### PR DESCRIPTION
Exposes the Streamlit material feed on the internal Cilium gateway (https://stockbot.phillips-homelab.net) instead of only the tailnet. Adds: cert-manager Certificate (`stockbot-tls`), `tls-gateway` listener `https-12` + HTTPRoute → `stock-bot-dash`:8501, a ReferenceGrant in the `stock-bot` ns, and a blocky customDNS entry → 192.168.10.211. Mirrors the existing zot/openwebui/grafana pattern. Validated via client dry-run + kustomize build.