### PR TITLE
loops: phase-1 foundations for the agent loop rig

### DIFF
--- a/cluster/talos/omni/phillips-homelab/patches/local-path-mounts.yml
+++ b/cluster/talos/omni/phillips-homelab/patches/local-path-mounts.yml
@@ -1,0 +1,13 @@
+# Bind-mounts the local-path-provisioner data dir into the kubelet's mount
+# namespace so nvme-scratch PVCs (loop /workspace scratch) work on this node.
+# Kubelet config change: applies with a kubelet restart, no reboot.
+machine:
+  kubelet:
+    extraMounts:
+      - destination: /var/local-path-provisioner
+        type: bind
+        source: /var/local-path-provisioner
+        options:
+          - bind
+          - rshared
+          - rw

--- a/cluster/talos/omni/phillips-homelab/template.yaml
+++ b/cluster/talos/omni/phillips-homelab/template.yaml
@@ -79,6 +79,8 @@ patches:
     file: patches/nvidia-modules.yml
   - name: gvisor-userns
     file: patches/gvisor-userns.yml
+  - name: local-path-mounts
+    file: patches/local-path-mounts.yml
 systemExtensions:
   - siderolabs/amd-ucode
   # runsc runtime for agent-sandbox isolation (gvisor RuntimeClass);

--- a/gitops/tools/apps/local-path.yml
+++ b/gitops/tools/apps/local-path.yml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: local-path
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: local-path-storage
+  project: default
+  source:
+    path: gitops/tools/apps/local-path
+    repoURL: https://github.com/AlverezYari/phillips-homelab.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/gitops/tools/apps/local-path/configmap.yaml
+++ b/gitops/tools/apps/local-path/configmap.yaml
@@ -1,0 +1,41 @@
+# nodePathMap lists ONLY homelab-04 (no DEFAULT_PATH_FOR_NON_LISTED_NODES):
+# nvme-scratch PVCs can bind nowhere else, by design. The backing path is a
+# Talos kubelet extraMount (cluster/talos/.../patches/local-path-mounts.yml).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-path-config
+  namespace: local-path-storage
+data:
+  config.json: |-
+    {
+      "nodePathMap": [
+        {
+          "node": "homelab-04",
+          "paths": ["/var/local-path-provisioner"]
+        }
+      ]
+    }
+  setup: |-
+    #!/bin/sh
+    set -eu
+    mkdir -m 0777 -p "$VOL_DIR"
+  teardown: |-
+    #!/bin/sh
+    set -eu
+    rm -rf "$VOL_DIR"
+  helperPod.yaml: |-
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: helper-pod
+    spec:
+      priorityClassName: system-node-critical
+      tolerations:
+        - key: node.kubernetes.io/disk-pressure
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: helper-pod
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent

--- a/gitops/tools/apps/local-path/deployment.yaml
+++ b/gitops/tools/apps/local-path/deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: local-path-provisioner
+  namespace: local-path-storage
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: local-path-provisioner
+  template:
+    metadata:
+      labels:
+        app: local-path-provisioner
+    spec:
+      serviceAccountName: local-path-provisioner
+      nodeSelector:
+        kubernetes.io/hostname: homelab-04
+      containers:
+      - name: local-path-provisioner
+        image: rancher/local-path-provisioner:v0.0.36
+        imagePullPolicy: IfNotPresent
+        command:
+        - local-path-provisioner
+        - --debug
+        - start
+        - --config
+        - /etc/config/config.json
+        - --service-account-name
+        - local-path-provisioner
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/config/
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        resources:
+          requests:
+            cpu: 25m
+            memory: 64Mi
+      volumes:
+      - name: config-volume
+        configMap:
+          name: local-path-config

--- a/gitops/tools/apps/local-path/kustomization.yaml
+++ b/gitops/tools/apps/local-path/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml
+- rbac.yaml
+- configmap.yaml
+- deployment.yaml
+- storageclass.yaml

--- a/gitops/tools/apps/local-path/namespace.yaml
+++ b/gitops/tools/apps/local-path/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: local-path-storage

