### PR TITLE
grafana: use Recreate deployment strategy (RWO PVC deadlock)

### DIFF
--- a/gitops/core/apps/grafana.yml
+++ b/gitops/core/apps/grafana.yml
@@ -53,6 +53,12 @@ spec:
             root_url: https://monitoring.phillips-homelab.net
         grafanaAgent:
           logLevel: warn
+        # RWO PVC: a single iSCSI volume can only attach to one node. With the
+        # chart default RollingUpdate, the new pod is created before the old is
+        # removed and deadlocks waiting for the volume (multi-attach). Recreate
+        # terminates the old pod first so the volume is free for the new one.
+        deploymentStrategy:
+          type: Recreate
         ingress:
           enabled: false
         persistence:


### PR DESCRIPTION
Grafana has been showing **Degraded in ArgoCD** for ~33h. The app itself is still serving (old pod `revision 24` returns `/api/health` = `database: ok`), but a new revision (25) has been wedged in `Init:0/1` the whole time.

## Root cause
Grafana's data PVC is **RWO** (`syno-iscsi-default`) — attachable to one node only. The chart default is **`strategy: RollingUpdate`** (maxSurge 25%→1, maxUnavailable 25%→0 at 1 replica), so Kubernetes creates the **new** pod before removing the old. The new pod landed on `homelab-01` while the old still holds the volume on `homelab-03`, so `init-chown-data` hangs forever on a multi-attach it can never win → rollout stuck → ArgoCD Degraded.

## Fix
Set `deploymentStrategy.type: Recreate` in the Helm values. Recreate terminates the old pod first, freeing the RWO volume before the new pod starts — no multi-attach window. A few seconds of downtime per rollout is fine for a single-replica, RWO-backed Grafana (it is effectively single-instance regardless). **This also unblocks the currently-stuck rollout on sync.**

## Note
`gitops/core/apps/` is not reliably auto-synced — after merge this needs a manual `kubectl -n argocd patch app grafana --type merge -p '{"operation":{"sync":{}}}'`.

## Related: cluster-wide audit
Scanned every Deployment that mounts an RWO PVC for the same RollingUpdate combo. Besides grafana, two others are at risk on their next rollout (not yet stuck): `media/jellyfin` and `tools/open-webui-pipelines`. The rest already use Recreate. Those two can be fixed in follow-ups.