### PR TITLE
stock-bot: deploy scout ad51dca (edgar date floor)

### DIFF
--- a/gitops/tools/apps/stock-bot/kustomization.yaml
+++ b/gitops/tools/apps/stock-bot/kustomization.yaml
@@ -37,7 +37,7 @@ resources:
 images:
   - name: stock-bot
     newName: zot.phillips-homelab.net/stock-bot
-    newTag: "4200077"
+    newTag: "ad51dca"
   - name: stock-bot-dash
     newName: zot.phillips-homelab.net/stock-bot-dash
     newTag: "4200077"


### PR DESCRIPTION
Bumps the scout image to the build carrying the EDGAR 90-day ingest floor (stock-bot PR #20). Dashboard image unchanged.

⚠️ **Merge ordering:** publish the `ad51dca` image to Zot **first**, then merge — otherwise the migrate PreSync hook + cronjobs will ImagePullBackOff.

Publish: `make dagger-publish STOCK_BOT_TAG=ad51dca` (needs ZOT_PASSWORD).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated stock-bot service with a new container image version for deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->