### PR TITLE
grafana: pin persistence.storageClassName (fix immutable-PVC sync failure)

### DIFF
--- a/gitops/core/apps/grafana.yml
+++ b/gitops/core/apps/grafana.yml
@@ -65,6 +65,11 @@ spec:
           type: pvc
           enabled: true
           size: 5Gi
+          # Must match the live bound PVC. The PVC was created via the cluster
+          # default StorageClass, so its storageClassName is syno-iscsi-default;
+          # leaving this unset makes the chart render it null, and ArgoCD then
+          # tries to patch the (immutable) field on every sync -> sync fails.
+          storageClassName: syno-iscsi-default
         service:
           annotations:
             tailscale.com/expose: "true"


### PR DESCRIPTION
Unblocks ArgoCD syncs of the `grafana` app.

## Problem
The grafana data PVC was created through the cluster **default** StorageClass, so its bound `storageClassName` is `syno-iscsi-default`. The chart left `persistence.storageClassName` unset, so it renders the PVC **without** that field. PVC specs are immutable after creation, so any real sync that re-applies manifests tries to change `storageClassName: syno-iscsi-default -> null` and fails:

```
PersistentVolumeClaim "grafana" is invalid: spec: Forbidden: spec is immutable
after creation except resources.requests and volumeAttributesClassName for bound claims
- "StorageClassName": "syno-iscsi-default",
+ "StorageClassName": null,
```

This stayed latent for months (nothing was OutOfSync, so no sync ran). It surfaced when #274's Recreate change made the Deployment OutOfSync and auto-sync then failed on the PVC.

## Fix
Pin `persistence.storageClassName: syno-iscsi-default` so the rendered PVC matches the live one — the apply becomes a no-op on the immutable field and syncs succeed. Verified the key against the pinned chart (grafana 8.10.4): `templates/pvc.yaml` renders `storageClassName` from `.Values.persistence.storageClassName`.

## Note
`gitops/core/apps/` needs a manual sync after merge.

## Context
Grafana itself is already healthy — #274 recovered the 33h-stuck rollout (now a single pod on Recreate). This PR only resolves the remaining ArgoCD OutOfSync/Failed sync state.