### PR TITLE
stock-bot: dashboard a5fe46a (treemap fix)

### DIFF
--- a/gitops/tools/apps/stock-bot/kustomization.yaml
+++ b/gitops/tools/apps/stock-bot/kustomization.yaml
@@ -35,7 +35,7 @@ images:
     newTag: 829131b
   - name: stock-bot-dash
     newName: zot.phillips-homelab.net/stock-bot-dash
-    newTag: e56b737
+    newTag: a5fe46a
 
 labels:
   - includeSelectors: false


### PR DESCRIPTION
Bumps stock-bot-dash e56b737 -> a5fe46a (allocation treemap fix; stock-bot PR #14).