### PR TITLE
stock-bot: readable alerts via /alerthook (24c4b12)

### DIFF
--- a/gitops/tools/apps/stock-bot/kustomization.yaml
+++ b/gitops/tools/apps/stock-bot/kustomization.yaml
@@ -37,7 +37,7 @@ resources:
 images:
   - name: stock-bot
     newName: zot.phillips-homelab.net/stock-bot
-    newTag: 323a8d0
+    newTag: 24c4b12
   - name: stock-bot-dash
     newName: zot.phillips-homelab.net/stock-bot-dash
     newTag: a5fe46a

--- a/gitops/tools/apps/stock-bot/serve-deployment.yaml
+++ b/gitops/tools/apps/stock-bot/serve-deployment.yaml
@@ -43,6 +43,9 @@ spec:
               value: ":8080"
             - name: LOG_LEVEL
               value: info
+            # /alerthook formats Alertmanager webhooks and posts them here.
+            - name: ALERT_NTFY_URL
+              value: http://ntfy.stock-bot.svc.cluster.local/stock-bot
           # startupProbe gives the pool generous time to warm up before
           # readiness/liveness start applying. Avoids flapping during
           # rollouts on slow first-connect / first-DB-handshake cycles.

--- a/gitops/tools/apps/stock-bot/vmalertmanagerconfig-ntfy.yaml
+++ b/gitops/tools/apps/stock-bot/vmalertmanagerconfig-ntfy.yaml
@@ -1,8 +1,8 @@
-# Route stock-bot alerts to ntfy. The webhook POSTs the Alertmanager payload
-# to the ntfy topic; ntfy reads the notification title/priority/tags from the
-# URL query params (the body carries the alert JSON detail). vmalertmanager
-# selects all VMAlertmanagerConfigs by default, so this merges into the running
-# vmstack Alertmanager without editing its helm config.
+# Route stock-bot alerts to the serve API's /alerthook, which formats the
+# Alertmanager payload into a readable ntfy message (clean title + bullets,
+# firing/resolved priority+tags) — instead of dumping raw webhook JSON to ntfy.
+# vmalertmanager selects all VMAlertmanagerConfigs by default, so this merges
+# into the running vmstack Alertmanager without editing its helm config.
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAlertmanagerConfig
 metadata:
@@ -20,5 +20,5 @@ spec:
   receivers:
     - name: ntfy
       webhook_configs:
-        - url: "http://ntfy.stock-bot.svc.cluster.local/stock-bot?title=stock-bot+alert&priority=high&tags=rotating_light"
+        - url: "http://stock-bot-serve.stock-bot.svc.cluster.local:8080/alerthook"
           send_resolved: true


### PR DESCRIPTION
Alertmanager -> serve /alerthook -> formatted ntfy (vs raw JSON). serve gets ALERT_NTFY_URL; scout bumped to 24c4b12.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Alert notifications from stock-bot are now configured to be delivered via ntfy service.

* **Chores**
  * Updated stock-bot service deployment with latest changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->