### PR TITLE
forgejo: set app resource requests/limits + bump DB memory

### DIFF
--- a/gitops/tools/apps/forgejo-db/cluster.yaml
+++ b/gitops/tools/apps/forgejo-db/cluster.yaml
@@ -23,7 +23,7 @@ spec:
 
   resources:
     requests:
-      cpu: 100m
-      memory: 256Mi
+      cpu: 250m
+      memory: 1Gi
     limits:
-      memory: 512Mi
+      memory: 2Gi

--- a/gitops/tools/apps/forgejo.yml
+++ b/gitops/tools/apps/forgejo.yml
@@ -33,6 +33,17 @@ spec:
 
         replicaCount: 1
 
+        # Node has ~32Gi RAM and load is modest — give the app real headroom
+        # so it isn't BestEffort/first-to-throttle under contention. No CPU
+        # limit on purpose (requests guarantee scheduling; a limit only adds
+        # throttling for a git workload that's bursty by nature).
+        resources:
+          requests:
+            cpu: 250m
+            memory: 512Mi
+          limits:
+            memory: 2Gi
+
         persistence:
           enabled: true
           create: true


### PR DESCRIPTION
## Why
FJO felt slow/laggy. Investigation found the DB is healthy *now* (archiving OK, disk 3%), but two compute constraints were worth removing:

- **App pod ran as BestEffort** — `resources: {}`, so no CPU/mem guarantee and first to be throttled/evicted under node contention.
- **DB memory capped at 512Mi** — fine at idle, tight for page/query caching under real load.

Node has ~32Gi RAM and load is modest, so no reason to keep these this tight.

## Changes
- **App** (`forgejo.yml`): requests `250m`/`512Mi`, mem limit `2Gi`. No CPU limit on purpose — git workloads are bursty and a CPU limit only adds throttling.
- **DB** (`forgejo-db/cluster.yaml`): requests `250m`/`1Gi`, mem limit `2Gi` (was `100m`/`256Mi` req, `512Mi` lim).

## Notes / rollout
- The DB change **rolls `forgejo-pg-1`** (single instance) → expect a brief FJO blip on sync.
- **Storage not touched.** Leading suspect for residual lag is Synology iSCSI latency (git data + DB both on `syno-iscsi-default`); this PR isolates the compute variable first. Follow-up if it still drags.
- Historical context: DB pod carries ~10.5k restarts from a May–Jun WAL-archive crashloop; recovered and stable ~1 month.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Increased CPU and memory resources allocated to Forgejo and its PostgreSQL database.
  - Improved capacity for handling heavier workloads and database operations.

- **Reliability**
  - Increased memory limits to help reduce resource pressure and improve service stability during periods of increased usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->