### PR TITLE
loops: phase-2 NATS + ntfy bridge; netpol + PSA fixes; dev image source

### DIFF
--- a/gitops/tools/apps/local-path/namespace.yaml
+++ b/gitops/tools/apps/local-path/namespace.yaml
@@ -1,4 +1,8 @@
+# privileged PSA: the provisioner's helper pods mount hostPath (the whole
+# point) and Talos enforces baseline cluster-wide by default.
 apiVersion: v1
 kind: Namespace
 metadata:
   name: local-path-storage
+  labels:
+    pod-security.kubernetes.io/enforce: privileged

--- a/gitops/tools/apps/loops/kustomization.yaml
+++ b/gitops/tools/apps/loops/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 - rbac.yaml
 - loop-secrets.yaml
 - netpol.yaml
+- nats-ntfy-bridge.yaml

--- a/gitops/tools/apps/loops/nats-ntfy-bridge.yaml
+++ b/gitops/tools/apps/loops/nats-ntfy-bridge.yaml
@@ -1,0 +1,83 @@
+# Relays loop events from NATS to the existing ntfy instance (stock-bot ns,
+# already routed to Casey's phone via ntfy.tail852f61.ts.net). One container
+# per subject so a dead subscription restarts independently.
+# Convention: harness publishes single-line JSON payloads.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nats-ntfy-bridge
+  namespace: loops
+data:
+  bridge.sh: |
+    #!/bin/sh
+    set -eu
+    SUBJECT="$1"; TITLE="$2"; PRIORITY="${3:-default}"
+    NATS_URL="nats://loop:${NATS_PASSWORD}@nats.loops.svc.cluster.local:4222"
+    echo "bridge: subscribing to ${SUBJECT}"
+    nats --server "$NATS_URL" sub "$SUBJECT" --raw | while IFS= read -r line; do
+      [ -z "$line" ] && continue
+      echo "bridge: relaying ${SUBJECT}: ${line}"
+      curl -s -m 10 -H "Title: ${TITLE}" -H "Priority: ${PRIORITY}" \
+        -d "${line}" "http://ntfy.stock-bot.svc.cluster.local/loops" || true
+    done
+    echo "bridge: subscription ${SUBJECT} ended" >&2
+    exit 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nats-ntfy-bridge
+  namespace: loops
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nats-ntfy-bridge
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nats-ntfy-bridge
+    spec:
+      containers:
+      - name: decisions
+        image: natsio/nats-box:0.18.0
+        command: ["/bin/sh", "/opt/bridge/bridge.sh", "loops.*.decisions", "Loop decision needed", "high"]
+        env:
+        - name: NATS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: loop-secrets
+              key: NATS_PASSWORD
+        volumeMounts:
+        - name: bridge
+          mountPath: /opt/bridge
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
+      - name: done
+        image: natsio/nats-box:0.18.0
+        command: ["/bin/sh", "/opt/bridge/bridge.sh", "loops.*.done", "Loop finished", "default"]
+        env:
+        - name: NATS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: loop-secrets
+              key: NATS_PASSWORD
+        volumeMounts:
+        - name: bridge
+          mountPath: /opt/bridge
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
+      volumes:
+      - name: bridge
+        configMap:
+          name: nats-ntfy-bridge

--- a/gitops/tools/apps/loops/netpol.yaml
+++ b/gitops/tools/apps/loops/netpol.yaml
@@ -52,6 +52,10 @@ spec:
     - ports:
       - port: "80"
         protocol: TCP
+  # kube-apiserver: the harness patches loop.phillips.dev/state on its own
+  # Sandbox CR (scoped by the loop-runner Role)
+  - toEntities:
+    - kube-apiserver
   # public internet (mirrors the agent-sandbox default for the non-sandbox
   # pods this CNP also selects; sandbox pods already have it via the
   # controller's NetworkPolicy)

