### PR TITLE
jellyfin: use Recreate deployment strategy (RWO PVC)

### DIFF
--- a/gitops/tools/apps/jellyfin.yml
+++ b/gitops/tools/apps/jellyfin.yml
@@ -14,6 +14,13 @@ spec:
       values: |-
         replicaCount: 1
 
+        # config + media PVCs are RWO (single-node attach). RollingUpdate would
+        # create the new pod before deleting the old one and deadlock on a
+        # multi-attach if it schedules onto a different node. Recreate tears the
+        # old pod down first so the volumes are free for the new one.
+        deploymentStrategy:
+          type: Recreate
+
         image:
           repository: jellyfin/jellyfin
           tag: latest


### PR DESCRIPTION
Follow-up to the RWO/RollingUpdate audit from #274.

`media/jellyfin` mounts two **RWO** PVCs (`jellyfin-config` 20Gi, `jellyfin-media` 200Gi) but uses the chart-default **`RollingUpdate`** strategy. It is not stuck today (its pod happens to be on the right node), but the next rollout that schedules the new pod onto a different node will deadlock in init waiting for a volume it cannot multi-attach — exactly what wedged grafana for 33h.

## Fix
Set `deploymentStrategy.type: Recreate` (the jellyfin-helm chart key) so the old pod is torn down before the new one starts. Brief downtime per rollout is fine for a single-replica, GPU-pinned, RWO-backed Jellyfin.

Verified the value key against the pinned chart (jellyfin 2.3.0): `templates/deployment.yaml` renders `strategy:` from `.Values.deploymentStrategy`.