### PR TITLE
stock-bot: enable Alpaca quotes (ExternalSecret + un-suspend)

### DIFF
--- a/gitops/tools/apps/stock-bot/alpaca-externalsecret.yaml
+++ b/gitops/tools/apps/stock-bot/alpaca-externalsecret.yaml
@@ -1,0 +1,25 @@
+# Alpaca market-data credentials, synced from 1Password via ESO.
+# Produces the k8s Secret `stock-bot-secrets` with the keys the quotes/news
+# cronjobs reference. Source: 1Password item `stock-bot-alpaca` (vault behind
+# the `staging` ClusterSecretStore) with fields `api_key` and `secret_key`.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: stock-bot-secrets
+  namespace: stock-bot
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: staging
+  target:
+    name: stock-bot-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: alpaca_api_key
+      remoteRef:
+        key: stock-bot-alpaca
+        property: api_key
+    - secretKey: alpaca_secret_key
+      remoteRef:
+        key: stock-bot-alpaca
+        property: secret_key

--- a/gitops/tools/apps/stock-bot/cronjob-quotes.yaml
+++ b/gitops/tools/apps/stock-bot/cronjob-quotes.yaml
@@ -12,9 +12,9 @@ metadata:
     app.kubernetes.io/component: ingest
     stock-bot.io/source: quotes
 spec:
-  # SUSPENDED: Alpaca creds not yet provisioned (stock-bot-secrets ExternalSecret
-  # deferred). Un-suspend once an Alpaca paper API key is in 1Password.
-  suspend: true
+  # Alpaca creds provisioned via the stock-bot-secrets ExternalSecret
+  # (alpaca-externalsecret.yaml, sourced from 1Password).
+  suspend: false
   schedule: "0 22 * * 1-5"   # 22:00 UTC weekdays — after US market close
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3

--- a/gitops/tools/apps/stock-bot/kustomization.yaml
+++ b/gitops/tools/apps/stock-bot/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - cronjob-digest.yaml
   - cronjob-holdings.yaml
   - snaptrade-externalsecret.yaml
+  - alpaca-externalsecret.yaml
   - serve-deployment.yaml
   - serve-service.yaml
   - dashboard-deployment.yaml


### PR DESCRIPTION
Provisions Alpaca creds via ESO (1Password item `stock-bot-alpaca` → secret `stock-bot-secrets`) and un-suspends the quotes cronjob (~400d daily bars). Enables candlestick price charts.