### PR TITLE
fix(loops): release-build writes under /tmp

### DIFF
--- a/loops/bin/release-build.sh
+++ b/loops/bin/release-build.sh
@@ -9,21 +9,21 @@
 set -euo pipefail
 
 F=http://forgejo-http.forgejo.svc.cluster.local:3000/api/v1
-git clone -q "https://oauth2:${FORGEJO_TOKEN}@code.phillips-homelab.net/${REPO}.git" /src
-cd /src
+git clone -q "https://oauth2:${FORGEJO_TOKEN}@code.phillips-homelab.net/${REPO}.git" /tmp/src
+cd /tmp/src
 git checkout -q "$TAG" 2>/dev/null || echo "tag $TAG not a ref yet; building from default branch"
 V=$(git describe --tags --always)
 
-mkdir -p /out /stage
+mkdir -p /tmp/out /tmp/stage
 for pair in darwin/arm64 darwin/amd64 linux/amd64; do
   os=${pair%/*}; arch=${pair#*/}
   for c in scopetui fleetview; do
     GOOS=$os GOARCH=$arch CGO_ENABLED=0 go build -trimpath \
       -ldflags="-s -w -X tycho.dev/agent/internal/version.Version=$V" \
-      -o "/stage/$c" "./agent/cmd/$c"
+      -o "/tmp/stage/$c" "./agent/cmd/$c"
   done
-  tar -czf "/out/tycho-${V}-${os}-${arch}.tar.gz" -C /stage scopetui fleetview
-  rm -f /stage/scopetui /stage/fleetview
+  tar -czf "/tmp/out/tycho-${V}-${os}-${arch}.tar.gz" -C /tmp/stage scopetui fleetview
+  rm -f /tmp/stage/scopetui /tmp/stage/fleetview
   echo "built ${os}/${arch}"
 done
 
@@ -39,7 +39,7 @@ case "$code" in
   *) echo "release create failed: $code"; head -c 300 /tmp/r; exit 1 ;;
 esac
 
-for f in /out/*.tar.gz; do
+for f in /tmp/out/*.tar.gz; do
   curl -s -o /dev/null -X POST "$F/repos/${REPO}/releases/${id}/assets?name=$(basename "$f")" \
     -H "Authorization: token ${FORGEJO_TOKEN}" -F "attachment=@${f}"
   echo "attached $(basename "$f")"


### PR DESCRIPTION
The release helper pod runs as the unprivileged `loop` user and cannot write to the paths `release-build.sh` used, so every release attempt failed on permission before it built anything.

Moves the clone, build output and staging directories under `/tmp`, which the unprivileged user owns.

Verified end to end: this script cut `scopetui-v0.2.0` with all three platform archives attached.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release build reliability by using temporary locations for source files and build artifacts.
  * Ensured packaged release assets are collected and uploaded from the correct temporary directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->