### PR TITLE
tychofleet: bump to 4df1946 (docs/faq/gallery/blog + review round)

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:4ce4426
+          image: zot.phillips-homelab.net/tychofleet:4df1946
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Site substance release: docs section, FAQ, gallery/blog split, humanized copy, for-science future framing. Image pushed to zot.

https://claude.ai/code/session_013igkM3DFDrc4rM4sr9DCG3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the TychoFleet application to a newer version.
  * No other deployment settings were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->