### PR TITLE
stock-bot: client-side-apply ExternalSecrets (fix SSA+force wedge)

### DIFF
--- a/gitops/tools/apps/stock-bot/alpaca-externalsecret.yaml
+++ b/gitops/tools/apps/stock-bot/alpaca-externalsecret.yaml
@@ -7,6 +7,10 @@ kind: ExternalSecret
 metadata:
   name: stock-bot-secrets
   namespace: stock-bot
+  annotations:
+    # Client-side apply: SSA conflicts with ESO's field manager on spec.data,
+    # making Argo retry with --force (illegal w/ server-side) and wedge the sync.
+    argocd.argoproj.io/sync-options: ServerSideApply=false
 spec:
   secretStoreRef:
     kind: ClusterSecretStore

--- a/gitops/tools/apps/stock-bot/snaptrade-externalsecret.yaml
+++ b/gitops/tools/apps/stock-bot/snaptrade-externalsecret.yaml
@@ -8,6 +8,12 @@ kind: ExternalSecret
 metadata:
   name: stock-bot-snaptrade
   namespace: stock-bot
+  annotations:
+    # Client-side apply: the app sets ServerSideApply=true globally, but SSA
+    # conflicts with ESO's field manager on spec.data, making Argo retry with
+    # --force (illegal w/ server-side) and wedge the sync. Other ExternalSecrets
+    # in the cluster work because their apps don't force SSA.
+    argocd.argoproj.io/sync-options: ServerSideApply=false
 spec:
   secretStoreRef:
     kind: ClusterSecretStore


### PR DESCRIPTION
Controller logs show the ExternalSecret applies fail with serverSideApply=true -> --force retry -> '--force cannot be used with --server-side'. ESO's field manager conflicts with Argo's SSA on spec.data. Annotate both ExternalSecrets ServerSideApply=false (client-side), like every other working ExternalSecret in the cluster. Merging = new revision -> Argo retries -> applies clean -> 4200077 rolls.