### PR TITLE
stock-bot: ipo deadline + dashboard f1661e0

### DIFF
--- a/gitops/tools/apps/stock-bot/cronjob-ipo.yaml
+++ b/gitops/tools/apps/stock-bot/cronjob-ipo.yaml
@@ -20,7 +20,10 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 1
-      activeDeadlineSeconds: 1800   # LLM calls are slow on one GPU
+      # 60 min: screening sends large prospectus prompts to the shared GPU;
+      # under contention some calls hit the client timeout, so give the run
+      # headroom rather than getting killed mid-screen (was 1800).
+      activeDeadlineSeconds: 3600
       ttlSecondsAfterFinished: 3600
       template:
         metadata:

--- a/gitops/tools/apps/stock-bot/kustomization.yaml
+++ b/gitops/tools/apps/stock-bot/kustomization.yaml
@@ -34,7 +34,7 @@ images:
     newTag: 829131b
   - name: stock-bot-dash
     newName: zot.phillips-homelab.net/stock-bot-dash
-    newTag: f1fc9e5
+    newTag: f1661e0
 
 labels:
   - includeSelectors: false


### PR DESCRIPTION
IPO cronjob deadline 1800->3600 (stop Degraded flapping on slow GPU); dashboard -> f1661e0 (company names + pipeline-health panel; stock-bot PR #12).