### PR TITLE
agent-sandbox: enable gVisor isolation (extension now live on homelab-04)

### DIFF
--- a/gitops/tools/apps/agent-sandbox/README.md
+++ b/gitops/tools/apps/agent-sandbox/README.md
@@ -27,13 +27,16 @@ runtimes). Pinned to **v0.5.0** (first release with `v1beta1` APIs).
    (drop the Deployment from manifest.yaml; keep the header comments).
 3. `kubectl kustomize gitops/tools/apps/agent-sandbox | kubectl apply --dry-run=server -f -`
 
-## gVisor isolation (pending)
+## gVisor isolation
 
-`cluster/talos/omni/phillips-homelab/template.yaml` stages `siderolabs/gvisor`
-on the gpu Workers block. It takes effect on the next
-`omnictl cluster template sync` **which reboots homelab-04** (Jellyfin /
-Open WebUI blip). After that, uncomment `runtimeClassName: gvisor` in
-`python-sandbox-template.yaml`. Until then sandboxes run under plain runc.
+The `siderolabs/gvisor` system extension is installed on homelab-04 (via the
+gpu Workers block in `cluster/talos/omni/phillips-homelab/template.yaml`;
+extension changes there apply via `omnictl cluster template sync`, which
+reboots the node). The `python` SandboxTemplate runs sandboxes under the
+`gvisor` RuntimeClass. To verify a pod is actually sandboxed, `uname -r`
+inside it reports gVisor's emulated kernel, not the Talos host kernel.
+Keep GPU workloads on the `nvidia` RuntimeClass — gvisor and nvidia coexist
+on the node but a single pod can't use both.
 
 ## Smoke test
 

--- a/gitops/tools/apps/agent-sandbox/gvisor-runtimeclass.yaml
+++ b/gitops/tools/apps/agent-sandbox/gvisor-runtimeclass.yaml
@@ -1,7 +1,5 @@
-# Usable once the siderolabs/gvisor system extension is installed on homelab-04
+# Backed by the siderolabs/gvisor system extension on homelab-04
 # (see cluster/talos/omni/phillips-homelab/template.yaml, gpu Workers block).
-# Until then this object is inert; pods referencing it fail to schedule with
-# "handler runsc not found".
 apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:

--- a/gitops/tools/apps/agent-sandbox/python-sandbox-template.yaml
+++ b/gitops/tools/apps/agent-sandbox/python-sandbox-template.yaml
@@ -10,8 +10,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: homelab-04
-      # Flip on after the gVisor extension lands on homelab-04:
-      # runtimeClassName: gvisor
+      runtimeClassName: gvisor
       containers:
       - name: python-runtime
         # Upstream's example runtime image; no release-tagged build exists yet


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The agent sandbox is now configured to run Python sandboxes with gVisor by default on the supported node.
  * Updated guidance reflects that gVisor and NVIDIA can coexist on the same node, with the usual single-runtime limitation per pod.

* **Documentation**
  * Clarified setup and verification steps for sandbox isolation.
  * Updated runtime notes so the docs match the current working configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->