--- a/gitops/tools/apps/nats.yml
+++ b/gitops/tools/apps/nats.yml
@@ -1,0 +1,63 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nats
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: loops
+  project: default
+  source:
+    chart: nats
+    repoURL: https://nats-io.github.io/k8s/helm/charts/
+    targetRevision: 1.3.16
+    helm:
+      values: |
+        config:
+          jetstream:
+            enabled: true
+            fileStore:
+              pvc:
+                enabled: true
+                size: 5Gi
+                storageClassName: nvme-scratch
+          merge:
+            authorization:
+              users:
+                - user: loop
+                  password: << $NATS_PASSWORD >>
+        container:
+          env:
+            NATS_PASSWORD:
+              valueFrom:
+                secretKeyRef:
+                  name: loop-secrets
+                  key: NATS_PASSWORD
+          merge:
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+        podTemplate:
+          merge:
+            spec:
+              nodeSelector:
+                kubernetes.io/hostname: homelab-04
+        natsBox:
+          enabled: true
+          container:
+            env:
+              NATS_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: loop-secrets
+                    key: NATS_PASSWORD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/loops/images/dev/Dockerfile
+++ b/loops/images/dev/Dockerfile
@@ -1,0 +1,36 @@
+# Loop dev image: Go toolchain + claude CLI + nats CLI + kubectl + harness.
+# Build (house pattern, from repo root):
+#   kubectl -n buildkit port-forward svc/buildkit 1234:1234 &
+#   buildctl --addr tcp://127.0.0.1:1234 build \
+#     --frontend dockerfile.v0 \
+#     --local context=loops/images/dev --local dockerfile=loops/images/dev \
+#     --output type=image,name=zot.phillips-homelab.net/loop-dev:$(git rev-parse --short HEAD),push=true
+FROM golang:1.24-bookworm
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git make jq curl ca-certificates ripgrep \
+    && rm -rf /var/lib/apt/lists/*
+
+# claude CLI (native installer drops it in ~/.local/bin; promote to PATH)
+RUN curl -fsSL https://claude.ai/install.sh | bash && \
+    install -m 0755 /root/.local/bin/claude /usr/local/bin/claude && \
+    rm -rf /root/.local
+
+# nats CLI
+RUN NATS_CLI_VERSION=0.4.0 && \
+    curl -fsSL "https://github.com/nats-io/natscli/releases/download/v${NATS_CLI_VERSION}/nats-${NATS_CLI_VERSION}-linux-amd64.tar.gz" \
+      | tar -xz -C /tmp && \
+    install -m 0755 /tmp/nats-*/nats /usr/local/bin/nats && rm -rf /tmp/nats-*
+
+# kubectl (only used to patch the loop's own Sandbox state label)
+RUN KUBECTL_VERSION="$(curl -fsSL https://dl.k8s.io/release/stable.txt)" && \
+    curl -fsSL -o /usr/local/bin/kubectl \
+      "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
+    chmod 0755 /usr/local/bin/kubectl
+
+RUN useradd -m -u 1000 -s /bin/bash loop && mkdir -p /workspace && chown loop:loop /workspace
+COPY --chmod=0755 harness.sh /usr/local/bin/harness.sh
+USER loop
+ENV HOME=/home/loop
+WORKDIR /workspace
+ENTRYPOINT ["/usr/local/bin/harness.sh"]

