### PR TITLE
feat(tychofleet): deploy c8329c6 with SMTP/session env via ESO

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:937aca8
+          image: zot.phillips-homelab.net/tychofleet:c8329c6
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -41,6 +41,18 @@ spec:
               value: "4321"
             - name: DATABASE_PATH
               value: /data/tychofleet.db
+            - name: SMTP_HOST
+              value: smtp.fastmail.com
+            - name: SMTP_PORT
+              value: "587"
+            - name: SMTP_USER
+              value: admin@tychofleet.com
+            - name: SMTP_FROM
+              value: admin@tychofleet.com
+          # SMTP_PASS, SESSION_SECRET, ADMIN_TOKEN
+          envFrom:
+            - secretRef:
+                name: tychofleet-config
           volumeMounts:
             - name: data
               mountPath: /data

--- a/gitops/apps/tychofleet/external-secret.yaml
+++ b/gitops/apps/tychofleet/external-secret.yaml
@@ -1,0 +1,34 @@
+# App secret for tychofleet, synced from the "tychofleet" 1Password item via
+# ESO. SMTP_PASS is a Fastmail app password (not the account login password).
+# One secret, many keys — add fields to the 1P item and a matching data entry
+# here as the app grows (tycho-config pattern).
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: tychofleet-config
+  namespace: tychofleet
+  annotations:
+    # Client-side apply: SSA conflicts with ESO's field manager on spec.data
+    # and can wedge the sync (see stock-bot ExternalSecrets).
+    argocd.argoproj.io/sync-options: ServerSideApply=false
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: staging
+  target:
+    name: tychofleet-config
+    creationPolicy: Owner
+  data:
+  - secretKey: SMTP_PASS
+    remoteRef:
+      key: tychofleet
+      property: SMTP_PASS
+  - secretKey: SESSION_SECRET
+    remoteRef:
+      key: tychofleet
+      property: SESSION_SECRET
+  - secretKey: ADMIN_TOKEN
+    remoteRef:
+      key: tychofleet
+      property: ADMIN_TOKEN

--- a/gitops/apps/tychofleet/network-policy.yaml
+++ b/gitops/apps/tychofleet/network-policy.yaml
@@ -1,6 +1,6 @@
-# v0 lockdown: ingress only from the Cloudflare tunnel, egress DNS only
-# (the app makes no outbound calls). Litestream phase 2 will need an
-# egress rule to garage:3900 like lighttheham's.
+# Lockdown: ingress only from the Cloudflare tunnel; egress DNS plus
+# SMTP submission (Fastmail, magic-link mail). Litestream phase 3 will
+# need an egress rule to garage:3900 like lighttheham's.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -28,4 +28,13 @@ spec:
             - port: "53"
               protocol: UDP
             - port: "53"
+              protocol: TCP
+    # smtp.fastmail.com submission. Port-scoped world egress rather than
+    # toFQDNs — nothing in the cluster uses the Cilium DNS proxy yet and
+    # this deploy is the wrong place to introduce it.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "587"
               protocol: TCP


### PR DESCRIPTION
Deploys the redesigned tychofleet (image `c8329c6`, digest `sha256:608062b2…`, migration-smoked) and wires its env.

- image `937aca8` → `c8329c6` (9 days / ~25 PRs of redesign)
- new `tychofleet-config` ExternalSecret syncing exactly `SMTP_PASS`, `SESSION_SECRET`, `ADMIN_TOKEN` from the `tychofleet` 1P item (staging ClusterSecretStore, SSA off per stock-bot lesson)
- plain env: `SMTP_HOST=smtp.fastmail.com`, `SMTP_PORT=587`, `SMTP_USER`/`SMTP_FROM=admin@tychofleet.com`
- netpol: adds egress `world:587` — the old policy was DNS-only ("app makes no outbound calls"), which would have blackholed magic-link mail. Port-scoped world instead of `toFQDNs` to avoid introducing the Cilium DNS proxy in this deploy.

Recreate strategy already in place; brief downtime expected and fine.

**Pre-merge gate:** Casey to confirm the `SMTP_PASS` value in 1P is the Fastmail **app password**, not the login password.

Post-sync verification (will run after merge): migrations through 0011, no SESSION_SECRET warning, new chrome live, `/api/debug/catalog` → 404, waitlist POST, live magic-link email.

Phase 3 (separate): CATALOG_DSN via CNPG role + netpol to tycho-pg, triggers CronJob, Litestream → Garage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added SMTP configuration to support email delivery.
  - Added secure secret synchronization for SMTP credentials, session security, and administrative access.
  - Enabled outbound SMTP submission for application emails.

- **Improvements**
  - Updated the application deployment to a newer version.
  - Continued restricting inbound traffic to approved access paths while allowing required email connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->