### PR TITLE
stock-bot: dashboard cc2f101 (Portfolio + Signals tabs)

### DIFF
--- a/gitops/tools/apps/stock-bot/kustomization.yaml
+++ b/gitops/tools/apps/stock-bot/kustomization.yaml
@@ -33,7 +33,7 @@ images:
     newTag: 829131b
   - name: stock-bot-dash
     newName: zot.phillips-homelab.net/stock-bot-dash
-    newTag: ffde963
+    newTag: cc2f101
 
 labels:
   - includeSelectors: false


### PR DESCRIPTION
Bumps stock-bot-dash ffde963 → cc2f101 (stock-bot PR #9: Portfolio + Signals Plotly tabs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated stock-bot service to a new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->