### PR TITLE
loops: pivot to Claude Pro subscription auth (no API key)

### DIFF
--- a/gitops/tools/apps/loops/loop-secrets.yaml
+++ b/gitops/tools/apps/loops/loop-secrets.yaml
@@ -1,6 +1,7 @@
 # Expects a "loop-rig" item in the 1Password phillips-homelab vault with
-# fields: anthropic-api-key (dedicated, cappable), forgejo-token (loop-bot,
-# scoped), nats-password. Will show SecretSyncedError until seeded.
+# fields: claude-oauth-token (from `claude setup-token`, Pro subscription,
+# 1-year validity), forgejo-token (loop-bot, scoped), nats-password.
+# Will show SecretSyncedError until seeded.
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -17,10 +18,10 @@ spec:
     name: loop-secrets
     creationPolicy: Owner
   data:
-  - secretKey: ANTHROPIC_API_KEY
+  - secretKey: CLAUDE_CODE_OAUTH_TOKEN
     remoteRef:
       key: loop-rig
-      property: anthropic-api-key
+      property: claude-oauth-token
   - secretKey: FORGEJO_TOKEN
     remoteRef:
       key: loop-rig

--- a/loops/images/dev/Dockerfile
+++ b/loops/images/dev/Dockerfile
@@ -8,7 +8,7 @@
 FROM golang:1.24-bookworm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      git make jq curl ca-certificates ripgrep \
+      git make jq curl ca-certificates ripgrep unzip \
     && rm -rf /var/lib/apt/lists/*
 
 # claude CLI (native installer drops it in ~/.local/bin; promote to PATH)
@@ -16,11 +16,11 @@ RUN curl -fsSL https://claude.ai/install.sh | bash && \
     install -m 0755 /root/.local/bin/claude /usr/local/bin/claude && \
     rm -rf /root/.local
 
-# nats CLI
+# nats CLI (releases ship zips)
 RUN NATS_CLI_VERSION=0.4.0 && \
-    curl -fsSL "https://github.com/nats-io/natscli/releases/download/v${NATS_CLI_VERSION}/nats-${NATS_CLI_VERSION}-linux-amd64.tar.gz" \
-      | tar -xz -C /tmp && \
-    install -m 0755 /tmp/nats-*/nats /usr/local/bin/nats && rm -rf /tmp/nats-*
+    curl -fsSL -o /tmp/nats.zip "https://github.com/nats-io/natscli/releases/download/v${NATS_CLI_VERSION}/nats-${NATS_CLI_VERSION}-linux-amd64.zip" && \
+    unzip -q /tmp/nats.zip -d /tmp/natscli && \
+    install -m 0755 /tmp/natscli/nats-*/nats /usr/local/bin/nats && rm -rf /tmp/nats.zip /tmp/natscli
 
 # kubectl (only used to patch the loop's own Sandbox state label)
 RUN KUBECTL_VERSION="$(curl -fsSL https://dl.k8s.io/release/stable.txt)" && \

--- a/loops/images/dev/harness.sh
+++ b/loops/images/dev/harness.sh
@@ -16,8 +16,11 @@ set -uo pipefail
 
 : "${LOOP_NAME:?LOOP_NAME required (sandbox name)}"
 : "${REPO_URL:?REPO_URL required (Forgejo clone URL, no creds)}"
-: "${ANTHROPIC_API_KEY:?ANTHROPIC_API_KEY required}"
+: "${CLAUDE_CODE_OAUTH_TOKEN:?CLAUDE_CODE_OAUTH_TOKEN required (claude setup-token)}"
 : "${FORGEJO_TOKEN:?FORGEJO_TOKEN required}"
+# Pro-subscription auth: an API key would take precedence over the OAuth
+# token and break auth if both are set.
+unset ANTHROPIC_API_KEY
 BRANCH="${BRANCH:-loop/${LOOP_NAME}}"
 MAX_ITER="${MAX_ITER:-30}"
 GATE_CMD="${GATE_CMD:-make build test lint}"
@@ -105,6 +108,21 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
     > "$WS/.iter-${iter}.log" 2>&1
   agent_rc=$?
   log "agent exited rc=${agent_rc} ($(wc -l < "$WS/.iter-${iter}.log") log lines)"
+
+  # Pro-plan rate limiting: iterations draw from the shared 5h prompt window.
+  # Back off without burning budget; give up after too many in a row.
+  if [ "$agent_rc" -ne 0 ] && grep -qiE 'rate.?limit|usage limit|limit (reached|exceeded)' "$WS/.iter-${iter}.log"; then
+    rl_count=$(( ${rl_count:-0} + 1 ))
+    if [ "$rl_count" -ge "${RATE_LIMIT_MAX_BACKOFFS:-8}" ]; then
+      npub done "{\"iter\":${iter},\"exhausted\":true,\"reason\":\"rate-limited\"}"
+      set_state blocked; term "persistent rate limiting"; exit 3
+    fi
+    iter=$((iter-1))
+    log "rate limited (${rl_count}); sleeping ${RATE_LIMIT_BACKOFF:-900}s, iteration not counted"
+    sleep "${RATE_LIMIT_BACKOFF:-900}"
+    continue
+  fi
+  rl_count=0
 
   relay_decisions
 


### PR DESCRIPTION
CLAUDE_CODE_OAUTH_TOKEN (via `claude setup-token`, 1yr) replaces
ANTHROPIC_API_KEY end to end; harness unsets any API key (precedence
would break OAuth auth) and backs off on rate limits without burning
iteration budget (Pro shares a ~45-prompt/5h window with interactive
use). Also fixes the natscli download in the Dockerfile (releases ship
zips, not tarballs).
