### PR TITLE
fix(exchange-rails): rename env back to SECRET_KEY_BASE (fix crashloop)

### DIFF
--- a/gitops/tools/apps/exchange-rails/deployment.yaml
+++ b/gitops/tools/apps/exchange-rails/deployment.yaml
@@ -32,7 +32,11 @@ spec:
               value: "1"
             - name: RAILS_SERVE_STATIC_FILES
               value: "1"
-            - name: RAILS_SECRET_KEY_BASE
+            # Rails reads ENV["SECRET_KEY_BASE"] (no RAILS_ prefix); naming it
+            # RAILS_SECRET_KEY_BASE makes Rails fail boot with "Missing
+            # secret_key_base for 'prod_k8s'". Value still comes from the
+            # ExternalSecret-backed secret.
+            - name: SECRET_KEY_BASE
               valueFrom:
                 secretKeyRef:
                   name: exchange-rails-secrets


### PR DESCRIPTION
exchange-rails is **Progressing/unhealthy** in ArgoCD: a rollout from `b9fb861` is wedged at 4/5 because the new pods CrashLoopBackOff at boot.

## Root cause
`b9fb861` correctly moved the secret value out of the manifest into a `secretKeyRef` (→ `exchange-rails-secrets`), but it also **renamed the env var** `SECRET_KEY_BASE` → `RAILS_SECRET_KEY_BASE`. Rails reads `ENV["SECRET_KEY_BASE"]` (no `RAILS_` prefix), so it can no longer find it:

```
Missing `secret_key_base` for 'prod_k8s' environment (ArgumentError)
  from /app/app/models/app_token.rb:2  (loaded during run_initializers)
```

The `exchange-rails-secrets/secret_key_base` value is present and valid (128 bytes) — only the **variable name** is wrong. The old pods predate the rename (still have `SECRET_KEY_BASE`) and keep serving, so the app is degraded, not down.

## Fix
Rename back to `SECRET_KEY_BASE`, keeping the secretKeyRef (so the secret stays out of the manifest). New pods boot, rollout completes, no downtime (the crashing pods are only the surge).