### PR TITLE
monitoring: fix Loki datasource tenant header; fix loop-rig quota queries

### DIFF
--- a/gitops/core/grafana-dashboards/datasources.yaml
+++ b/gitops/core/grafana-dashboards/datasources.yaml
@@ -22,8 +22,13 @@ data:
         url: http://loki-gateway:80
         access: proxy
         editable: false
+        # Vector ships logs with tenant_id "1"; without the matching
+        # X-Scope-OrgID header every query returns "no org id".
         jsonData:
           maxLines: 1000
+          httpHeaderName1: X-Scope-OrgID
+        secureJsonData:
+          httpHeaderValue1: "1"
       - name: Tempo
         type: tempo
         uid: tempo

--- a/gitops/core/grafana-dashboards/loop-rig.yaml
+++ b/gitops/core/grafana-dashboards/loop-rig.yaml
@@ -34,7 +34,7 @@ data:
           "type": "stat", "title": "CPU quota used",
           "datasource": {"type": "prometheus", "uid": "prometheus"},
           "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
-          "targets": [{"expr": "100 * kube_resourcequota{namespace=\"loops\", resource=\"requests.cpu\", type=\"used\"} / kube_resourcequota{namespace=\"loops\", resource=\"requests.cpu\", type=\"hard\"}", "instant": true}],
+          "targets": [{"expr": "100 * max(kube_resourcequota{namespace=\"loops\", resource=\"requests.cpu\", type=\"used\"}) / max(kube_resourcequota{namespace=\"loops\", resource=\"requests.cpu\", type=\"hard\"})", "instant": true}],
           "fieldConfig": {"defaults": {"unit": "percent", "decimals": 0, "min": 0, "max": 100, "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 70}, {"color": "red", "value": 90}]}}},
           "options": {"colorMode": "value", "graphMode": "none", "reduceOptions": {"calcs": ["lastNotNull"]}}
         },
@@ -42,7 +42,7 @@ data:
           "type": "stat", "title": "Memory quota used",
           "datasource": {"type": "prometheus", "uid": "prometheus"},
           "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
-          "targets": [{"expr": "100 * kube_resourcequota{namespace=\"loops\", resource=\"requests.memory\", type=\"used\"} / kube_resourcequota{namespace=\"loops\", resource=\"requests.memory\", type=\"hard\"}", "instant": true}],
+          "targets": [{"expr": "100 * max(kube_resourcequota{namespace=\"loops\", resource=\"requests.memory\", type=\"used\"}) / max(kube_resourcequota{namespace=\"loops\", resource=\"requests.memory\", type=\"hard\"})", "instant": true}],
           "fieldConfig": {"defaults": {"unit": "percent", "decimals": 0, "min": 0, "max": 100, "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 70}, {"color": "red", "value": 90}]}}},
           "options": {"colorMode": "value", "graphMode": "none", "reduceOptions": {"calcs": ["lastNotNull"]}}
         },


### PR DESCRIPTION
Grafana's Loki datasource sent no X-Scope-OrgID while Vector writes
tenant "1" — every Loki query in Grafana returned "no org id" (verified
via loki-gateway). Also wrap the loop-rig quota used/hard division in
max() so PromQL vector matching doesn't reject the differing type label.
