### PR TITLE
feat(loops): fonts-dejavu-core in loop-dev — visual-test PNGs need real glyphs

### DIFF
--- a/loops/images/dev/Dockerfile
+++ b/loops/images/dev/Dockerfile
@@ -8,7 +8,7 @@
 FROM golang:1.25-bookworm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      git make jq curl ca-certificates ripgrep unzip \
+      git make jq curl ca-certificates ripgrep unzip fonts-dejavu-core \
     && rm -rf /var/lib/apt/lists/*
 
 # claude CLI (native installer drops it in ~/.local/bin; promote to PATH)


### PR DESCRIPTION
Without a TTF the tui-visual render falls back to PIL's bitmap font and
every mark/border renders as tofu, degrading the loop's ability to
judge its own UI output. Seen live in tuikit3's first capture.
