### PR TITLE
feat(loops): loopctl release — cut a Forgejo release with in-cluster builds

### DIFF
--- a/loops/bin/loopctl
+++ b/loops/bin/loopctl
@@ -10,6 +10,7 @@
 #   loopctl reap <name> [--no-pr]
 #   loopctl pr <owner/repo> <branch> [title...]
 #   loopctl merge <owner/repo> <pr#>
+#   loopctl release <owner/repo> <tag> [title...]
 #
 # Secrets never touch the laptop: FJO/NATS calls run in short-lived helper
 # pods that read the loop-secrets Secret in-cluster.
@@ -214,6 +215,24 @@ code=\$(curl -s -o /tmp/r -w '%{http_code}' -X POST \"\$F/repos/${repo}/pulls/${
 if [ \"\$code\" = 200 ]; then echo \"PR #${idx} merged\"; else echo \"merge failed: \$code\"; head -c 300 /tmp/r; exit 1; fi"
 }
 
+# release: cut a Forgejo release with cross-built client binaries. The
+# build runs inside the helper pod (loop-dev carries Go), so source,
+# toolchain and token all stay in-cluster -- the same invariant every
+# other verb keeps. The pod body lives in release-build.sh rather than
+# inline here; nesting a build script inside this file's quoting was
+# unreadable and quietly broke.
+cmd_release() {
+  local repo=${1:?usage: loopctl release <owner/repo> <tag> [title...]}
+  local tag=${2:?tag required}; shift 2
+  local title=${*:-$tag}
+  local body
+  body=$(cat "$REPO_ROOT/loops/bin/release-build.sh")
+  helper_pod release "$body" "" "    env:
+    - {name: REPO, value: \"$repo\"}
+    - {name: TAG, value: \"$tag\"}
+    - {name: TITLE, value: \"$title\"}"
+}
+
 cmd=${1:-help}; shift || true
 case $cmd in
   spawn) cmd_spawn "$@";;
@@ -225,5 +244,6 @@ case $cmd in
   reap) cmd_reap "$@";;
   pr) cmd_pr "$@";;
   merge) cmd_merge "$@";;
+  release) cmd_release "$@";;
   *) sed -n '2,14p' "$0";;
 esac

--- a/loops/bin/release-build.sh
+++ b/loops/bin/release-build.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Runs INSIDE a loopctl helper pod (loop-dev image: Go toolchain, jq,
+# curl, git). Clones the repo with the in-cluster FJO token, cross-builds
+# the client binaries, creates or reuses a release, and attaches the
+# archives. Source, toolchain and token all stay in-cluster, matching
+# every other loopctl verb's invariant.
+#
+# Env in: REPO (owner/repo), TAG, TITLE, FORGEJO_TOKEN (from loop-secrets).
+set -euo pipefail
+
+F=http://forgejo-http.forgejo.svc.cluster.local:3000/api/v1
+git clone -q "https://oauth2:${FORGEJO_TOKEN}@code.phillips-homelab.net/${REPO}.git" /src
+cd /src
+git checkout -q "$TAG" 2>/dev/null || echo "tag $TAG not a ref yet; building from default branch"
+V=$(git describe --tags --always)
+
+mkdir -p /out /stage
+for pair in darwin/arm64 darwin/amd64 linux/amd64; do
+  os=${pair%/*}; arch=${pair#*/}
+  for c in scopetui fleetview; do
+    GOOS=$os GOARCH=$arch CGO_ENABLED=0 go build -trimpath \
+      -ldflags="-s -w -X tycho.dev/agent/internal/version.Version=$V" \
+      -o "/stage/$c" "./agent/cmd/$c"
+  done
+  tar -czf "/out/tycho-${V}-${os}-${arch}.tar.gz" -C /stage scopetui fleetview
+  rm -f /stage/scopetui /stage/fleetview
+  echo "built ${os}/${arch}"
+done
+
+BODY="Client binaries (scopetui, fleetview) cross-built in-cluster from ${V}."
+PAYLOAD=$(jq -n --arg t "$TAG" --arg n "$TITLE" --arg b "$BODY" \
+  '{tag_name:$t, name:$n, body:$b, draft:false, prerelease:true}')
+code=$(curl -s -o /tmp/r -w '%{http_code}' -X POST "$F/repos/${REPO}/releases" \
+  -H "Authorization: token ${FORGEJO_TOKEN}" -H 'Content-Type: application/json' -d "$PAYLOAD")
+case "$code" in
+  201) id=$(jq -r .id /tmp/r) ;;
+  409|422) id=$(curl -s "$F/repos/${REPO}/releases/tags/${TAG}" -H "Authorization: token ${FORGEJO_TOKEN}" | jq -r .id)
+           echo "release exists; attaching to it" ;;
+  *) echo "release create failed: $code"; head -c 300 /tmp/r; exit 1 ;;
+esac
+
+for f in /out/*.tar.gz; do
+  curl -s -o /dev/null -X POST "$F/repos/${REPO}/releases/${id}/assets?name=$(basename "$f")" \
+    -H "Authorization: token ${FORGEJO_TOKEN}" -F "attachment=@${f}"
+  echo "attached $(basename "$f")"
+done
+echo "release ready: https://code.phillips-homelab.net/${REPO}/releases/tag/${TAG}"


### PR DESCRIPTION
Casey was remote on a laptop with no way to fetch a macOS scopetui
build; the binary exceeded the chat upload limit and the laptop cannot
reach the build host. This adds `loopctl release <owner/repo> <tag>`,
which cross-builds scopetui and fleetview for darwin/arm64,
darwin/amd64 and linux/amd64 inside a helper pod and attaches the
archives to a Forgejo release.

The pod body lives in release-build.sh rather than inline: nesting a
build script inside loopctl's own quoting produced a script that
passed `bash -n` and then broke at runtime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `loopctl release` command for creating software releases from a repository tag.
  * Automatically builds and packages client binaries for macOS and Linux on supported architectures.
  * Publishes packaged artifacts to the corresponding Forgejo release.
  * Reuses existing releases when the specified tag has already been published.
  * Supports falling back to the repository’s default branch when a requested tag is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->