### PR TITLE
tychofleet: deploy site behind Cloudflare tunnel

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tychofleet
+  namespace: tychofleet
+  labels:
+    app: tychofleet
+spec:
+  replicas: 1
+  # Single SQLite writer — same constraint as light-the-ham.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: tychofleet
+  template:
+    metadata:
+      labels:
+        app: tychofleet
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: app
+          image: zot.phillips-homelab.net/tychofleet:e9f245f
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - containerPort: 4321
+          env:
+            - name: HOST
+              value: "0.0.0.0"
+            - name: PORT
+              value: "4321"
+            - name: DATABASE_PATH
+              value: /data/tychofleet.db
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 100m
+            limits:
+              memory: 512Mi
+              cpu: 500m
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 4321
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 4321
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: tychofleet-data

--- a/gitops/apps/tychofleet/namespace.yaml
+++ b/gitops/apps/tychofleet/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tychofleet

--- a/gitops/apps/tychofleet/network-policy.yaml
+++ b/gitops/apps/tychofleet/network-policy.yaml
@@ -1,0 +1,31 @@
+# v0 lockdown: ingress only from the Cloudflare tunnel, egress DNS only
+# (the app makes no outbound calls). Litestream phase 2 will need an
+# egress rule to garage:3900 like lighttheham's.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: tychofleet
+  namespace: tychofleet
+spec:
+  endpointSelector:
+    matchLabels:
+      app: tychofleet
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: cloudflare
+      toPorts:
+        - ports:
+            - port: "4321"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP

--- a/gitops/apps/tychofleet/pvc.yaml
+++ b/gitops/apps/tychofleet/pvc.yaml
@@ -1,0 +1,15 @@
+# syno-iscsi-default (Retain, network-attached) rather than nvme-scratch:
+# this PVC is the only copy of the waitlist DB until the litestream
+# phase-2 sidecar lands, and nvme-scratch is node-local with Delete reclaim.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: tychofleet-data
+  namespace: tychofleet
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: syno-iscsi-default
+  resources:
+    requests:
+      storage: 1Gi

--- a/gitops/apps/tychofleet/service.yaml
+++ b/gitops/apps/tychofleet/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tychofleet
+  namespace: tychofleet
+  labels:
+    app: tychofleet
+spec:
+  selector:
+    app: tychofleet
+  ports:
+    - name: http
+      port: 80
+      targetPort: 4321
+      protocol: TCP
+  type: ClusterIP

--- a/gitops/tools/apps/tychofleet.yaml
+++ b/gitops/tools/apps/tychofleet.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tychofleet
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/AlverezYari/phillips-homelab.git
+    path: gitops/apps/tychofleet
+    targetRevision: main
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: tychofleet
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## Summary
Mirrors the lighttheham pattern per the deploy brief:
- namespace + Deployment (image `zot.phillips-homelab.net/tychofleet:e9f245f` pinned, Recreate for single SQLite writer, runAsNonRoot 1001, restricted profile, `/` probes on 4321)
- 1Gi RWO PVC at `/data` on `syno-iscsi-default` — deliberately NOT `nvme-scratch` (node-local, Delete reclaim) since this is the only copy of the DB until litestream phase 2
- ClusterIP Service 80 → 4321
- CiliumNetworkPolicy: ingress only from the cloudflare namespace on 4321, egress DNS only
- Argo app in `gitops/tools/apps/` (auto-discovered), auto-sync/prune/self-heal

Cloudflare-side (zone onboarding, NS flip, tunnel public hostname for tychofleet.com) is dashboard work, not in git — cloudflared here is token-run/remotely managed.

Phase 2 (litestream → Garage `tychofleet-db` + ESO creds) intentionally deferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment configuration for the Tychofleet application.
  * Added persistent storage for application data.
  * Added internal service exposure on port 80.
  * Added health checks and resource limits for improved reliability.
  * Added automated deployment and synchronization through Argo CD.

* **Security**
  * Restricted network access to authorized ingress traffic and DNS egress.
  * Configured containers to run with reduced privileges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->