### PR TITLE
loops: fix ntfy egress port (Cilium matches pod port 8080, not svc port 80)

### DIFF
--- a/gitops/tools/apps/loops/nats-ntfy-bridge.yaml
+++ b/gitops/tools/apps/loops/nats-ntfy-bridge.yaml
@@ -17,8 +17,10 @@ data:
     nats --server "$NATS_URL" sub "$SUBJECT" --raw | while IFS= read -r line; do
       [ -z "$line" ] && continue
       echo "bridge: relaying ${SUBJECT}: ${line}"
-      curl -s -m 10 -H "Title: ${TITLE}" -H "Priority: ${PRIORITY}" \
-        -d "${line}" "http://ntfy.stock-bot.svc.cluster.local/loops" || true
+      status=$(curl -s -o /dev/null -w '%{http_code}' -m 10 \
+        -H "Title: ${TITLE}" -H "Priority: ${PRIORITY}" \
+        -d "${line}" "http://ntfy.stock-bot.svc.cluster.local/loops" || echo curl-fail)
+      [ "$status" = "200" ] || echo "bridge: ntfy POST FAILED status=${status}"
     done
     echo "bridge: subscription ${SUBJECT} ended" >&2
     exit 1

--- a/gitops/tools/apps/loops/netpol.yaml
+++ b/gitops/tools/apps/loops/netpol.yaml
@@ -43,14 +43,16 @@ spec:
     - ports:
       - port: "4222"
         protocol: TCP
-  # ntfy (bridge -> phone notifications, existing stock-bot instance)
+  # ntfy (bridge -> phone notifications, existing stock-bot instance).
+  # Cilium matches the POD port post-DNAT: the service is 80 but the
+  # container listens on 8080 (NTFY_LISTEN_HTTP).
   - toEndpoints:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: stock-bot
         app.kubernetes.io/name: ntfy
     toPorts:
     - ports:
-      - port: "80"
+      - port: "8080"
         protocol: TCP
   # kube-apiserver: the harness patches loop.phillips.dev/state on its own
   # Sandbox CR (scoped by the loop-runner Role)


### PR DESCRIPTION
Every bridge POST was silently dropped: the CNP allowed :80 but ntfy's
container listens on :8080 and Cilium evaluates policy post-DNAT. Also
make the bridge log non-200 POSTs instead of hiding them behind || true.
