### PR TITLE
glance: add Forgejo, Stockbot, Tempo tracing shortcuts

### DIFF
--- a/gitops/tools/apps/glance/configmap.yaml
+++ b/gitops/tools/apps/glance/configmap.yaml
@@ -34,6 +34,8 @@ data:
                     url: https://phillips-homelab.omni.siderolabs.io/
                   - title: Blocky
                     url: https://blocky.phillips-homelab.net
+                  - title: Forgejo
+                    url: https://code.phillips-homelab.net
                   - title: Home Assistant
                     url: https://home-assistant.phillips-homelab.net
                   - title: Jellyfin
@@ -42,6 +44,8 @@ data:
                     url: https://files.phillips-homelab.net
                   - title: OpenWebUI
                     url: https://openwebui.phillips-homelab.net
+                  - title: Stockbot
+                    url: https://stockbot.phillips-homelab.net
 
               - type: weather
                 location: Vestavia Hills, Alabama, United States
@@ -62,6 +66,10 @@ data:
                         url: https://phillips-homelab.omni.siderolabs.io/
                       - title: Blocky
                         url: https://blocky.phillips-homelab.net
+                      - title: Forgejo
+                        url: https://code.phillips-homelab.net
+                      - title: Tracing (Tempo)
+                        url: https://monitoring.phillips-homelab.net/explore
                   - title: Apps
                     links:
                       - title: Home Assistant
@@ -72,6 +80,8 @@ data:
                         url: https://files.phillips-homelab.net
                       - title: OpenWebUI
                         url: https://openwebui.phillips-homelab.net
+                      - title: Stockbot
+                        url: https://stockbot.phillips-homelab.net
 
               - type: hacker-news
                 limit: 15


### PR DESCRIPTION
Extends the Glance homepage shortcut list. Single-file change to the glance ConfigMap, branched cleanly off main.

## Changes
- **Bookmarks → Infra**: add Forgejo (`code.phillips-homelab.net`) and Tracing/Tempo (Grafana Explore)
- **Bookmarks → Apps**: add Stockbot (`stockbot.phillips-homelab.net`)
- **Homelab Services monitor**: add Forgejo + Stockbot uptime tiles

## Notes
- Garage omitted — `ingress.s3`/`ingress.web` disabled (internal-only `*.garage.local`).
- Tempo has no UI; "Tracing" points at Grafana Explore.
- ConfigMap change — glance pod needs `kubectl rollout restart deploy/glance -n glance` after sync to reload.

Supersedes the mislabeled #281.