### PR TITLE
fix(tychofleet): SMTP_USER is the Fastmail account login

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -45,8 +45,10 @@ spec:
               value: smtp.fastmail.com
             - name: SMTP_PORT
               value: "587"
+            # Fastmail SMTP AUTH needs the account login, not the sending
+            # identity — admin@tychofleet.com is an alias and 535s.
             - name: SMTP_USER
-              value: admin@tychofleet.com
+              value: devs@lighttheham.com
             - name: SMTP_FROM
               value: admin@tychofleet.com
           # SMTP_PASS, SESSION_SECRET, ADMIN_TOKEN


### PR DESCRIPTION
AUTH PLAIN as admin@tychofleet.com gets 535 -- it's a sending
identity, not a user. Auth as devs@lighttheham.com (already public
in lighttheham's ADMIN_EMAILS); SMTP_FROM stays admin@tychofleet.com.
