### PR TITLE
feat(loops): reap uploads /workspace/renders/*.png as PR visual confirmations + tycho/tychofleet SPEC archive

### DIFF
--- a/loops/bin/loopctl
+++ b/loops/bin/loopctl
@@ -157,6 +157,22 @@ if [ -n \"\$idx\" ]; then
     | curl -s -o /dev/null -X POST \"\$F/repos/${repo}/issues/\$idx/comments\" -H \"Authorization: token \${FORGEJO_TOKEN}\" -H 'Content-Type: application/json' -d @-
   curl -s -o /dev/null -X POST \"\$F/repos/${repo}/pulls/\$idx/requested_reviewers\" -H \"Authorization: token \${FORGEJO_TOKEN}\" -H 'Content-Type: application/json' -d '{\"reviewers\":[\"$REVIEWER\"]}'
   echo 'PROGRESS attached as comment; review requested from $REVIEWER'
+  # Visual confirmations: UI loops drop PNGs in /workspace/renders/
+  # (SPEC contract, added after a restyle shipped green gates but was
+  # visually broken). Upload each as a PR attachment and embed them in
+  # one comment so review OPENS with pictures next to the diff.
+  if ls /ws/renders/*.png >/dev/null 2>&1; then
+    IMGS=''
+    for f in /ws/renders/*.png; do
+      url=\$(curl -s -X POST \"\$F/repos/${repo}/issues/\$idx/assets?name=\$(basename \"\$f\")\" -H \"Authorization: token \${FORGEJO_TOKEN}\" -F \"attachment=@\$f\" | jq -r '.browser_download_url // empty')
+      [ -n \"\$url\" ] && IMGS=\"\$IMGS![\$(basename \"\$f\")](\$url)\n\n\"
+    done
+    if [ -n \"\$IMGS\" ]; then
+      jq -n --arg b \"\$(printf '## Visual confirmations\n\n%b' \"\$IMGS\")\" '{body: \$b}' \
+        | curl -s -o /dev/null -X POST \"\$F/repos/${repo}/issues/\$idx/comments\" -H \"Authorization: token \${FORGEJO_TOKEN}\" -H 'Content-Type: application/json' -d @-
+      echo 'visual confirmations attached'
+    fi
+  fi
 fi" \
       "  volumes:
   - name: ws

--- a/loops/specs/fleetorg2/SPEC.md
+++ b/loops/specs/fleetorg2/SPEC.md
@@ -1,0 +1,83 @@
+# SPEC — fleetorg2: hands-on-test feedback round (targets, Fleet Zero, membership chain, email)
+
+Repo: `loop-bot/tychofleet`. Gate: `make build test lint`. Run
+`pnpm install --frozen-lockfile` once at start; `pnpm biome check
+--write .` before every commit. Same rig as the fleetorg loop — its
+work (programs/enrollments/admin/member pages, docs/domain-model.md)
+is on main; read it before building on it.
+
+Context: Casey drove the whole flow by hand (waitlist → approve →
+program+target → enroll → tycho.conf) and it works. This SPEC is his
+punch list, verbatim intent, one item per iteration.
+
+## Work items (one per iteration, in order)
+
+- [ ] **Edit/remove targets.** Admin can edit a program target's
+  name/designation/RA/Dec/match-radius and remove a target from a
+  program (server-rendered forms + `api/admin/` endpoints, same
+  patterns as programs-create/add-target). Lib-layer tests. Removing
+  a target that has attributed observations is out of scope (nothing
+  attributes yet) — a plain delete is fine today.
+- [ ] **Target catalog typeahead.** Nobody remembers coordinates.
+  Vendor a static deep-sky-object catalog as JSON at
+  `src/data/dso-catalog.json`: every Messier object (M1–M110) with
+  common name, designation, aliases, ICRS RA/Dec in degrees — you
+  know these; generate them accurately — plus a checked-in
+  `scripts/fetch-catalog.mjs` that regenerates/extends the JSON from
+  OpenNGC (https://github.com/mattiaverga/OpenNGC, CC-BY-SA-4.0 —
+  include attribution in the JSON header and docs) for the full
+  NGC/IC set later; the script needs network so it is run by humans,
+  NEVER by the gate. Admin add-target gets a search box over the
+  vendored JSON (name/designation/alias substring, server-rendered or
+  minimal progressive JS consistent with house no-bloat style) that
+  autofills name/designation/RA/Dec on pick. Manual coordinate entry
+  stays for objects not in the list.
+- [ ] **Fleet Zero.** Rename the seed fleet: slug `fleet-zero`, name
+  "Fleet Zero" (Casey: "which is cooler"). Idempotent migration
+  updates the existing `fleet-1` row in deployed DBs; seed.ts +
+  scripts/migrate.mjs mirror + FLEET_ONE_SLUG constant (rename it) +
+  fleet page references/tests all follow. seed.test.ts guards the
+  mirror sync — it will catch you if you miss one side.
+- [ ] **Membership chain, wired for real.** Today approve dumps every
+  member into the seed fleet via members.fleetId's default — Casey
+  wants membership to flow member → team → fleet. Admin gets minimal
+  team management: create team, add/remove a member, attach/detach a
+  team to a fleet (a `fleet_members` row with principal_type=team).
+  Approve stops implying fleet membership by itself: it creates the
+  member only; the member page resolves visible programs through the
+  chain (direct member `fleet_members` row OR team membership →
+  team's `fleet_members` row), and shows "not yet assigned to a
+  fleet" state honestly when the chain is empty. `members.fleetId`
+  column stays (schema comment already calls it the v1 coexisting
+  link) but display/enrollment logic must use the chain. Update
+  docs/domain-model.md to describe the wired reality.
+- [ ] **Email, log-only by default.** Approval currently surfaces the
+  member link only in the admin UI. Add outbound email (nodemailer or
+  equivalent minimal dep): on approve, send the member their link.
+  Env contract: SMTP_HOST/SMTP_PORT/SMTP_USER/SMTP_PASS/SMTP_FROM —
+  ALL optional; any missing → log-only mode (email rendered to the
+  server log, nothing sent, flow unchanged) so prod stays safe until
+  credentials exist. Never block or fail approve on send failure —
+  log and continue; the admin UI keeps showing the link either way.
+  Tests exercise log-only mode + a fake transport; no network in
+  tests. Document local testing with Mailpit
+  (`docker run -d -p 1025:1025 -p 8025:8025 axllent/mailpit`,
+  SMTP_HOST=localhost SMTP_PORT=1025, UI at :8025) and the intended
+  prod path (Fastmail SMTP submission, creds via ESO — pointer only,
+  no secrets, DNS/SPF/DKIM is dashboard work outside this repo).
+
+## Warts / traps
+
+- migration.test.ts's pre-fleets fixture filter (`tag < "0003_"`) is
+  correct — don't touch it when adding migrations.
+- Schema changes via `pnpm drizzle-kit generate` only; seed changes
+  must be mirrored in scripts/migrate.mjs (guard test enforces).
+- The Fleet Zero rename migration runs against a REAL deployed DB —
+  make it idempotent and safe on both a fresh DB and one where
+  fleet-1 exists with members attached.
+- No secrets, no trackers, no client-side bloat; repo goes public.
+- Biome format before every gate run.
+
+Finish: /workspace/PR.md — call out the membership-chain behavior
+change (approve no longer implies fleet membership) prominently; it
+changes what admins must do after approving someone.

--- a/loops/specs/fleetorg3/SPEC.md
+++ b/loops/specs/fleetorg3/SPEC.md
@@ -1,0 +1,66 @@
+# SPEC — fleetorg3: admin hierarchy, magic-link sessions, /profile
+
+Repo: `loop-bot/tychofleet`. Gate: `make build test lint`.
+`pnpm install --frozen-lockfile` once at start; `pnpm biome check
+--write .` before every commit. Builds on the fleetorg/fleetorg2 work
+already on main (programs, enrollments, membership chain, catalog
+typeahead, email-with-log-only-default).
+
+Context from Casey's second hands-on test: admin jumps straight to
+programs with no way to create fleets or campaigns (both are
+seed-only); there is no login/logout or notion of "who am I" — members
+exist only as token URLs; nothing explains what a Program IS.
+
+## Work items (one per iteration, in order)
+
+- [ ] **Admin hierarchy.** Create fleet; create campaign under a
+  fleet; programs listed/created nested under their campaign, with
+  Fleet → Campaign → Program breadcrumbs everywhere in admin. Each
+  level gets ONE line of inline help copy, verbatim intent:
+  fleet = "whose scopes count"; campaign = "the story — a shared
+  effort's umbrella, gallery, and goal"; program = "a standing
+  instruction: these targets, these scopes, this window. Today it
+  decides which frames pool into the fleet's shared master; when
+  directed capture arrives it becomes the tasking the operator
+  executes." Lib-layer tests per house pattern.
+- [ ] **Magic-link sessions.** Passwordless member login: enter email
+  → one-time, short-lived (15 min), single-use signed token emailed
+  via the existing email path (log-only/Mailpit locally) → exchanging
+  it sets an HttpOnly SameSite=Lax session cookie (sessions table:
+  member, expiry ~30 days, revocable); logout clears it. Reuse
+  src/lib/rate-limit.ts on the request-link endpoint. Never reveal
+  whether an email is a member (uniform response). SESSION_SECRET env
+  for signing; in dev, absent → derive an ephemeral one and log a
+  loud warning (never a hardcoded default).
+- [ ] **/profile.** For the logged-in member: email + editable display
+  name, teams, fleets (resolved through the membership chain),
+  enrollments with their sourceIds, and the tycho.conf download.
+  Honest empty states ("not on a team yet", "not assigned to a
+  fleet") — same spirit as the member page's unassigned state.
+- [ ] **Session-aware member flows.** Enroll/leave and the member page
+  work from a session, not only the token URL. Token links keep
+  working (they're the invite bootstrap — a fresh invitee has no
+  session yet); visiting one while logged out offers the magic-link
+  login for next time. No token in any URL the profile links to.
+- [ ] **Copy/consistency sweep.** Fleet Zero naming everywhere, admin
+  section headers reflect the hierarchy, and docs/domain-model.md
+  gains the site→operator mapping table (Program → decides
+  FleetMaster inputs today / compiles to CaptureProgram later;
+  enrollment → future Observation). Update RUNBOOK env-var list
+  (SESSION_SECRET, SMTP_*).
+
+## Warts / traps
+
+- Session cookies: HttpOnly, SameSite=Lax, Secure when the request is
+  https — the pod sits behind Cloudflare Tunnel in prod, plain http in
+  dev, so key Secure off `Astro.request` protocol, not an env guess.
+- migration.test.ts's `tag < "0003_"` fixture filter stays as-is.
+- drizzle-kit generate for schema (sessions table etc.); seed changes
+  mirror into scripts/migrate.mjs (guard test enforces).
+- No client-side JS beyond what the typeahead already established;
+  no trackers; no secrets; repo goes public.
+- Biome --write before every gate.
+
+Finish: /workspace/PR.md — call out the auth model (magic-link,
+session lifetime, what SESSION_SECRET does) and any place token-URL
+and session identity could disagree, for the reviewer.

--- a/loops/specs/fleetorg4/SPEC.md
+++ b/loops/specs/fleetorg4/SPEC.md
@@ -1,0 +1,65 @@
+# SPEC — fleetorg4: flatten Program into Campaign
+
+Repo: `loop-bot/tychofleet`. Gate: `make build test lint`.
+`pnpm install --frozen-lockfile` once at start; `pnpm biome check
+--write .` before every commit.
+
+## Context — a deliberate reversal, don't second-guess it
+
+Three rounds of founder hands-on testing produced a verdict: the
+Campaign → Program two-level split is a failed abstraction. Casey's
+mental model (and now the canon): **a campaign IS the tasking** — one
+fleet decides to observe target(s) over a time period. There is no
+separate "program" object a human manages. Cross-fleet campaigns are a
+future *type* of campaign (campaigns.fleetId stays single-fleet today,
+correctly). The word "program" survives in exactly one place: docs
+describing the future operator compile step (an active campaign
+compiles to a tycho `CaptureProgram` CR when directed capture arrives).
+
+## Work items (one per iteration, in order)
+
+- [ ] **Schema flatten.** Migration: `campaign_targets` replaces
+  `program_targets` (same columns, keyed to campaignId);
+  `enrollments.programId` → `campaignId`; campaigns gain nullable
+  `startsAt`/`endsAt` (the window that lived on programs); `programs`
+  and `program_targets` tables dropped after data moves up (any
+  existing program's targets/enrollments reattach to its campaign).
+  Precedent for data-moving SQL inside a generated migration file:
+  drizzle/0003 (the fleet_id backfill) — DDL via drizzle-kit generate,
+  hand-added data movement in the same file, idempotent and safe on a
+  DB with real rows AND on a fresh empty one. migration.test.ts gets a
+  flatten-scenario case in the style of the 0003 backfill test.
+- [ ] **Admin de-clunk.** Remove the program level from admin
+  entirely: a campaign's page manages its targets (catalog typeahead
+  intact), window, and activate/complete directly. Two levels of
+  breadcrumb (Fleet → Campaign), not three. Founder's words: current
+  managing is "clunky as fuck" — fewer pages, fewer clicks; creating a
+  fleet+campaign+target should feel like one short errand, not a form
+  safari.
+- [ ] **Member surfaces re-key.** /profile, member page, enroll/leave
+  APIs, and the tycho.conf enrollment stanza all speak campaigns now.
+  Update docs/tycho-conf-enrollments.md and mark the stanza change
+  prominently as BREAKING vs the previous shape — permitted freely
+  today because nothing on the agent side consumes it yet; after an
+  agent-side parser exists this doc becomes a versioned contract.
+- [ ] **Docs truth pass.** docs/domain-model.md: campaign = the
+  tasking (fleet + targets + window + enrollments); the site→operator
+  table maps *campaign* → future CaptureProgram compile, enrollment →
+  future Observation; cross-fleet campaigns noted as a future campaign
+  type. Also add a "Known gaps" section recording (do NOT build): admin
+  identity is basic-auth while members have real sessions — the two
+  coexist in one browser with no way to see or switch identity; fine
+  solo, must become a proper admin session/role before a second admin
+  exists.
+
+## Warts / traps
+
+- migration.test.ts pre-fleets fixture filter (`tag < "0003_"`) stays.
+- Seed changes mirror into scripts/migrate.mjs (guard test enforces).
+- The flatten migration will run against the deployed prod DB
+  eventually — treat "safe on non-empty DB" as a hard requirement,
+  same bar the Fleet Zero rename met.
+- No new dependencies; no client-JS growth; repo goes public.
+
+Finish: /workspace/PR.md — lead with the schema flatten and the
+BREAKING tycho.conf stanza change.

--- a/loops/specs/tuikit/SPEC.md
+++ b/loops/specs/tuikit/SPEC.md
@@ -1,0 +1,107 @@
+# SPEC — tuikit: scopetui redesign phase A (pattern kit, theme, headless split, restyle)
+
+Repo: `loop-bot/tycho`. Gate: `make build test lint` (offline — the
+combine/scorer venv skips are expected and loud; your work is Go-only).
+
+## Read first, it is the law
+
+`docs/design/scopetui/README.md` — the design handoff. This SPEC
+implements its **phase A** only: the pattern kit ("3 · Pattern kit"),
+the design tokens, the grid rules, the headless split, and re-rendering
+scopetui's EXISTING panes through the kit. You are NOT building the new
+screens (6a/6b/6c/5a/5b/4a/4b/2c) — those need agent/operator data that
+does not exist yet and come in later phases. Every current scopetui
+feature must keep working in all three modes (-scope direct, -agent,
+-conf field) — this phase changes how things LOOK and how view code is
+STRUCTURED, not what the TUI does.
+
+Current state: `agent/cmd/scopetui/` (~3.8k lines, package main), one
+bubbletea model, hand-rolled lipgloss everywhere, ~12 package-level
+style vars (main.go:71-86), rounded borders, ANSI-256 colors. No
+`bubbles` imports — keep it that way in this phase (the handoff permits
+`bubbles/textinput` for the `/` filter LATER; the filter is not in
+phase A).
+
+## Work items (one per iteration, in order)
+
+- [ ] **Theme.** New package `agent/internal/tuikit`: a `Theme` struct
+  holding every color from the handoff's Design-tokens table
+  (background #1b1b1b, border #4d4d4d, rule #333333, text #e6e6e6 /
+  #8f8f8f / #7f7f7f / #5a5a5a, accent #ff8c1a, good #3ddc97, info
+  #56d4dd, warn #ff9d2e, bad #ff3b30) as
+  `lipgloss.CompleteColor` — TrueColor hex plus a hand-picked ANSI256
+  approximation for each (the current TUI's 208/42/81/196/240 values
+  are good approximations for accent/good/info/bad/border). One
+  `DefaultTheme`. State marks are constants here too (⇩ ○ ✓ ! ✗ ▮
+  [✓] [ ] [—]) — color NEVER carries state alone (NO_COLOR rule).
+- [ ] **Pattern kit, part 1: pane, bar, statusBar.** In `tuikit`,
+  per the handoff's "Lip Gloss helpers" signatures: `Pane(title,
+  state, body)` with Idle/Focused/Alert/Stale states (square
+  `lipgloss.Border` single-line — rounded borders are RETIRED; Alert
+  beats Focused: when both, focus shows only by brightening the
+  title; Stale = dashed border), `Bar(segments, width)` (fill ▮
+  U+25AE, empty ▯ U+25AF, NEVER █ — advance-width trap, handoff "Grid
+  rules" #1), `StatusBar(mode, endpoint, facts)` (worst fact last).
+  Golden-string unit tests, including a bar-width invariance test
+  (rendered cell width identical at 0%, 50%, 100% fill) and the
+  focus-vs-alert precedence.
+- [ ] **Pattern kit, part 2: chip, eventLine, emptyState, confirm,
+  keyHints.** `Chip` with the four independent axes (value on/off/
+  read-only · selected · in-flight/pending amber · locked),
+  `EventLine` (fixed 5-column gutter), `EmptyState` (sentence + key
+  hint, never "(none)"), `Confirm` (Plain y/n vs TypeToConfirm —
+  type-to-confirm ONLY when frames die), `KeyHints`
+  (Global/Pane/Destructive; lowercase never destroys, destructive
+  keys shifted). Golden tests per state.
+- [ ] **Headless split.** Introduce the model/view seam the handoff's
+  "Non-TTY / headless" section calls for, sized for phase A: the
+  update loop's state becomes observable through one interface (a
+  snapshot/event emitter the View consumes), and a new
+  `-headless` flag runs the same model WITHOUT the bubbletea program,
+  emitting one JSON line per state-changing event to stdout
+  (journald-friendly). Scope discipline: same connection modes, same
+  folding logic, no attach protocol, no socket — just the seam + JSON
+  emission, so the TUI is provably one consumer of the model rather
+  than entangled with it. Test: headless mode against fakescope
+  emits parseable JSON lines for connect/status/event.
+- [ ] **Restyle Now + Albums through the kit.** Replace hand-rolled
+  borders/styles in the existing Now and Albums panes with
+  tuikit.Pane/Bar/theme; keep information content identical except
+  where the handoff's 2a/2b state language directly applies to data
+  that already exists (e.g. disconnected → the pane renders Stale
+  dashed with values marked stale, never blank/zero — scopetui
+  already tracks misses). Grid rules #2-4: fixed-width cells sized to
+  widest possible value +1 slack, truncate never wrap, bars in fixed
+  columns.
+- [ ] **Restyle Settings chips + Events + footer through the kit.**
+  Settings chips move to tuikit.Chip preserving current behavior
+  (shift-T toggle, in-flight amber until agent ack maps to the
+  pending axis); Events uses EventLine; footer uses KeyHints;
+  status line uses StatusBar. Rounded borders now fully gone.
+- [ ] **80-col + NO_COLOR pass, and docs.** Verify (test where
+  feasible) the layout degrades to single-pane at 80 cols per grid
+  rule #5, and that NO_COLOR/non-TTY rendering still reads (marks
+  carry state). Update `docs/dev/style.md` or add
+  `docs/dev/tui-style.md` describing tuikit as the reality: theme
+  tokens, helper inventory, glyph/grid rules, and which handoff
+  screens remain future phases (list them explicitly so the next
+  SPEC writer doesn't re-derive).
+
+## Warts / traps
+
+- scopetui is package main — the kit goes in `agent/internal/tuikit`
+  (importable by fleetview later), NOT inside cmd/scopetui.
+- Do not break `agent/cmd/scopetui` tests (fieldmode_test, campaign
+  tests, condition_test) or the three modes; refactor incrementally —
+  every iteration must gate green, so restyle pane-by-pane, not
+  big-bang.
+- Comment style: docs/dev/style.md (why, not what).
+- The handoff HTML is a browser reference; you cannot render it —
+  the README's tables are authoritative and transcribed above where
+  needed.
+- No new deps beyond what exists (bubbletea + lipgloss). No
+  bubbles imports in phase A.
+
+Finish: /workspace/PR.md — lead with before/after of the style-var
+inventory (12 package vars → theme+kit), the headless seam contract,
+and what phase B/C screens remain.

--- a/loops/specs/tuikit2/SPEC.md
+++ b/loops/specs/tuikit2/SPEC.md
@@ -1,0 +1,75 @@
+# SPEC — tuikit2: geometry correction — chips are pills, height is law
+
+Repo: `loop-bot/tycho`. Gate: `make build test lint`.
+
+## Why this loop exists (read carefully — it's a correction)
+
+The tuikit restyle (PR #85) got states right and geometry catastrophically
+wrong. On a real 40-row terminal the Settings pane rendered every chip as
+a lipgloss-BORDERED box (3+ rows each, blank rows between), the total
+View exceeded the terminal height, and bubbletea pushed the header off
+the top of the screen. Founder verdict on the live result: "really bad
+first pass."
+
+Root cause to internalize: in the design's HTML mock, chips are
+single-row inline pills (`padding:0 6px`, hairline border, content
+width, several per row). A hairline border does not exist in a
+terminal — `lipgloss.Border` costs +2 rows. Therefore in terminal
+translation, **chips have NO lipgloss border, ever**. State is carried
+by background fill, foreground color, and marks, on ONE row.
+
+## Geometry law (non-negotiable, test-enforced)
+
+1. **Chip = exactly 1 row.** `Padding(0,1)`, content width. States,
+   extracted from the mock's pattern kit:
+   - on: `✓ label` — good (#3ddc97) fg on subtle raised bg (#262626)
+   - off: `· label` — dim fg (#7f7f7f) on subtle bg
+   - read-only value: `label value` — secondary fg on subtle bg
+   - selected (cursor): accent (#ff8c1a) BACKGROUND, near-black fg,
+     bold — the only chip state with a loud fill
+   - pending (sent, not acked): warn (#ff9d2e) fg + `…` suffix
+   - locked/unavailable: dimmest fg, `[—]` mark
+2. **Chip grid:** chips joined on a row with a 2-space gap, wrapped to
+   as many per row as width allows (uniform cell width per row batch is
+   fine); NO blank rows between chip rows; toggles before values
+   (existing behavior).
+3. **Total View height ≤ terminal height. Always.** Restore/respect the
+   height budgeting the pre-restyle code had: panes share the vertical
+   budget from tea.WindowSizeMsg; the Events pane is the flexible one;
+   the header/status line must NEVER scroll off.
+4. **Density ceiling:** for the same model state, the new layout may
+   not be taller than the pre-restyle layout (commit d96f995) ±2 rows.
+   That layout fit; treat it as the budget.
+5. Pane borders (single-line, square) remain pane-only. One blank row
+   between stacked panes, none inside a pane body.
+
+## Enforcement (the part the last loop lacked)
+
+- Golden tests that render the FULL View from a populated fixture
+  (scope connected, ~15 settings chips, 3 albums, 6 events) at 120x40
+  and 80x24 and assert `lines(View()) <= height` — these two tests are
+  the reason this SPEC exists; write them FIRST, red, then fix until
+  green.
+- A chip-height test: any chip state renders to exactly 1 line.
+- PR.md MUST embed the raw ASCII render of the 120x40 fixture View in
+  a code block, so a human can see the layout in review without
+  building. If it looks like bordered boxes again, the loop has failed
+  regardless of green gates.
+
+## Work items
+
+- [ ] Height-law golden tests (red first) + chip 1-row test.
+- [ ] Rewrite tuikit.Chip to the pill spec above; update chip golden
+  tests to the new truth.
+- [ ] Restore pane height budgeting in scopetui's View composition
+  (header + status always visible; Events flexes; 80-col single-pane
+  path keeps working).
+- [ ] Density pass: blank-row audit inside panes; verify against the
+  d96f995 ceiling; update docs/dev/tui-style.md's geometry section and
+  embed the fixture render in PR.md.
+
+## Warts
+
+- Do not touch the headless seam, Theme colors, Pane/Bar/StatusBar
+  helpers' state logic — they're correct; this is geometry only.
+- Comment style: docs/dev/style.md.

--- a/loops/specs/tuikit3/SPEC.md
+++ b/loops/specs/tuikit3/SPEC.md
@@ -1,0 +1,75 @@
+# SPEC — tuikit2: geometry correction — chips are pills, height is law
+
+Repo: `loop-bot/tycho`. Gate: `make build test lint`.
+
+## Why this loop exists (read carefully — it's a correction)
+
+The tuikit restyle (PR #85) got states right and geometry catastrophically
+wrong. On a real 40-row terminal the Settings pane rendered every chip as
+a lipgloss-BORDERED box (3+ rows each, blank rows between), the total
+View exceeded the terminal height, and bubbletea pushed the header off
+the top of the screen. Founder verdict on the live result: "really bad
+first pass."
+
+Root cause to internalize: in the design's HTML mock, chips are
+single-row inline pills (`padding:0 6px`, hairline border, content
+width, several per row). A hairline border does not exist in a
+terminal — `lipgloss.Border` costs +2 rows. Therefore in terminal
+translation, **chips have NO lipgloss border, ever**. State is carried
+by background fill, foreground color, and marks, on ONE row.
+
+## Geometry law (non-negotiable, test-enforced)
+
+1. **Chip = exactly 1 row.** `Padding(0,1)`, content width. States,
+   extracted from the mock's pattern kit:
+   - on: `✓ label` — good (#3ddc97) fg on subtle raised bg (#262626)
+   - off: `· label` — dim fg (#7f7f7f) on subtle bg
+   - read-only value: `label value` — secondary fg on subtle bg
+   - selected (cursor): accent (#ff8c1a) BACKGROUND, near-black fg,
+     bold — the only chip state with a loud fill
+   - pending (sent, not acked): warn (#ff9d2e) fg + `…` suffix
+   - locked/unavailable: dimmest fg, `[—]` mark
+2. **Chip grid:** chips joined on a row with a 2-space gap, wrapped to
+   as many per row as width allows (uniform cell width per row batch is
+   fine); NO blank rows between chip rows; toggles before values
+   (existing behavior).
+3. **Total View height ≤ terminal height. Always.** Restore/respect the
+   height budgeting the pre-restyle code had: panes share the vertical
+   budget from tea.WindowSizeMsg; the Events pane is the flexible one;
+   the header/status line must NEVER scroll off.
+4. **Density ceiling:** for the same model state, the new layout may
+   not be taller than the pre-restyle layout (commit d96f995) ±2 rows.
+   That layout fit; treat it as the budget.
+5. Pane borders (single-line, square) remain pane-only. One blank row
+   between stacked panes, none inside a pane body.
+
+## Enforcement (the part the last loop lacked)
+
+- Golden tests that render the FULL View from a populated fixture
+  (scope connected, ~15 settings chips, 3 albums, 6 events) at 120x40
+  and 80x24 and assert `lines(View()) <= height` — these two tests are
+  the reason this SPEC exists; write them FIRST, red, then fix until
+  green.
+- A chip-height test: any chip state renders to exactly 1 line.
+- PR.md MUST embed the raw ASCII render of the 120x40 fixture View in
+  a code block, so a human can see the layout in review without
+  building. If it looks like bordered boxes again, the loop has failed
+  regardless of green gates.
+
+## Work items
+
+- [ ] Height-law golden tests (red first) + chip 1-row test.
+- [ ] Rewrite tuikit.Chip to the pill spec above; update chip golden
+  tests to the new truth.
+- [ ] Restore pane height budgeting in scopetui's View composition
+  (header + status always visible; Events flexes; 80-col single-pane
+  path keeps working).
+- [ ] Density pass: blank-row audit inside panes; verify against the
+  d96f995 ceiling; update docs/dev/tui-style.md's geometry section and
+  embed the fixture render in PR.md.
+
+## Warts
+
+- Do not touch the headless seam, Theme colors, Pane/Bar/StatusBar
+  helpers' state logic — they're correct; this is geometry only.
+- Comment style: docs/dev/style.md.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reaping workflows can now attach rendered PNGs to the related Forgejo issue and post them as embedded visual confirmations when available.

* **Documentation**
  * Added specifications covering fleet administration, authentication, member profiles, campaign management, operational guidance, and breaking changes.
  * Added UI toolkit specifications for themes, headless behavior, layout geometry, chip rendering, pane spacing, and visual regression coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->