### PR TITLE
stock-bot: holdings cronjob + SnapTrade ExternalSecret (deploy 829131b)

### DIFF
--- a/gitops/tools/apps/stock-bot/cronjob-holdings.yaml
+++ b/gitops/tools/apps/stock-bot/cronjob-holdings.yaml
@@ -1,0 +1,71 @@
+# Holdings ingest CronJob.
+#
+# Pulls brokerage positions from SnapTrade once a day, mirrors them into the
+# positions table, and augments the watchlist with held tickers (reason
+# 'robinhood') so EDGAR -> triage track what's actually owned. Runs before the
+# 06:00 ipo / 07:00 digest jobs so new holdings are picked up the same morning.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: stock-bot-holdings
+  labels:
+    app.kubernetes.io/name: stock-bot-holdings
+    app.kubernetes.io/component: ingest
+    stock-bot.io/source: holdings
+spec:
+  schedule: "0 5 * * *"   # daily at 05:00
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  startingDeadlineSeconds: 60
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 240
+      ttlSecondsAfterFinished: 3600
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: stock-bot-holdings
+            stock-bot.io/source: holdings
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: feed
+              image: stock-bot
+              args: ["ingest", "holdings"]
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: stock-bot-pg-app
+                      key: uri
+                - name: LOG_LEVEL
+                  value: info
+                - name: SNAPTRADE_CLIENT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: stock-bot-snaptrade
+                      key: client_id
+                - name: SNAPTRADE_CONSUMER_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: stock-bot-snaptrade
+                      key: consumer_key
+              resources:
+                requests:
+                  cpu: 25m
+                  memory: 32Mi
+                limits:
+                  cpu: 500m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 65532
+                runAsGroup: 65532
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault

--- a/gitops/tools/apps/stock-bot/kustomization.yaml
+++ b/gitops/tools/apps/stock-bot/kustomization.yaml
@@ -15,6 +15,8 @@ resources:
   - cronjob-triage.yaml
   - cronjob-ipo.yaml
   - cronjob-digest.yaml
+  - cronjob-holdings.yaml
+  - snaptrade-externalsecret.yaml
   - serve-deployment.yaml
   - serve-service.yaml
   - dashboard-deployment.yaml
@@ -28,7 +30,7 @@ resources:
 images:
   - name: stock-bot
     newName: zot.phillips-homelab.net/stock-bot
-    newTag: 2bab22e
+    newTag: 829131b
   - name: stock-bot-dash
     newName: zot.phillips-homelab.net/stock-bot-dash
     newTag: ffde963

--- a/gitops/tools/apps/stock-bot/snaptrade-externalsecret.yaml
+++ b/gitops/tools/apps/stock-bot/snaptrade-externalsecret.yaml
@@ -1,0 +1,25 @@
+# SnapTrade personal-key credentials, synced from 1Password via ESO.
+# Personal keys authenticate user-scoped calls with just clientId + consumerKey
+# (the key is bound to its single auto-provisioned user), so only two fields.
+# Create a 1Password item named "stock-bot-snaptrade" with fields client_id
+# and consumer_key in the vault backing the `staging` ClusterSecretStore.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: stock-bot-snaptrade
+  namespace: stock-bot
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: staging
+  target:
+    creationPolicy: Owner
+  data:
+    - secretKey: client_id
+      remoteRef:
+        key: stock-bot-snaptrade
+        property: client_id
+    - secretKey: consumer_key
+      remoteRef:
+        key: stock-bot-snaptrade
+        property: consumer_key


### PR DESCRIPTION
Deploys the SnapTrade holdings integration (stock-bot PR #8). Adds `cronjob-holdings` (daily 05:00, SnapTrade → positions + watchlist), `snaptrade-externalsecret.yaml` (ESO from 1Password item `stock-bot-snaptrade`, fields `client_id`/`consumer_key`), and bumps the image to `829131b` (migration 0009 + holdings command). Verified locally against the real account: 15 Robinhood holdings read with just the two personal keys.

**Merge once the 1Password item exists** so ESO can populate the secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new daily scheduled job for automated data processing.

* **Chores**
  * Updated application container image to latest version.
  * Implemented external secret management for secure credential handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->