### PR TITLE
openwebui: Recreate strategy for pipelines subchart (RWO PVC)

### DIFF
--- a/gitops/tools/apps/openwebui.yml
+++ b/gitops/tools/apps/openwebui.yml
@@ -54,6 +54,14 @@ spec:
           - name: OLLAMA_BASE_URL
             value: "http://openwebui-ollama:11434"
 
+        # Pipelines subchart deploys a Deployment backed by an RWO PVC. Force
+        # Recreate so its rollout doesn't deadlock on a multi-attach when the
+        # new pod schedules onto a different node than the old one.
+        pipelines:
+          enabled: true
+          strategy:
+            type: Recreate
+
         ollama:
           enabled: true
           replicaCount: 1


### PR DESCRIPTION
Follow-up to the RWO/RollingUpdate audit from #274.

`tools/open-webui-pipelines` (the pipelines subchart Deployment) mounts an **RWO** PVC (`open-webui-pipelines`) but uses the default **`RollingUpdate`** strategy. Not stuck today, but it will deadlock the same way grafana did the next time the new pod schedules onto a different node and tries to multi-attach the volume.

## Fix
Set `pipelines.strategy.type: Recreate`. Verified against the pinned chart (open-webui 8.19.0): the `pipelines` subchart `templates/deployment.yaml` renders `strategy:` from its `.Values.strategy`, overridden from the parent under `pipelines.strategy`.

The **main** open-webui workload is a StatefulSet (handles per-pod PVCs, no multi-attach deadlock) so it needs no change; `open-webui-ollama` already uses Recreate. Only the pipelines Deployment was at risk.