--- a/loops/images/dev/harness.sh
+++ b/loops/images/dev/harness.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Loop harness: the authoritative layer for loop mechanics.
+# The agent proposes, the harness disposes: validation gates and git push
+# live here, where the agent cannot rationalize around them.
+#
+# Contract (from the loop-rig brief):
+#   - stateless `claude -p` per iteration
+#   - harness-owned gate (GATE_CMD, default "make build test lint")
+#   - commit+push on green only; MAX_ITER budget
+#   - decisions: agent writes /workspace/decisions/NNN-slug.json, harness
+#     relays to NATS; answers drain from loops.<name>.inbox to /workspace/.inbox
+#   - done: all boxes checked + gate green -> agent writes /workspace/.loop-done
+#   - exit codes: 0 done, 2 blocked-needs-human, 3 budget exhausted
+#   - state label loop.phillips.dev/state on own Sandbox CR
+set -uo pipefail
+
+: "${LOOP_NAME:?LOOP_NAME required (sandbox name)}"
+: "${REPO_URL:?REPO_URL required (Forgejo clone URL, no creds)}"
+: "${ANTHROPIC_API_KEY:?ANTHROPIC_API_KEY required}"
+: "${FORGEJO_TOKEN:?FORGEJO_TOKEN required}"
+BRANCH="${BRANCH:-loop/${LOOP_NAME}}"
+MAX_ITER="${MAX_ITER:-30}"
+GATE_CMD="${GATE_CMD:-make build test lint}"
+NATS_SERVER="${NATS_SERVER:-nats.loops.svc.cluster.local:4222}"
+NATS_URL="nats://loop:${NATS_PASSWORD:-}@${NATS_SERVER}"
+WS=/workspace
+REPO_DIR="$WS/repo"
+MEMORY_URL="${MEMORY_URL:-}"   # optional read-only memory repo
+
+log()  { echo "[harness $(date -u +%H:%M:%S)] $*"; }
+term() { echo "$*" > /dev/termination-log 2>/dev/null || true; }
+
+npub() { # npub <subject-suffix> <json> — best-effort, never fatal
+  nats --server "$NATS_URL" pub "loops.${LOOP_NAME}.$1" "$2" >/dev/null 2>&1 \
+    || log "WARN nats pub $1 failed"
+}
+
+set_state() { # running|blocked|done — best-effort
+  kubectl -n loops patch sandbox "$LOOP_NAME" --type=merge \
+    -p "{\"metadata\":{\"labels\":{\"loop.phillips.dev/state\":\"$1\"}}}" \
+    >/dev/null 2>&1 || log "WARN state label patch failed ($1)"
+}
+
+drain_inbox() { # answers published to loops.<name>.inbox land in .inbox/
+  mkdir -p "$WS/.inbox"
+  local n=0
+  while msg=$(nats --server "$NATS_URL" sub "loops.${LOOP_NAME}.inbox" \
+      --raw --count 1 --timeout 2s 2>/dev/null) && [ -n "$msg" ]; do
+    n=$((n+1))
+    echo "$msg" > "$WS/.inbox/$(date -u +%s)-$n.json"
+  done
+  [ "$n" -gt 0 ] && log "drained $n inbox message(s)"
+}
+
+relay_decisions() { # new decision files -> NATS (file-then-relay per brief)
+  mkdir -p "$WS/decisions/.sent"
+  local f
+  for f in "$WS"/decisions/*.json; do
+    [ -e "$f" ] || continue
+    if jq -e . "$f" >/dev/null 2>&1; then
+      npub decisions "$(jq -c --arg loop "$LOOP_NAME" '. + {loop: $loop}' "$f")"
+      mv "$f" "$WS/decisions/.sent/"
+      log "relayed decision $(basename "$f")"
+    else
+      log "WARN malformed decision file $(basename "$f"), leaving in place"
+    fi
+  done
+}
+
+# ---- bootstrap -------------------------------------------------------------
+log "loop ${LOOP_NAME} starting; waiting for SPEC.md"
+for _ in $(seq 1 360); do [ -f "$WS/SPEC.md" ] && break; sleep 5; done
+if [ ! -f "$WS/SPEC.md" ]; then
+  term "no SPEC.md after 30m"; set_state blocked; exit 2
+fi
+
+git config --global credential.helper store
+FORGEJO_HOST=$(echo "$REPO_URL" | sed -E 's#^https?://([^/]+)/.*#\1#')
+echo "https://loop-bot:${FORGEJO_TOKEN}@${FORGEJO_HOST}" > ~/.git-credentials
+git config --global user.name "loop-bot"
+git config --global user.email "loop-bot@phillips-homelab.net"
+
+if [ ! -d "$REPO_DIR/.git" ]; then
+  git clone "$REPO_URL" "$REPO_DIR" || { term "clone failed"; set_state blocked; exit 2; }
+  git -C "$REPO_DIR" checkout -B "$BRANCH"
+fi
+if [ -n "$MEMORY_URL" ] && [ ! -d "$WS/memory/.git" ]; then
+  git clone --depth 1 "$MEMORY_URL" "$WS/memory" || log "WARN memory clone failed"
+fi
+[ -f "$WS/PROGRESS.md" ] || printf '# PROGRESS\n\n(harness: no iterations yet)\n' > "$WS/PROGRESS.md"
+
+PROMPT='You are one iteration of an autonomous coding loop. Read /workspace/SPEC.md (the task, checkboxes, guardrails) and /workspace/PROGRESS.md (state so far), and check /workspace/.inbox/ for operator answers to earlier decisions. Then do exactly ONE thing: the next unchecked SPEC item. Work in /workspace/repo. Follow SPEC guardrails strictly. If an item is blocked after 3 distinct attempts (see PROGRESS), write a decision file to /workspace/decisions/NNN-slug.json (fields: question, context, options[2-3], recommendation, risk) and move to the next item. Update PROGRESS.md: what you did, gate expectations, what is next, any BLOCKED items. If ALL items are done, create /workspace/.loop-done containing a one-paragraph summary. If ALL remaining items are BLOCKED, create /workspace/.loop-blocked with a summary. Never write secrets to logs or files. Do not run git push (the harness pushes). Consult /workspace/memory/ (gotchas, conventions) if present.'
+
+# ---- iteration loop --------------------------------------------------------
+set_state running
+iter=0
+while [ "$iter" -lt "$MAX_ITER" ]; do
+  iter=$((iter+1))
+  log "=== iteration ${iter}/${MAX_ITER} ==="
+  drain_inbox
+
+  claude -p "$PROMPT" \
+    --dangerously-skip-permissions \
+    --add-dir "$WS" \
+    > "$WS/.iter-${iter}.log" 2>&1
+  agent_rc=$?
+  log "agent exited rc=${agent_rc} ($(wc -l < "$WS/.iter-${iter}.log") log lines)"
+
+  relay_decisions
+
+  gate_result=red
+  if (cd "$REPO_DIR" && eval "$GATE_CMD") > "$WS/.gate-${iter}.log" 2>&1; then
+    gate_result=green
+    if ! git -C "$REPO_DIR" diff --quiet || ! git -C "$REPO_DIR" diff --cached --quiet \
+       || [ -n "$(git -C "$REPO_DIR" status --porcelain)" ]; then
+      git -C "$REPO_DIR" add -A
+      git -C "$REPO_DIR" commit -m "loop(${LOOP_NAME}): iteration ${iter}" >/dev/null
+    fi
+    git -C "$REPO_DIR" push -u origin "$BRANCH" >/dev/null 2>&1 || log "WARN push failed"
+  else
+    log "gate RED (tail): $(tail -3 "$WS/.gate-${iter}.log" | tr '\n' ' ')"
+    printf '\n> harness: iteration %s gate FAILED:\n```\n%s\n```\n' \
+      "$iter" "$(tail -20 "$WS/.gate-${iter}.log")" >> "$WS/PROGRESS.md"
+  fi
+
+  npub events "{\"iter\":${iter},\"gate\":\"${gate_result}\",\"agent_rc\":${agent_rc},\"ts\":\"$(date -u +%FT%TZ)\"}"
+
+  if [ -f "$WS/.loop-done" ]; then
+    if [ "$gate_result" = green ]; then
+      log "done sentinel + green gate: finishing"
+      npub done "{\"iter\":${iter},\"summary\":$(jq -Rs . < "$WS/.loop-done")}"
+      set_state done; term "done in ${iter} iterations"; exit 0
+    fi
+    log "done sentinel but gate RED: removing sentinel, continuing"
+    rm -f "$WS/.loop-done"
+    printf '\n> harness: .loop-done rejected, gate is red.\n' >> "$WS/PROGRESS.md"
+  fi
+  if [ -f "$WS/.loop-blocked" ]; then
+    npub done "{\"iter\":${iter},\"blocked\":true,\"summary\":$(jq -Rs . < "$WS/.loop-blocked")}"
+    set_state blocked; term "blocked after ${iter} iterations"; exit 2
+  fi
+done
+
+npub done "{\"iter\":${iter},\"exhausted\":true}"
+set_state blocked
+term "budget exhausted (${MAX_ITER} iterations)"
+exit 3


### PR DESCRIPTION
- nats app (chart 1.3.16): single replica on homelab-04, JetStream on
  nvme-scratch, loop user auth from ESO secret
- nats-ntfy-bridge: relays loops.*.decisions / loops.*.done to the
  existing stock-bot ntfy (phone)
- netpol: add kube-apiserver entity egress (harness patches its own
  Sandbox state label; verified blocked without it)
- local-path namespace: privileged PSA label (helper pods need hostPath,
  Talos enforces baseline) — found via failed PVC provisioning
- loops/images/dev: Dockerfile + harness.sh (loop mechanics per brief)
