### PR TITLE
stock-bot: quote image newTags (fix kustomize ComparisonError)

### DIFF
--- a/gitops/tools/apps/stock-bot/kustomization.yaml
+++ b/gitops/tools/apps/stock-bot/kustomization.yaml
@@ -37,10 +37,10 @@ resources:
 images:
   - name: stock-bot
     newName: zot.phillips-homelab.net/stock-bot
-    newTag: 4200077
+    newTag: "4200077"
   - name: stock-bot-dash
     newName: zot.phillips-homelab.net/stock-bot-dash
-    newTag: 4200077
+    newTag: "4200077"
 
 labels:
   - includeSelectors: false


### PR DESCRIPTION
Image SHA 4200077 is all-numeric; unquoted YAML parsed it as a number -> kustomize build failed -> Argo sync frozen. Quote all newTag values.