### PR TITLE
stock-bot: event-date windowing + llm timeout (4200077)

### DIFF
--- a/gitops/tools/apps/stock-bot/kustomization.yaml
+++ b/gitops/tools/apps/stock-bot/kustomization.yaml
@@ -37,10 +37,10 @@ resources:
 images:
   - name: stock-bot
     newName: zot.phillips-homelab.net/stock-bot
-    newTag: 24c4b12
+    newTag: 4200077
   - name: stock-bot-dash
     newName: zot.phillips-homelab.net/stock-bot-dash
-    newTag: a5fe46a
+    newTag: 4200077
 
 labels:
   - includeSelectors: false


### PR DESCRIPTION
Bumps scout + dashboard to 4200077: digest/feed window on event date (no backlog pollution); LLM timeout 60s (IPO reliability).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated stock-bot and stock-bot-dash container images to the latest build version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->