### PR TITLE
talos: enable user namespaces on gpu worker for gVisor

### DIFF
--- a/cluster/talos/omni/phillips-homelab/patches/gvisor-userns.yml
+++ b/cluster/talos/omni/phillips-homelab/patches/gvisor-userns.yml
@@ -1,0 +1,7 @@
+# gVisor's runsc gofer clones into fresh user namespaces; Talos disables
+# them by default (user.max_user_namespaces=0), which surfaces as the
+# misleading "fork/exec /proc/self/exe: no space left on device".
+# Value per Talos user-namespace docs. Scoped to the gpu worker only.
+machine:
+  sysctls:
+    user.max_user_namespaces: "11255"

--- a/cluster/talos/omni/phillips-homelab/template.yaml
+++ b/cluster/talos/omni/phillips-homelab/template.yaml
@@ -77,6 +77,8 @@ patches:
           disk: /dev/nvme0n1
   - name: nvidia-modules
     file: patches/nvidia-modules.yml
+  - name: gvisor-userns
+    file: patches/gvisor-userns.yml
 systemExtensions:
   - siderolabs/amd-ucode
   # runsc runtime for agent-sandbox isolation (gvisor RuntimeClass);


### PR DESCRIPTION
Talos defaults user.max_user_namespaces=0; runsc's gofer needs userns
and fails with a misleading ENOSPC. Applied via omnictl (hot, no
reboot) and verified: sandbox pod under gvisor RuntimeClass reports
the Sentry kernel.
