### PR TITLE
stock-bot: self-hosted ntfy + digest delivery

### DIFF
--- a/gitops/tools/apps/stock-bot/cronjob-digest.yaml
+++ b/gitops/tools/apps/stock-bot/cronjob-digest.yaml
@@ -47,11 +47,9 @@ spec:
                   value: daily
                 - name: DIGEST_LOOKBACK_HOURS
                   value: "24"
-                # Optional delivery: set to an ntfy/webhook topic URL to push the
-                # digest. Unset = store in the digests table only. If the topic
-                # is private, source this from an ExternalSecret instead.
-                # - name: DIGEST_NTFY_URL
-                #   value: https://ntfy.phillips-homelab.net/stock-bot
+                # Push the digest to the in-cluster ntfy on the "stock-bot" topic.
+                - name: DIGEST_NTFY_URL
+                  value: http://ntfy.stock-bot.svc.cluster.local/stock-bot
               resources:
                 requests:
                   cpu: 25m

--- a/gitops/tools/apps/stock-bot/kustomization.yaml
+++ b/gitops/tools/apps/stock-bot/kustomization.yaml
@@ -23,6 +23,8 @@ resources:
   - dashboard-deployment.yaml
   - dashboard-service.yaml
   - dashboard-rbac.yaml
+  - ntfy-deployment.yaml
+  - ntfy-service.yaml
 
 # Single point of override for the image tags. Bump newTag to deploy a new
 # build; Argo syncs it. (`migrate up` runs as a PreSync hook, so a tag

--- a/gitops/tools/apps/stock-bot/ntfy-deployment.yaml
+++ b/gitops/tools/apps/stock-bot/ntfy-deployment.yaml
@@ -1,0 +1,79 @@
+# Self-hosted ntfy — the notification bus for stock-bot (daily digest now,
+# job-failure alerts via Alertmanager later). In-cluster publishers POST to
+# http://ntfy.stock-bot.svc/<topic>; subscribers reach it over the tailnet.
+# Cache is ephemeral (emptyDir): real-time delivery doesn't need persistence.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ntfy
+  namespace: stock-bot
+  labels:
+    app.kubernetes.io/name: ntfy
+    app.kubernetes.io/component: notifications
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ntfy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ntfy
+        app.kubernetes.io/component: notifications
+    spec:
+      securityContext:
+        fsGroup: 65532
+      containers:
+        - name: ntfy
+          image: docker.io/binwiederhier/ntfy:v2.11.0
+          args: ["serve"]
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: NTFY_BASE_URL
+              value: "http://ntfy"
+            - name: NTFY_LISTEN_HTTP
+              value: ":8080"
+            - name: NTFY_CACHE_FILE
+              value: "/var/cache/ntfy/cache.db"
+            - name: NTFY_CACHE_DURATION
+              value: "24h"
+            - name: NTFY_BEHIND_PROXY
+              value: "true"
+            # Lets the iOS app receive instant push for a self-hosted server.
+            - name: NTFY_UPSTREAM_BASE_URL
+              value: "https://ntfy.sh"
+          livenessProbe:
+            httpGet:
+              path: /v1/health
+              port: http
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /v1/health
+              port: http
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+          volumeMounts:
+            - name: cache
+              mountPath: /var/cache/ntfy
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+      volumes:
+        - name: cache
+          emptyDir: {}

--- a/gitops/tools/apps/stock-bot/ntfy-service.yaml
+++ b/gitops/tools/apps/stock-bot/ntfy-service.yaml
@@ -1,0 +1,22 @@
+# ntfy service, exposed on the tailnet (http://ntfy via MagicDNS) so the
+# ntfy phone app can subscribe. In-cluster publishers use the ClusterIP DNS
+# name directly (ntfy.stock-bot.svc.cluster.local).
+apiVersion: v1
+kind: Service
+metadata:
+  name: ntfy
+  namespace: stock-bot
+  labels:
+    app.kubernetes.io/name: ntfy
+  annotations:
+    tailscale.com/expose: "true"
+    tailscale.com/hostname: ntfy
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: ntfy
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP


### PR DESCRIPTION
In-cluster ntfy (tailnet-exposed at http://ntfy) + digest cronjob now POSTs the daily roll-up to the stock-bot topic. Notification bus also ready for Alertmanager job-failure alerts next.