### PR TITLE
stock-bot: dashboard f1fc9e5 (readability pass)

### DIFF
--- a/gitops/tools/apps/stock-bot/kustomization.yaml
+++ b/gitops/tools/apps/stock-bot/kustomization.yaml
@@ -34,7 +34,7 @@ images:
     newTag: 829131b
   - name: stock-bot-dash
     newName: zot.phillips-homelab.net/stock-bot-dash
-    newTag: f6363a1
+    newTag: f1fc9e5
 
 labels:
   - includeSelectors: false


### PR DESCRIPTION
Bumps stock-bot-dash f6363a1 -> f1fc9e5 (dark theme + readable charts; stock-bot PR #11).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Stock-bot service updated to the latest version and will be deployed in the next automated deployment cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->