### PR TITLE
stock-bot: dashboard job-health RBAC + e56b737

### DIFF
--- a/gitops/tools/apps/stock-bot/dashboard-deployment.yaml
+++ b/gitops/tools/apps/stock-bot/dashboard-deployment.yaml
@@ -26,6 +26,7 @@ spec:
         app.kubernetes.io/name: stock-bot-dash
         app.kubernetes.io/component: dashboard
     spec:
+      serviceAccountName: stock-bot-dash
       containers:
         - name: dash
           image: stock-bot-dash
@@ -38,6 +39,10 @@ spec:
                 secretKeyRef:
                   name: stock-bot-pg-app
                   key: uri
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           startupProbe:
             httpGet:
               path: /_stcore/health

--- a/gitops/tools/apps/stock-bot/dashboard-rbac.yaml
+++ b/gitops/tools/apps/stock-bot/dashboard-rbac.yaml
@@ -1,0 +1,31 @@
+# Read-only access for the dashboard pod to report real CronJob/Job status.
+# Scoped to the stock-bot namespace, get/list on batch resources only.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stock-bot-dash
+  namespace: stock-bot
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: stock-bot-dash-jobs-reader
+  namespace: stock-bot
+rules:
+  - apiGroups: ["batch"]
+    resources: ["cronjobs", "jobs"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: stock-bot-dash-jobs-reader
+  namespace: stock-bot
+subjects:
+  - kind: ServiceAccount
+    name: stock-bot-dash
+    namespace: stock-bot
+roleRef:
+  kind: Role
+  name: stock-bot-dash-jobs-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/gitops/tools/apps/stock-bot/kustomization.yaml
+++ b/gitops/tools/apps/stock-bot/kustomization.yaml
@@ -22,6 +22,7 @@ resources:
   - serve-service.yaml
   - dashboard-deployment.yaml
   - dashboard-service.yaml
+  - dashboard-rbac.yaml
 
 # Single point of override for the image tags. Bump newTag to deploy a new
 # build; Argo syncs it. (`migrate up` runs as a PreSync hook, so a tag
@@ -34,7 +35,7 @@ images:
     newTag: 829131b
   - name: stock-bot-dash
     newName: zot.phillips-homelab.net/stock-bot-dash
-    newTag: f1661e0
+    newTag: e56b737
 
 labels:
   - includeSelectors: false


### PR DESCRIPTION
Adds a read-only ServiceAccount + Role (batch cronjobs/jobs get,list) for the dashboard to show live job status; bumps stock-bot-dash to e56b737 (k8s job health + Finviz profile links; stock-bot PR #13).