### PR TITLE
gitops: self-manage app-of-apps with automated sync (no more manual nudges)

### DIFF
--- a/gitops/core/apps/homelab-core.yml
+++ b/gitops/core/apps/homelab-core.yml
@@ -1,17 +1,20 @@
+# Self-managed app-of-apps for core infra. Lives inside the path it watches
+# (gitops/core/apps), so once adopted it reconciles itself — no manual sync
+# needed when core apps are added or changed.
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: core-apps
+  name: homelab-core
   namespace: argocd
 spec:
   destination:
     namespace: argocd
-    server: 'https://kubernetes.default.svc'
+    server: https://kubernetes.default.svc
+  project: default
   source:
     path: gitops/core/apps
     repoURL: https://github.com/AlverezYari/phillips-homelab.git
     targetRevision: main
-  project: default
   syncPolicy:
     automated:
       prune: true

--- a/gitops/tools/homelab-tools.yml
+++ b/gitops/tools/homelab-tools.yml
@@ -1,0 +1,25 @@
+# Self-managed app-of-apps for tools. Lives inside the path it watches
+# (gitops/tools, non-recursive), alongside tool-apps.yml, so once adopted it
+# reconciles itself — no manual sync needed. The tool *children* are managed
+# one level down by tool-apps (gitops/tools/apps), which already auto-syncs.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: homelab-tools
+  namespace: argocd
+spec:
+  destination:
+    namespace: argocd
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: gitops/tools
+    repoURL: https://github.com/AlverezYari/phillips-homelab.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## Problem
`homelab-core` and `homelab-tools` (the two root app-of-apps) were **live-only** — manually `kubectl apply`'d, not in git, and with **no `syncPolicy`**. So every time an app was added/changed under `gitops/core/apps` or `gitops/tools`, the app-of-apps sat `OutOfSync` until a manual sync (this is what required the `kubectl patch app homelab-core ...` nudge to deploy Reloader).

The repo *did* have `core-apps.yml` / `tool-apps.yml`, but `core-apps.yml` was orphaned (wrong name, never deployed) and `homelab-core`/`homelab-tools` weren't tracked at all.

## Fix
Define both app-of-apps **in git, inside the path each one already watches**, so they reconcile themselves, with `automated: {prune, selfHeal}`:
- **`gitops/core/apps/homelab-core.yml`** — new; `homelab-core` watches `gitops/core/apps`, so it now self-manages.
- **`gitops/tools/homelab-tools.yml`** — new; `homelab-tools` watches `gitops/tools` (non-recursive, alongside the existing `tool-apps.yml`), so it now self-manages. (`tool-apps` already had auto-sync for the tool children.)
- **Deleted `gitops/core/core-apps.yml`** — orphaned duplicate, never deployed.

Names match the live apps, so this **adopts** the existing Applications rather than recreating them (no prune/recreate of children).

## One-time adoption (after merge)
The live apps have no auto-sync yet, so they need a single manual sync to pick up their own git definition — after that they self-manage forever:
```
kubectl -n argocd patch app homelab-core  --type merge -p '{"operation":{"sync":{}}}'
kubectl -n argocd patch app homelab-tools --type merge -p '{"operation":{"sync":{}}}'
```