### PR TITLE
tycho adopt prep

### DIFF
--- a/gitops/tools/apps/tycho.yml
+++ b/gitops/tools/apps/tycho.yml
@@ -15,8 +15,8 @@ spec:
     repoURL: https://github.com/AlverezYari/phillips-homelab.git
     targetRevision: main
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    # Automation temporarily off while adopting the hand-applied tycho
+    # workloads (operator/gateway/scorer/seestar-proxy/agent) into this
+    # app. Re-enable (prune+selfHeal) once `argocd app diff` is clean.
     syncOptions:
       - CreateNamespace=true

--- a/loops/bin/release-build.sh
+++ b/loops/bin/release-build.sh
@@ -9,21 +9,21 @@
 set -euo pipefail
 
 F=http://forgejo-http.forgejo.svc.cluster.local:3000/api/v1
-git clone -q "https://oauth2:${FORGEJO_TOKEN}@code.phillips-homelab.net/${REPO}.git" /src
-cd /src
+git clone -q "https://oauth2:${FORGEJO_TOKEN}@code.phillips-homelab.net/${REPO}.git" /tmp/src
+cd /tmp/src
 git checkout -q "$TAG" 2>/dev/null || echo "tag $TAG not a ref yet; building from default branch"
 V=$(git describe --tags --always)
 
-mkdir -p /out /stage
+mkdir -p /tmp/out /tmp/stage
 for pair in darwin/arm64 darwin/amd64 linux/amd64; do
   os=${pair%/*}; arch=${pair#*/}
   for c in scopetui fleetview; do
     GOOS=$os GOARCH=$arch CGO_ENABLED=0 go build -trimpath \
       -ldflags="-s -w -X tycho.dev/agent/internal/version.Version=$V" \
-      -o "/stage/$c" "./agent/cmd/$c"
+      -o "/tmp/stage/$c" "./agent/cmd/$c"
   done
-  tar -czf "/out/tycho-${V}-${os}-${arch}.tar.gz" -C /stage scopetui fleetview
-  rm -f /stage/scopetui /stage/fleetview
+  tar -czf "/tmp/out/tycho-${V}-${os}-${arch}.tar.gz" -C /tmp/stage scopetui fleetview
+  rm -f /tmp/stage/scopetui /tmp/stage/fleetview
   echo "built ${os}/${arch}"
 done
 
@@ -39,7 +39,7 @@ case "$code" in
   *) echo "release create failed: $code"; head -c 300 /tmp/r; exit 1 ;;
 esac
 
-for f in /out/*.tar.gz; do
+for f in /tmp/out/*.tar.gz; do
   curl -s -o /dev/null -X POST "$F/repos/${REPO}/releases/${id}/assets?name=$(basename "$f")" \
     -H "Authorization: token ${FORGEJO_TOKEN}" -F "attachment=@${f}"
   echo "attached $(basename "$f")"


### PR DESCRIPTION
- **fix(loops): release-build writes under /tmp — helper pod runs as non-root**
- **chore(tycho): disable automated sync ahead of workload adoption**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deployment**
  * Automated synchronization, pruning, and self-healing are temporarily disabled for Tycho workloads. Changes must be applied manually until configuration differences are resolved.

* **Release Builds**
  * Release packaging now uses temporary build and output locations, keeping generated files isolated and ensuring only finalized archives are uploaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->