### PR TITLE
feat(loops): chromium in loop-dev — web loops get eyes

### DIFF
--- a/loops/images/dev/Dockerfile
+++ b/loops/images/dev/Dockerfile
@@ -9,6 +9,7 @@ FROM golang:1.25-bookworm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       git make jq curl ca-certificates ripgrep unzip fonts-dejavu-core \
+      chromium \
     && rm -rf /var/lib/apt/lists/*
 
 # claude CLI (native installer drops it in ~/.local/bin; promote to PATH)


### PR DESCRIPTION
The TUI visual-test round proved loops must look at their own output;
web loops need a browser for the same contract (headless screenshots
of the dev server against the design's screen PNGs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added Chromium to the development environment’s installed system tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->