### PR TITLE
tycho: namespace + tycho-config ExternalSecret

### DIFF
--- a/gitops/tools/apps/tycho.yml
+++ b/gitops/tools/apps/tycho.yml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tycho
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: tycho
+  project: default
+  source:
+    path: gitops/tools/apps/tycho
+    repoURL: https://github.com/AlverezYari/phillips-homelab.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/gitops/tools/apps/tycho/externalsecret.yaml
+++ b/gitops/tools/apps/tycho/externalsecret.yaml
@@ -1,0 +1,49 @@
+# Main config secret for the tycho operator, synced from 1Password via ESO.
+# Expects a "tycho" item in the vault backing the `staging` ClusterSecretStore
+# with fields: see_start_pem, s3_access_key_id, s3_secret_access_key (Garage),
+# source_auth_token.
+# One secret, many keys: add new fields to the 1P item and a matching data
+# entry here as the operator grows, rather than one ExternalSecret per value.
+# POSTGRES_DSN is NOT here: the gateway takes it from the CNPG-generated
+# tycho-pg-app secret per the usual <cluster>-app convention.
+# Will show SecretSyncedError until the 1P item is seeded.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: tycho-config
+  namespace: tycho
+  annotations:
+    # Client-side apply: SSA conflicts with ESO's field manager on spec.data
+    # and can wedge the sync (see stock-bot ExternalSecrets).
+    argocd.argoproj.io/sync-options: ServerSideApply=false
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: staging
+  target:
+    name: tycho-config
+    creationPolicy: Owner
+  data:
+  - secretKey: see_start_pem
+    remoteRef:
+      key: tycho
+      property: see_start_pem
+  - secretKey: S3_ACCESS_KEY_ID
+    remoteRef:
+      key: tycho
+      property: s3_access_key_id
+  - secretKey: S3_SECRET_ACCESS_KEY
+    remoteRef:
+      key: tycho
+      property: s3_secret_access_key
+  # SOURCE_AUTH_TOKEN (gateway) and IDENTITY_TOKEN (agent) must be equal, so
+  # both map to the single source_auth_token 1P field — they can't drift.
+  - secretKey: SOURCE_AUTH_TOKEN
+    remoteRef:
+      key: tycho
+      property: source_auth_token
+  - secretKey: IDENTITY_TOKEN
+    remoteRef:
+      key: tycho
+      property: source_auth_token

--- a/gitops/tools/apps/tycho/kustomization.yaml
+++ b/gitops/tools/apps/tycho/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml
+- externalsecret.yaml

--- a/gitops/tools/apps/tycho/namespace.yaml
+++ b/gitops/tools/apps/tycho/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tycho


### PR DESCRIPTION
## Summary
- New `tycho` namespace + Argo `Application` stub under `gitops/tools/apps/` (auto-discovered by `tool-apps`, `CreateNamespace=true`)
- `tycho-config` ExternalSecret (staging ClusterSecretStore → 1P item `tycho`), one main config secret we append keys to as the operator grows:
  - `see_start_pem`
  - `S3_ACCESS_KEY_ID` / `S3_SECRET_ACCESS_KEY` (Garage, for the gateway)
  - `SOURCE_AUTH_TOKEN` + `IDENTITY_TOKEN` — both mapped to the single `source_auth_token` 1P field so the gateway and agent tokens can't drift
- `POSTGRES_DSN` intentionally not in ESO: gateway takes it from the CNPG `tycho-pg-app` secret per convention
- `ServerSideApply=false` annotation on the ExternalSecret (ESO field-manager vs SSA wedge, same as stock-bot)

## Seeding
Create a 1P item named `tycho` in the vault behind the `staging` ClusterSecretStore with fields `see_start_pem`, `s3_access_key_id`, `s3_secret_access_key`, `source_auth_token`. ExternalSecret shows SecretSyncedError until then.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment configuration for the Tycho application through Argo CD.
  * Added automatic creation and management of the Tycho namespace.
  * Added secure configuration synchronization for Tycho, including storage, authentication, and gateway credentials.
  * Enabled automated synchronization, pruning, and self-healing for the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->