### PR TITLE
stock-bot: un-suspend news ingest

### DIFF
--- a/gitops/tools/apps/stock-bot/cronjob-news.yaml
+++ b/gitops/tools/apps/stock-bot/cronjob-news.yaml
@@ -11,9 +11,8 @@ metadata:
     app.kubernetes.io/component: ingest
     stock-bot.io/source: news
 spec:
-  # SUSPENDED: Alpaca creds not yet provisioned (stock-bot-secrets ExternalSecret
-  # deferred). Un-suspend once an Alpaca paper API key is in 1Password.
-  suspend: true
+  # Alpaca creds provisioned via the stock-bot-secrets ExternalSecret.
+  suspend: false
   schedule: "0 */4 * * *"   # every 4 hours
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3


### PR DESCRIPTION
Un-suspends stock-bot-ingest-news (every 4h, Alpaca → news → triage). Creds already provisioned via stock-bot-secrets.