--- a/gitops/tools/apps/local-path/rbac.yaml
+++ b/gitops/tools/apps/local-path/rbac.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-path-provisioner
+  namespace: local-path-storage
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-path-provisioner
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "persistentvolumeclaims", "configmaps", "pods", "pods/log"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["persistentvolumes"]
+  verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-path-provisioner
+subjects:
+- kind: ServiceAccount
+  name: local-path-provisioner
+  namespace: local-path-storage
+roleRef:
+  kind: ClusterRole
+  name: local-path-provisioner
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: local-path-provisioner-helper
+  namespace: local-path-storage
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["create", "delete", "get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: local-path-provisioner-helper
+  namespace: local-path-storage
+subjects:
+- kind: ServiceAccount
+  name: local-path-provisioner
+  namespace: local-path-storage
+roleRef:
+  kind: Role
+  name: local-path-provisioner-helper
+  apiGroup: rbac.authorization.k8s.io

--- a/gitops/tools/apps/local-path/storageclass.yaml
+++ b/gitops/tools/apps/local-path/storageclass.yaml
@@ -1,0 +1,9 @@
+# Fast scratch on homelab-04's NVMe. Not precious: reclaimPolicy Delete,
+# loop durability comes from git push-per-iteration, not the PVC.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: nvme-scratch
+provisioner: rancher.io/local-path
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete

--- a/gitops/tools/apps/loops.yml
+++ b/gitops/tools/apps/loops.yml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: loops
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: loops
+  project: default
+  source:
+    path: gitops/tools/apps/loops
+    repoURL: https://github.com/AlverezYari/phillips-homelab.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/gitops/tools/apps/loops/kustomization.yaml
+++ b/gitops/tools/apps/loops/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml
+- quota.yaml
+- rbac.yaml
+- loop-secrets.yaml
+- netpol.yaml

--- a/gitops/tools/apps/loops/loop-secrets.yaml
+++ b/gitops/tools/apps/loops/loop-secrets.yaml
@@ -1,0 +1,31 @@
+# Expects a "loop-rig" item in the 1Password phillips-homelab vault with
+# fields: anthropic-api-key (dedicated, cappable), forgejo-token (loop-bot,
+# scoped), nats-password. Will show SecretSyncedError until seeded.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: loop-secrets
+  namespace: loops
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=false
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: staging
+  target:
+    name: loop-secrets
+    creationPolicy: Owner
+  data:
+  - secretKey: ANTHROPIC_API_KEY
+    remoteRef:
+      key: loop-rig
+      property: anthropic-api-key
+  - secretKey: FORGEJO_TOKEN
+    remoteRef:
+      key: loop-rig
+      property: forgejo-token
+  - secretKey: NATS_PASSWORD
+    remoteRef:
+      key: loop-rig
+      property: nats-password

--- a/gitops/tools/apps/loops/namespace.yaml
+++ b/gitops/tools/apps/loops/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: loops

--- a/gitops/tools/apps/loops/netpol.yaml
+++ b/gitops/tools/apps/loops/netpol.yaml
@@ -1,0 +1,59 @@
+# Additive holes through the agent-sandbox default policy (which blocks all
+# RFC1918 but allows public internet). Union semantics: sandbox pods get
+# world + these cluster services; non-sandbox pods in loops (nats, bridge)
+# get default-deny egress except these rules.
+# Known deviation from the brief: public egress can't be narrowed to
+# api.anthropic.com while the controller's per-template policy allows all
+# world traffic — revisit when upstream makes it customizable.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: loops-egress
+  namespace: loops
+spec:
+  endpointSelector: {}
+  egress:
+  # cluster DNS (sandbox pods run dnsPolicy None by default; loop pods set
+  # ClusterFirst — verified empirically in Phase 4)
+  - toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s-app: kube-dns
+    toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
+  # Forgejo HTTP (git clone/push over http with token, API)
+  - toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: forgejo
+        app.kubernetes.io/name: forgejo
+    toPorts:
+    - ports:
+      - port: "3000"
+        protocol: TCP
+  # NATS (loop event bus)
+  - toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: loops
+        app.kubernetes.io/name: nats
+    toPorts:
+    - ports:
+      - port: "4222"
+        protocol: TCP
+  # ntfy (bridge -> phone notifications, existing stock-bot instance)
+  - toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: stock-bot
+        app.kubernetes.io/name: ntfy
+    toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+  # public internet (mirrors the agent-sandbox default for the non-sandbox
+  # pods this CNP also selects; sandbox pods already have it via the
+  # controller's NetworkPolicy)
+  - toEntities:
+    - world

--- a/gitops/tools/apps/loops/quota.yaml
+++ b/gitops/tools/apps/loops/quota.yaml
@@ -1,0 +1,30 @@
+# Hard fleet backstop per the loop-rig brief: quota caps the namespace no
+# matter what the conductor does. ~8 concurrent loops at the LimitRange
+# defaults, with headroom for NATS + the bridge.
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: loops-quota
+  namespace: loops
+spec:
+  hard:
+    requests.cpu: "24"
+    requests.memory: 48Gi
+    limits.cpu: "32"
+    limits.memory: 56Gi
+    persistentvolumeclaims: "16"
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: loops-defaults
+  namespace: loops
+spec:
+  limits:
+  - type: Container
+    defaultRequest:
+      cpu: 500m
+      memory: 1Gi
+    default:
+      cpu: "2"
+      memory: 4Gi

--- a/gitops/tools/apps/loops/rbac.yaml
+++ b/gitops/tools/apps/loops/rbac.yaml
@@ -1,0 +1,34 @@
+# SA mounted by loop sandbox pods; the harness patches the
+# loop.phillips.dev/state label on its own Sandbox CR. Nothing else.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: loop-runner
+  namespace: loops
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: loop-runner
+  namespace: loops
+rules:
+- apiGroups: ["agents.x-k8s.io"]
+  resources: ["sandboxes"]
+  verbs: ["get", "list", "watch", "patch"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: loop-runner
+  namespace: loops
+subjects:
+- kind: ServiceAccount
+  name: loop-runner
+  namespace: loops
+roleRef:
+  kind: Role
+  name: loop-runner
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
- loops namespace with ResourceQuota (fleet backstop ~8 loops) + LimitRange
- loop-runner SA scoped to patching own Sandbox labels
- loop-secrets ExternalSecret (1Password loop-rig item, to be seeded)
- CiliumNetworkPolicy: DNS/Forgejo/NATS/ntfy holes through the
  agent-sandbox default policy
- local-path-provisioner v0.0.36 + nvme-scratch StorageClass, provisioning
  only on homelab-04; Talos kubelet extraMounts patch (gpu Workers block)
