### PR TITLE
tycho: CNPG tycho-pg cluster

### DIFF
--- a/gitops/tools/apps/tycho-db.yml
+++ b/gitops/tools/apps/tycho-db.yml
@@ -1,0 +1,52 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tycho-db
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: tycho
+  project: default
+  ignoreDifferences:
+  - group: postgresql.cnpg.io
+    kind: Cluster
+    jsonPointers:
+    - /spec/affinity
+    - /spec/bootstrap/initdb/encoding
+    - /spec/bootstrap/initdb/localeCType
+    - /spec/bootstrap/initdb/localeCollate
+    - /spec/enablePDB
+    - /spec/enableSuperuserAccess
+    - /spec/failoverDelay
+    - /spec/imageName
+    - /spec/logLevel
+    - /spec/maxSyncReplicas
+    - /spec/minSyncReplicas
+    - /spec/monitoring
+    - /spec/postgresGID
+    - /spec/postgresUID
+    - /spec/postgresql
+    - /spec/primaryUpdateMethod
+    - /spec/primaryUpdateStrategy
+    - /spec/replicationSlots
+    - /spec/smartShutdownTimeout
+    - /spec/startDelay
+    - /spec/stopDelay
+    - /spec/switchoverDelay
+  source:
+    path: gitops/tools/apps/tycho-db
+    repoURL: https://github.com/AlverezYari/phillips-homelab.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - ServerSideDiff=true

--- a/gitops/tools/apps/tycho-db/cluster.yaml
+++ b/gitops/tools/apps/tycho-db/cluster.yaml
@@ -1,0 +1,23 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: tycho-pg
+  namespace: tycho
+spec:
+  instances: 1
+
+  storage:
+    storageClass: syno-iscsi-default
+    size: 10Gi
+
+  bootstrap:
+    initdb:
+      database: tycho
+      owner: tycho
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 512Mi

--- a/gitops/tools/apps/tycho-db/kustomization.yaml
+++ b/gitops/tools/apps/tycho-db/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml
+- cluster.yaml
+- vmpodscrape.yaml

--- a/gitops/tools/apps/tycho-db/namespace.yaml
+++ b/gitops/tools/apps/tycho-db/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tycho

--- a/gitops/tools/apps/tycho-db/vmpodscrape.yaml
+++ b/gitops/tools/apps/tycho-db/vmpodscrape.yaml
@@ -1,0 +1,13 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMPodScrape
+metadata:
+  name: tycho-pg
+  namespace: tycho
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: tycho-pg
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s


### PR DESCRIPTION
## Summary
- `tycho-db` Argo app (sync-wave 0, SSA + ServerSideDiff, same CNPG ignoreDifferences block as tipoff-db)
- `tycho-pg` Cluster in the `tycho` namespace: 1 instance, 10Gi on syno-iscsi-default, initdb database/owner `tycho`
- CNPG auto-creates the `tycho-pg-app` secret — the POSTGRES_DSN source for the tycho gateway per convention
- VMPodScrape for CNPG metrics, matching tipoff-pg

No Garage WAL archiving yet — follow the forgejo-db objectstore pattern later if tycho's data warrants backups (remember region=garage).