### PR TITLE
ntfy: HTTPS via tailscale Ingress

### DIFF
--- a/gitops/tools/apps/stock-bot/kustomization.yaml
+++ b/gitops/tools/apps/stock-bot/kustomization.yaml
@@ -25,6 +25,7 @@ resources:
   - dashboard-rbac.yaml
   - ntfy-deployment.yaml
   - ntfy-service.yaml
+  - ntfy-ingress.yaml
 
 # Single point of override for the image tags. Bump newTag to deploy a new
 # build; Argo syncs it. (`migrate up` runs as a PreSync hook, so a tag

--- a/gitops/tools/apps/stock-bot/ntfy-deployment.yaml
+++ b/gitops/tools/apps/stock-bot/ntfy-deployment.yaml
@@ -32,7 +32,7 @@ spec:
               containerPort: 8080
           env:
             - name: NTFY_BASE_URL
-              value: "http://ntfy"
+              value: "https://ntfy.tail852f61.ts.net"
             - name: NTFY_LISTEN_HTTP
               value: ":8080"
             - name: NTFY_CACHE_FILE

--- a/gitops/tools/apps/stock-bot/ntfy-ingress.yaml
+++ b/gitops/tools/apps/stock-bot/ntfy-ingress.yaml
@@ -1,0 +1,18 @@
+# Tailnet HTTPS for ntfy via the tailscale operator (matches the atuin
+# pattern). Serves https://ntfy.<tailnet>.ts.net with a tailnet-issued cert,
+# so the ntfy app can subscribe over TLS.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ntfy
+  namespace: stock-bot
+spec:
+  ingressClassName: tailscale
+  defaultBackend:
+    service:
+      name: ntfy
+      port:
+        number: 80
+  tls:
+    - hosts:
+        - ntfy

--- a/gitops/tools/apps/stock-bot/ntfy-service.yaml
+++ b/gitops/tools/apps/stock-bot/ntfy-service.yaml
@@ -1,6 +1,6 @@
-# ntfy service, exposed on the tailnet (http://ntfy via MagicDNS) so the
-# ntfy phone app can subscribe. In-cluster publishers use the ClusterIP DNS
-# name directly (ntfy.stock-bot.svc.cluster.local).
+# ntfy ClusterIP service. Tailnet exposure is via the tailscale Ingress
+# (ntfy-ingress.yaml), which serves HTTPS at https://ntfy.<tailnet>.ts.net.
+# In-cluster publishers use ntfy.stock-bot.svc.cluster.local directly.
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,9 +8,6 @@ metadata:
   namespace: stock-bot
   labels:
     app.kubernetes.io/name: ntfy
-  annotations:
-    tailscale.com/expose: "true"
-    tailscale.com/hostname: ntfy
 spec:
   type: ClusterIP
   selector:


### PR DESCRIPTION
Serve ntfy over TLS at https://ntfy.tail852f61.ts.net (tailscale Ingress, atuin pattern) instead of http-only L3 expose; set NTFY_BASE_URL to match.