### PR TITLE
stock-bot(app): ignoreDifferences for ExternalSecrets

### DIFF
--- a/gitops/tools/apps/stock-bot.yml
+++ b/gitops/tools/apps/stock-bot.yml
@@ -18,6 +18,17 @@ spec:
     path: gitops/tools/apps/stock-bot
     repoURL: https://github.com/AlverezYari/phillips-homelab.git
     targetRevision: main
+  # ESO mutates ExternalSecrets post-admission (defaults on data/refreshInterval/
+  # deletionPolicy). With ServerSideApply that drift made Argo try to force-replace
+  # them — "--force cannot be used with --server-side" — wedging the sync. Ignore
+  # those fields (matches the synology-csi app's ESO handling).
+  ignoreDifferences:
+    - group: external-secrets.io
+      kind: ExternalSecret
+      jsonPointers:
+        - /spec/refreshInterval
+        - /spec/target/deletionPolicy
+        - /spec/data
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
Permanent fix for the wedged sync: ESO mutates ExternalSecret fields post-admission, and with ServerSideApply that drift made Argo try to force-replace them (`--force cannot be used with --server-side`), freezing the app. Adds ignoreDifferences for ExternalSecret spec/data, refreshInterval, target/deletionPolicy — matching the synology-csi app's ESO handling. No cluster changes applied here; review + merge, then the stock-bot app syncs clean to 4200077.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved deployment synchronization issues for stock-bot to prevent configuration drift problems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->