### PR TITLE
feat(tycho): adopt operator/gateway/scorer/seestar-proxy/agent into gitops

### DIFF
--- a/gitops/tools/apps/tycho/agent/kustomization.yaml
+++ b/gitops/tools/apps/tycho/agent/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - statefulset.yaml
+  - service.yaml
+  - service-api.yaml
+images:
+  # Pin to a real build before applying: set newTag to a tag `make
+  # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
+  # job) actually published, e.g. a git short sha.
+  - name: zot.phillips-homelab.net/tycho-agent
+    newTag: "0b57ae0"

--- a/gitops/tools/apps/tycho/agent/service-api.yaml
+++ b/gitops/tools/apps/tycho/agent/service-api.yaml
@@ -1,0 +1,25 @@
+# LoadBalancer Service exposing tycho.agent.v1.Agent (ADR 0004's gRPC
+# control API, AGENT_API_ADDR :9090) to LAN clients — scopetui phase 2
+# today, the operator later. Separate from service.yaml (the headless
+# Service the StatefulSet itself requires): that one is cluster-internal
+# by design, this one is deliberately reachable off-cluster.
+#
+# Stewardship (ADR 0004) is enforced by the agent process itself, not
+# by this Service — TYCHO_GRANTS/AGENT_API_TOKEN (statefulset.yaml)
+# gate what a LAN client can do once it connects.
+apiVersion: v1
+kind: Service
+metadata:
+  name: tycho-agent-api
+  namespace: tycho
+  labels:
+    app.kubernetes.io/name: tycho-agent
+    app.kubernetes.io/part-of: tycho
+spec:
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: tycho-agent
+  ports:
+    - name: agent-api
+      port: 9090
+      targetPort: agent-api

--- a/gitops/tools/apps/tycho/agent/service.yaml
+++ b/gitops/tools/apps/tycho/agent/service.yaml
@@ -1,0 +1,22 @@
+# Headless Service governing the StatefulSet (required: StatefulSet's
+# spec.serviceName must name one). Not a load-balanced/ClusterIP
+# service for other pods to call — the agent is southbound-only and has
+# no API of its own — this exists purely so the StatefulSet controller
+# has a governing Service, per k8s convention. /healthz and /readyz
+# stay reachable directly at the pod IP for kubelet probes without it.
+apiVersion: v1
+kind: Service
+metadata:
+  name: tycho-agent
+  namespace: tycho
+  labels:
+    app.kubernetes.io/name: tycho-agent
+    app.kubernetes.io/part-of: tycho
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: tycho-agent
+  ports:
+    - name: health
+      port: 8090
+      targetPort: health

--- a/gitops/tools/apps/tycho/agent/statefulset.yaml
+++ b/gitops/tools/apps/tycho/agent/statefulset.yaml
@@ -1,0 +1,150 @@
+# tycho-agent StatefulSet.
+#
+# StatefulSet (not Deployment) because the buffer directory must be
+# PVC-backed and survive pod restarts (SPEC: "files survive restarts
+# and re-enter the queue") — volumeClaimTemplates gives the single
+# replica a stable PVC that isn't torn down on rollout the way a bare
+# Deployment + PVC would be.
+#
+# Assumptions the operator should confirm/adjust before applying (SPEC:
+# real-infra integration is validated by the operator, not this loop):
+#   - Runs in the `tycho` namespace, alongside tycho-gateway
+#     (deploy/gateway/).
+#   - One replica per physical Seestar (SPEC scopes discovery to a
+#     static IP — no mDNS/scan this loop), so SCOPE_HOST and SOURCE_ID
+#     below are placeholders the operator sets per scope; deploying a
+#     second scope means copying this manifest set with a new name,
+#     SCOPE_HOST and SOURCE_ID.
+#   - `tycho-config` is the ESO-managed secret in the `tycho` namespace
+#     (ExternalSecret synced from 1Password by the homelab GitOps repo,
+#     not created here). Key `see_start_pem` holds the shared fleet
+#     interop RSA private key (PKCS#1 or PKCS#8 PEM — see
+#     agent/internal/zwo.LoadPrivateKey). It is mounted as a file and
+#     referenced by path (KEY_PATH), never placed in an env var — SPEC:
+#     "the fleet interop key must never appear in the repo in any form"
+#     and, by the same logic, never in a pod's env/logs either.
+#   - `tycho-config` also carries `IDENTITY_TOKEN` (the bearer token
+#     this source presents to tycho-gateway's register/heartbeat —
+#     identical by construction to the gateway's SOURCE_AUTH_TOKEN,
+#     same 1Password field), so no separate agent secret is needed.
+#   - `image` points at the registry `make images`/`make push` (repo
+#     root Makefile) and `.forgejo/workflows/ci.yml`'s tag-triggered
+#     job publish to (`REGISTRY ?= zot.phillips-homelab.net`). The tag
+#     below is a placeholder — pin it via this directory's
+#     `kustomization.yaml` `images[].newTag` (set to a real `make
+#     images`/CI build's tag, e.g. a git short sha) before applying.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tycho-agent
+  namespace: tycho
+  labels:
+    app.kubernetes.io/name: tycho-agent
+    app.kubernetes.io/part-of: tycho
+spec:
+  serviceName: tycho-agent
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tycho-agent
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tycho-agent
+    spec:
+      # Satisfies PodSecurity "restricted"; fsGroup makes the PVC-backed
+      # buffer writable by the scratch image's non-root user (without it,
+      # mkdir on the root-owned ext4 volume fails with EACCES — hit live
+      # on first deploy).
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: agent
+          image: zot.phillips-homelab.net/tycho-agent:latest # pin via kustomization.yaml images[].newTag — see comment above
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - name: health
+              containerPort: 8090
+            - name: agent-api
+              containerPort: 9090
+          env:
+            - name: SCOPE_HOST
+              value: "10.20.20.53" # S30 Pro on the home LAN (travel-router setup later will change this)
+            - name: SCOPE_CONTROL_HOST
+              # Control rides through seestar-proxy (one shared upstream
+              # connection for all tooling — see deploy/seestar-proxy/);
+              # HTTP :80 FITS retrieval stays direct via SCOPE_HOST.
+              value: "seestar-proxy.tycho.svc.cluster.local"
+            - name: KEY_PATH
+              value: /etc/tycho-agent/fleet-key/fleet-key.pem
+            - name: GATEWAY_URL
+              value: "http://tycho-gateway.tycho.svc.cluster.local"
+            - name: GATEWAY_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: tycho-config
+                  key: IDENTITY_TOKEN
+            - name: BUFFER_DIR
+              value: /var/lib/tycho-agent/buffer
+            - name: SOURCE_ID
+              value: "seestar-1" # placeholder — unique per agent instance/scope
+            - name: HEALTH_ADDR
+              value: ":8090"
+            - name: TYCHO_SITE_TZ
+              value: "America/Chicago" # backyard site tz; unset defaults to UTC (logged warning) per SPEC #21
+            - name: SESSION_SETTLE_SECONDS
+              value: "300" # manifest (re)writes only once a session is quiet this long; issue #33
+            - name: TYCHO_GRANTS
+              # ADR 0004 stewardship: the owner-granted capability tiers
+              # for the control API (AGENT_API_ADDR :9090, service-api.yaml).
+              # status,events,settings for the POC; "dispatch"/"debug" stay
+              # withheld until there's a real owner UI to grant them from.
+              value: "status,events,settings"
+            # AGENT_API_TOKEN (bearer token the control API requires in an
+            # `authorization: Bearer <token>` header) is deliberately unset
+            # here: no 1Password field for it exists in tycho-config yet.
+            # service-api.yaml's LoadBalancer puts the control API on the
+            # LAN, so set this (secretKeyRef, same pattern as GATEWAY_TOKEN
+            # above) before applying outside a trusted network — unset
+            # serves it unauthenticated and logs a loud startup warning.
+          volumeMounts:
+            - name: fleet-key
+              mountPath: /etc/tycho-agent/fleet-key
+              readOnly: true
+            - name: buffer
+              mountPath: /var/lib/tycho-agent/buffer
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 10
+            periodSeconds: 15
+      volumes:
+        - name: fleet-key
+          secret:
+            secretName: tycho-config
+            items:
+              - key: see_start_pem
+                path: fleet-key.pem
+  volumeClaimTemplates:
+    - metadata:
+        name: buffer
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 20Gi

--- a/gitops/tools/apps/tycho/gateway/deployment.yaml
+++ b/gitops/tools/apps/tycho/gateway/deployment.yaml
@@ -1,0 +1,111 @@
+# tycho-gateway Deployment.
+#
+# Assumptions the operator should confirm/adjust before applying (SPEC:
+# real-infra integration is validated by the operator, not this loop):
+#   - Runs in the `tycho` namespace. Garage runs in the `garage`
+#     namespace (bucket `tycho`, key `tycho-key`), NATS in `loops` —
+#     both reachable cross-namespace by the DNS names below. Garage
+#     requires region `garage` or it 400s (gateway defaults S3_REGION
+#     accordingly; set explicitly here anyway).
+#   - CNPG cluster is named `tycho-pg` in the `tycho` namespace, so its
+#     generated app-user secret is `tycho-pg-app` (CNPG's own naming
+#     convention: `<cluster-name>-app`, containing an `uri` key) —
+#     rename the secretKeyRef below if the real cluster is named
+#     differently. Not provisioned yet as of this writing.
+#   - `tycho-config` is the ESO-managed secret (ExternalSecret synced
+#     from 1Password by the homelab GitOps repo): S3_ACCESS_KEY_ID,
+#     S3_SECRET_ACCESS_KEY, SOURCE_AUTH_TOKEN (plus IDENTITY_TOKEN for
+#     the agent and see_start_pem for the fleet key). This manifest
+#     only references keys in it, never inlines values.
+#   - `image` points at the registry `make images`/`make push` (repo
+#     root Makefile) and `.forgejo/workflows/ci.yml`'s tag-triggered
+#     job publish to (`REGISTRY ?= zot.phillips-homelab.net`). The tag
+#     below is a placeholder — pin it via this directory's
+#     `kustomization.yaml` `images[].newTag` (set to a real `make
+#     images`/CI build's tag, e.g. a git short sha) before applying.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tycho-gateway
+  namespace: tycho
+  labels:
+    app.kubernetes.io/name: tycho-gateway
+    app.kubernetes.io/part-of: tycho
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tycho-gateway
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tycho-gateway
+    spec:
+      # Satisfies PodSecurity "restricted" (warnings observed on first
+      # deploy; the namespace may enforce it later).
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: gateway
+          image: zot.phillips-homelab.net/tycho-gateway:latest # pin via kustomization.yaml images[].newTag — see comment above
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: LISTEN_ADDR
+              value: ":8080"
+            - name: S3_ENDPOINT
+              value: "http://garage.garage.svc.cluster.local:3900"
+            - name: S3_REGION
+              value: "garage"
+            - name: S3_BUCKET
+              value: "tycho"
+            - name: S3_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: tycho-config
+                  key: S3_ACCESS_KEY_ID
+            - name: S3_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: tycho-config
+                  key: S3_SECRET_ACCESS_KEY
+            - name: POSTGRES_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: tycho-pg-app
+                  key: uri
+            - name: NATS_URL
+              valueFrom:
+                secretKeyRef:
+                  # Credentialed URL (nats://user:pass@host). Currently the
+                  # loops NATS `loop` user, hand-minted for the POC smoke
+                  # test — a dedicated tycho NATS user delivered via
+                  # tycho-config is queued as the durable fix (issue #29).
+                  name: tycho-nats
+                  key: NATS_URL
+            - name: SOURCE_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: tycho-config
+                  key: SOURCE_AUTH_TOKEN
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 15

--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+images:
+  # Pin to a real build before applying: set newTag to a tag `make
+  # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
+  # job) actually published, e.g. a git short sha.
+  - name: zot.phillips-homelab.net/tycho-gateway
+    newTag: "f29f094"

--- a/gitops/tools/apps/tycho/gateway/service.yaml
+++ b/gitops/tools/apps/tycho/gateway/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tycho-gateway
+  namespace: tycho
+  labels:
+    app.kubernetes.io/name: tycho-gateway
+    app.kubernetes.io/part-of: tycho
+spec:
+  selector:
+    app.kubernetes.io/name: tycho-gateway
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/gitops/tools/apps/tycho/kustomization.yaml
+++ b/gitops/tools/apps/tycho/kustomization.yaml
@@ -1,5 +1,25 @@
+# Tycho operator stack, adopted from hand-applied state 2026-07-28.
+# Workload manifests are vendored from loop-bot/tycho deploy/ @ e21ee60;
+# image tags there matched the live cluster exactly at adoption time
+# (kubectl diff was empty). Re-vendor from that repo when bumping.
+# The tycho namespace is NOT here: it is owned by the tycho-db app.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: tycho
 resources:
-- namespace.yaml
 - externalsecret.yaml
+- operator
+- gateway
+- scorer
+- seestar-proxy
+- agent
+patches:
+# If ArgoCD ever prunes a CRD it takes every custom resource with it —
+# here, every ImagingSession record of every night's capture. Never
+# auto-prune them.
+- target:
+    kind: CustomResourceDefinition
+  patch: |-
+    - op: add
+      path: /metadata/annotations/argocd.argoproj.io~1sync-options
+      value: Prune=false

--- a/gitops/tools/apps/tycho/namespace.yaml
+++ b/gitops/tools/apps/tycho/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: tycho

--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -1,0 +1,144 @@
+# tycho-operator Deployment.
+#
+# tycho5 items 2-5: Seestar status controller (NATS_URL,
+# SEESTAR_STALE_AFTER), session-close consumer + combine Job spawn
+# (SESSION_QUIESCENCE_TIMEOUT, COMBINE_IMAGE, COMBINE_S3_SECRET_NAME,
+# COMBINE_SCRATCH_SIZE), ntfy notifications (NTFY_URL, optional). tycho12
+# (issue #32 tier 2) adds the weather poller (WEATHER_ENABLED,
+# WEATHER_POLL_INTERVAL, WEATHER_USABLE_THRESHOLD_PERCENT) — see this
+# directory's README for the manual per-Seestar site-coordinate step
+# it depends on. See operator/main.go's loadConfig for the current,
+# authoritative env var list, and this directory's README for the
+# combine Job template's container contract (env vars the image
+# COMBINE_IMAGE points at must honor).
+#
+# COMBINE_IMAGE below points at a real, pushed image and is bumped by
+# hand whenever combine/ changes in a way a running cluster needs. It
+# is not tracked by kustomization.yaml images[], because it names the
+# image the operator writes into Job specs rather than an image the
+# operator itself runs.
+#
+# Assumptions the operator should confirm/adjust before applying (SPEC:
+# real-infra integration is validated by the operator, not this loop):
+#   - Runs in the `tycho` namespace, alongside tycho-gateway and
+#     tycho-agent (deploy/gateway/, deploy/agent/).
+#   - Single replica: the operator does not need HA for this loop's
+#     scope (leader election is wired but off by default via
+#     LEADER_ELECT; flip it on and raise replicas together if that
+#     changes).
+#   - `image` points at the registry `make images`/`make push` (repo
+#     root Makefile) and `.forgejo/workflows/ci.yml`'s tag-triggered
+#     job publish to (`REGISTRY ?= zot.phillips-homelab.net`). The tag
+#     below is a placeholder — pin it via this directory's
+#     `kustomization.yaml` `images[].newTag` (set to a real `make
+#     images`/CI build's tag, e.g. a git short sha) before applying.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tycho-operator
+  namespace: tycho
+  labels:
+    app.kubernetes.io/name: tycho-operator
+    app.kubernetes.io/part-of: tycho
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tycho-operator
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tycho-operator
+    spec:
+      serviceAccountName: tycho-operator
+      # Satisfies PodSecurity "restricted", matching gateway/agent.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          image: zot.phillips-homelab.net/tycho-operator:latest # pin via kustomization.yaml images[].newTag — see comment above
+          ports:
+            - name: metrics
+              containerPort: 8080
+            - name: health
+              containerPort: 8081
+          env:
+            - name: METRICS_ADDR
+              value: ":8080"
+            - name: HEALTH_PROBE_ADDR
+              value: ":8081"
+            - name: LEADER_ELECT
+              value: "false"
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NATS_URL
+              valueFrom:
+                secretKeyRef:
+                  # Credentialed URL — loops NATS requires auth; same
+                  # borrowed secret as the gateway until issue #29 lands.
+                  name: tycho-nats
+                  key: NATS_URL
+            # SEESTAR_STALE_AFTER is optional (default 3m, ~3x
+            # tycho-agent's default 60s heartbeat interval); set
+            # explicitly here so cluster behavior doesn't silently
+            # follow whatever operator/main.go's default happens to be.
+            - name: SEESTAR_STALE_AFTER
+              value: "3m"
+            # SESSION_QUIESCENCE_TIMEOUT is optional (default 5m, per
+            # BRIEF.md's "quiescence timeout ~5 min" fallback).
+            - name: SESSION_QUIESCENCE_TIMEOUT
+              value: "5m"
+            # COMBINE_IMAGE/COMBINE_S3_SECRET_NAME are required — the
+            # operator fails closed at startup without them. See the
+            # placeholder-image note above.
+            - name: COMBINE_IMAGE
+              value: "zot.phillips-homelab.net/tycho-combine:9bb5cce" # PRs #96/#97: partition before load, and combinability is RGB-and-solved
+            - name: COMBINE_S3_SECRET_NAME
+              value: "tycho-combine-s3" # hand-minted from tycho-config values — see README
+            # COMBINE_SCRATCH_SIZE is optional (default 10Gi): the
+            # emptyDir size limit for the combine Job's scratch volume.
+            - name: COMBINE_SCRATCH_SIZE
+              value: "10Gi"
+            # NTFY_URL is optional: a full ntfy topic URL for
+            # best-effort session-close/combine-result notifications.
+            # Unset (the default — no value here) disables
+            # notifications entirely; there's no real topic to point at
+            # yet, so it's deliberately left unset rather than set to a
+            # placeholder that would silently start posting somewhere.
+            # - name: NTFY_URL
+            #   value: "https://ntfy.sh/your-topic-here"
+            # WEATHER_ENABLED is the tier-2 sky-conditions kill-switch
+            # (default true); flip to "false" to disable Open-Meteo
+            # polling entirely without a rollout.
+            - name: WEATHER_ENABLED
+              value: "true"
+            # WEATHER_POLL_INTERVAL is optional (default 30m).
+            - name: WEATHER_POLL_INTERVAL
+              value: "30m"
+            # WEATHER_USABLE_THRESHOLD_PERCENT is optional (default
+            # 40): status.sky.usable is true when cloud cover is below
+            # this percentage.
+            - name: WEATHER_USABLE_THRESHOLD_PERCENT
+              value: "40"
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 10
+            periodSeconds: 15

--- a/gitops/tools/apps/tycho/operator/fleet.tycho.dev_fleetmasters.yaml
+++ b/gitops/tools/apps/tycho/operator/fleet.tycho.dev_fleetmasters.yaml
@@ -1,0 +1,214 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: fleetmasters.fleet.tycho.dev
+spec:
+  group: fleet.tycho.dev
+  names:
+    kind: FleetMaster
+    listKind: FleetMasterList
+    plural: fleetmasters
+    shortNames:
+    - fmaster
+    singular: fleetmaster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.target
+      name: Target
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.combinedSessionIDs
+      name: Sessions
+      type: string
+    - jsonPath: .status.revision
+      name: Revision
+      type: integer
+    - jsonPath: .status.masterJobRef.name
+      name: Job
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          FleetMaster is the cross-source depth-combine of one target's
+          per-session results across every (or an allow-listed subset of)
+          contributing source: the fleet's whole reason to exist is pooling
+          frames from *different* scopes shooting the *same* target into one
+          deeper integration, rather than leaving TargetMaster's per-source
+          nightly stacks siloed by scope. Declared explicitly by creating this
+          CR (unlike TargetMaster, which the operator auto-creates once a
+          source's own target reaches 2 combinable nights), since cross-source
+          pooling is an explicit opt-in.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              FleetMasterSpec declares one target as fleet-pooled: every source's
+              combinable sessions for Target (not just one source's, unlike
+              TargetMaster) are combined into a single cross-source master.
+            properties:
+              sourceAllowList:
+                description: |-
+                  SourceAllowList restricts which sources' sessions may contribute
+                  to this fleet master. Empty (the default) means every source --
+                  the common case for "pool the whole fleet on this target".
+                items:
+                  type: string
+                type: array
+              target:
+                description: |-
+                  Target is the target-slug shared by every contributing session's
+                  ImagingSessionSpec.Target (internal/targetmaster.SlugFromSessionID),
+                  same derivation TargetMasterSpec.Target uses.
+                minLength: 1
+                type: string
+            required:
+            - target
+            type: object
+          status:
+            description: |-
+              FleetMasterStatus tracks the latest cross-source combine Job's
+              progress, which sessions it covers, and which sources contributed.
+            properties:
+              actualCombinedSessionIDs:
+                description: |-
+                  ActualCombinedSessionIDs is the oldest-first SessionID list the
+                  current Revision's Job ACTUALLY combined, per its completion
+                  report. Falls back to CombinedSessionIDs when no report is
+                  available. Mirrors TargetMasterStatus.ActualCombinedSessionIDs.
+                items:
+                  type: string
+                type: array
+              combinedSessionIDs:
+                description: |-
+                  CombinedSessionIDs is the oldest-first ImagingSessionSpec.SessionID
+                  list the current Revision's Job was ASKED to combine, spanning
+                  every contributing source -- spawn-time intent, mirrors
+                  TargetMasterStatus.CombinedSessionIDs.
+                items:
+                  type: string
+                type: array
+              contributingSources:
+                description: |-
+                  ContributingSources is the spawn-time per-source breakdown of
+                  CombinedSessionIDs (SPEC: "honest provenance" -- contributing
+                  sources + per-source frame counts must be visible here, not
+                  collapsed into a single total), oldest-contributing-source-first
+                  by SourceID.
+                items:
+                  description: |-
+                    FleetMasterSourceContribution records one source's contribution to a
+                    fleet master's combined input set -- the per-source breakdown a
+                    single pooled total would otherwise hide.
+                  properties:
+                    frameCount:
+                      description: |-
+                        FrameCount is the sum of ImagingSessionStatus.SubCount across
+                        that source's contributing sessions -- the closest v0 has to a
+                        "how many subs did this source contribute" figure, since the
+                        operator has no S3 access to read frame counts out of the
+                        combined result itself.
+                      format: int32
+                      type: integer
+                    sessionCount:
+                      description: |-
+                        SessionCount is how many of that source's combinable sessions
+                        were folded into the current Revision.
+                      format: int32
+                      type: integer
+                    sourceID:
+                      description: SourceID is the contributing Seestar's tycho-agent source id.
+                      type: string
+                  required:
+                  - frameCount
+                  - sessionCount
+                  - sourceID
+                  type: object
+                type: array
+              droppedSessionIDs:
+                description: |-
+                  DroppedSessionIDs is the subset of CombinedSessionIDs the current
+                  Revision's Job excluded from the actual combine (frame-kind
+                  mismatch), per the same completion report.
+                items:
+                  type: string
+                type: array
+              masterCompletedAt:
+                description: |-
+                  MasterCompletedAt is when the current Revision's Job finished
+                  (success or failure).
+                format: date-time
+                type: string
+              masterJobRef:
+                description: MasterJobRef names the k8s Job spawned for the current Revision.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              masterStartedAt:
+                description: MasterStartedAt is when the current Revision's Job was created.
+                format: date-time
+                type: string
+              phase:
+                description: Phase is the fleet master's current lifecycle state.
+                enum:
+                - Combining
+                - Done
+                - Failed
+                type: string
+              resultKey:
+                description: |-
+                  ResultKey is the Garage object key the current Revision's Job
+                  writes the combined output to (fleet-masters/{target}/master.fit,
+                  schemas/object-layout.md's "Fleet masters (cross-source)"
+                  section -- deliberately not rooted under any single source's
+                  tycho-source-{id}/ prefix, since the result belongs to no one
+                  source).
+                type: string
+              revision:
+                description: |-
+                  Revision is the fleet combine Job revision MasterJobRef currently
+                  names: 1 for the first Job, 2+ for a recombine spawned because
+                  further sessions became combinable after an earlier revision
+                  already completed. Mirrors TargetMasterStatus.Revision.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/gitops/tools/apps/tycho/operator/fleet.tycho.dev_imagingsessions.yaml
+++ b/gitops/tools/apps/tycho/operator/fleet.tycho.dev_imagingsessions.yaml
@@ -1,0 +1,235 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: imagingsessions.fleet.tycho.dev
+spec:
+  group: fleet.tycho.dev
+  names:
+    kind: ImagingSession
+    listKind: ImagingSessionList
+    plural: imagingsessions
+    shortNames:
+    - imsess
+    singular: imagingsession
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.sourceID
+      name: Source
+      type: string
+    - jsonPath: .spec.sessionID
+      name: Session
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.closeReason
+      name: CloseReason
+      type: string
+    - jsonPath: .status.subCount
+      name: Subs
+      type: integer
+    - jsonPath: .status.combineJobRef.name
+      name: Job
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ImagingSession is one observing-night session for one Seestar,
+          tracked from open through combine-job completion.
+
+          CaptureProgram and Observation are reserved for fleet scheduling
+          (BRIEF.md) and are deliberately not implemented here.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              ImagingSessionSpec identifies one observing-night session and where
+              its objects live in Garage.
+            properties:
+              objectPrefix:
+                description: |-
+                  ObjectPrefix is the Garage key prefix for this session's objects
+                  (schemas/object-layout.md), e.g.
+                  "tycho-source-{id}/sessions/{sessionID}/".
+                minLength: 1
+                type: string
+              sessionID:
+                description: |-
+                  SessionID is the session identity used in event envelopes and
+                  the object layout (sessions/{sessionID}/...).
+                minLength: 1
+                type: string
+              sourceID:
+                description: SourceID is the owning Seestar's tycho-agent source id.
+                minLength: 1
+                type: string
+              target:
+                description: |-
+                  Target is this session's target slug: the human-facing path
+                  component used in a target master's location
+                  (masters/{target-slug}/, schemas/object-layout.md) and CR names.
+                  Session grouping and matching itself is decided by sky position,
+                  not by this string (docs/ATTRIBUTION.md, "Target identity is
+                  matched by name, not by sky position") -- see
+                  internal/targetmaster.CombinableSessions and .ResolveTargetSlug,
+                  which choose Target deterministically from TargetRADeg/
+                  TargetDecDeg when available, falling back to a name-derived slug
+                  (SlugFromSessionID) otherwise.
+                type: string
+              targetDecDeg:
+                description: |-
+                  TargetRADeg and TargetDecDeg are this session's target sky
+                  position in degrees (ICRS-like RA/Dec), forwarded from the
+                  session's manifest.json target block
+                  (schemas/manifest.schema.json) via the tycho.session.closed
+                  event's optional target_ra_deg/target_dec_deg fields
+                  (schemas/tycho.session.closed.schema.json) at session-close
+                  time -- the operator has no S3 access to read manifest.json
+                  directly (SPEC guardrail), so the closing event is the only
+                  route a position can reach it by. Both are nil together for a
+                  session whose close event didn't carry one: a quiescence-timeout
+                  close never reads a manifest at all, and an older or malformed
+                  manifest may lack a usable target block.
+                  internal/targetmaster falls back to Target-slug matching for
+                  such a session rather than dropping it from its target's
+                  grouping (docs/ATTRIBUTION.md's "fall back to name grouping"
+                  guardrail).
+                type: number
+              targetRADeg:
+                description: |-
+                  TargetRADeg and TargetDecDeg are this session's target sky
+                  position in degrees (ICRS-like RA/Dec), forwarded from the
+                  session's manifest.json target block
+                  (schemas/manifest.schema.json) via the tycho.session.closed
+                  event's optional target_ra_deg/target_dec_deg fields
+                  (schemas/tycho.session.closed.schema.json) at session-close
+                  time -- the operator has no S3 access to read manifest.json
+                  directly (SPEC guardrail), so the closing event is the only
+                  route a position can reach it by. Both are nil together for a
+                  session whose close event didn't carry one: a quiescence-timeout
+                  close never reads a manifest at all, and an older or malformed
+                  manifest may lack a usable target block.
+                  internal/targetmaster falls back to Target-slug matching for
+                  such a session rather than dropping it from its target's
+                  grouping (docs/ATTRIBUTION.md's "fall back to name grouping"
+                  guardrail).
+                type: number
+            required:
+            - objectPrefix
+            - sessionID
+            - sourceID
+            type: object
+          status:
+            description: |-
+              ImagingSessionStatus tracks close detection and the resulting
+              combine Job.
+            properties:
+              closeReason:
+                description: |-
+                  CloseReason records how the session's close was detected, once
+                  closed.
+                enum:
+                - clean
+                - quiescence
+                type: string
+              closedAt:
+                description: |-
+                  ClosedAt is when the session was detected closed (clean or
+                  quiescence).
+                format: date-time
+                type: string
+              combineCompletedAt:
+                description: |-
+                  CombineCompletedAt is when the combine Job finished (success or
+                  failure).
+                format: date-time
+                type: string
+              combineJobRef:
+                description: |-
+                  CombineJobRef names the k8s Job spawned to combine this
+                  session's subs, once one has been created.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              combineStartedAt:
+                description: CombineStartedAt is when the combine Job was created.
+                format: date-time
+                type: string
+              combinedSubCount:
+                description: |-
+                  CombinedSubCount is the sub_count Revision's combine Job was
+                  spawned to combine. Compared against a later close event's
+                  sub_count to detect the session growing past what the latest
+                  revision covered.
+                format: int32
+                type: integer
+              phase:
+                description: Phase is the session's current lifecycle state.
+                enum:
+                - Open
+                - Closed
+                - Combining
+                - Done
+                - Failed
+                type: string
+              resultKeys:
+                description: |-
+                  ResultKeys lists the Garage object keys the combine Job produced,
+                  populated on successful completion.
+                items:
+                  type: string
+                type: array
+              revision:
+                description: |-
+                  Revision is the combine Job revision CombineJobRef currently
+                  names: 1 for the session's original combine, 2+ for a recombine
+                  spawned because the session grew (more subs closed) after an
+                  earlier revision already completed. Part of the Job's name
+                  (stack-<sessionID> for revision 1, stack-<sessionID>-r2 for
+                  revision 2, ...) so redelivered/duplicate close signals for the
+                  same revision keep hitting the same deterministic name.
+                format: int32
+                type: integer
+              subCount:
+                description: SubCount is the accepted-sub count as of close.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/gitops/tools/apps/tycho/operator/fleet.tycho.dev_seestars.yaml
+++ b/gitops/tools/apps/tycho/operator/fleet.tycho.dev_seestars.yaml
@@ -1,0 +1,202 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: seestars.fleet.tycho.dev
+spec:
+  group: fleet.tycho.dev
+  names:
+    kind: Seestar
+    listKind: SeestarList
+    plural: seestars
+    shortNames:
+    - ss
+    singular: seestar
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.sourceID
+      name: Source
+      type: string
+    - jsonPath: .status.connected
+      name: Connected
+      type: boolean
+    - jsonPath: .status.verified
+      name: Verified
+      type: boolean
+    - jsonPath: .status.ready
+      name: Ready
+      type: boolean
+    - jsonPath: .status.sky.summary
+      name: SKY
+      type: string
+    - jsonPath: .status.model
+      name: Model
+      type: string
+    - jsonPath: .status.lastSeen
+      name: LastSeen
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Seestar is the fleet-inventory record for one physical Seestar
+          telescope, keyed by its tycho-agent source id.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SeestarSpec describes a single fleet member (one physical
+              Seestar).
+            properties:
+              displayName:
+                description: |-
+                  DisplayName is an optional human-friendly name shown alongside
+                  SourceID in tooling and notifications.
+                type: string
+              site:
+                description: |-
+                  Site is an optional label for the scope's physical location
+                  (e.g. a site/backyard name), informational only.
+                type: string
+              siteLatitude:
+                description: |-
+                  SiteLatitude is the site's latitude in decimal degrees, used by
+                  the weather controller to query Open-Meteo for sky conditions
+                  (issue #32 tier 2). Optional and settable now; the operator may
+                  also learn it from a future agent API, so treat this as
+                  best-known-so-far rather than necessarily authoritative. Both
+                  SiteLatitude and SiteLongitude must be set for weather polling
+                  to happen for this Seestar.
+                maximum: 90
+                minimum: -90
+                type: number
+              siteLongitude:
+                description: |-
+                  SiteLongitude is the site's longitude in decimal degrees. See
+                  SiteLatitude.
+                maximum: 180
+                minimum: -180
+                type: number
+              sourceID:
+                description: |-
+                  SourceID is the tycho-agent source identity for this scope, as
+                  used in tycho.source.* / tycho.session.* event envelopes and in
+                  the Garage object layout (tycho-source-{id}/...). Immutable in
+                  practice: identifies which agent this CR tracks.
+                minLength: 1
+                type: string
+            required:
+            - sourceID
+            type: object
+          status:
+            description: |-
+              SeestarStatus reports what the operator has last observed about a
+              Seestar from tycho.source.registered / tycho.source.heartbeat events.
+            properties:
+              battery:
+                description: Battery is the last reported battery level (percent),
+                  when known.
+                format: int32
+                type: integer
+              connected:
+                description: |-
+                  Connected is true while heartbeats keep arriving within the
+                  staleness threshold; false once it's timed out.
+                type: boolean
+              firmware:
+                description: Firmware is the scope's reported firmware version, when
+                  known.
+                type: string
+              lastSeen:
+                description: |-
+                  LastSeen is the timestamp of the most recently processed
+                  registered/heartbeat event for this source.
+                format: date-time
+                type: string
+              model:
+                description: Model is the scope's reported hardware model.
+                type: string
+              ready:
+                description: |-
+                  Ready mirrors Verified && Connected, computed by the controller
+                  on every reconcile so it can be surfaced as a printer column
+                  without a client evaluating both fields itself.
+                type: boolean
+              sky:
+                description: |-
+                  Sky is the site's most recently polled cloud cover, populated by
+                  the weather controller once this Seestar has both SiteLatitude
+                  and SiteLongitude set (issue #32 tier 2). Zero value until the
+                  first successful poll.
+                properties:
+                  bestHourAt:
+                    description: BestHourAt is the hour BestHourCloudCoverPercent
+                      applies to.
+                    format: date-time
+                    type: string
+                  bestHourCloudCoverPercent:
+                    description: |-
+                      BestHourCloudCoverPercent is the lowest cloud cover percentage
+                      forecast within the next 6 hours, when known.
+                    format: int32
+                    type: integer
+                  cloudCoverPercent:
+                    description: |-
+                      CloudCoverPercent is the current cloud cover percentage (0-100)
+                      at the site, from the most recent successful poll.
+                    format: int32
+                    type: integer
+                  fetchedAt:
+                    description: |-
+                      FetchedAt is when CloudCoverPercent was last successfully
+                      fetched. A FetchedAt that stops advancing while the Seestar
+                      stays reconciled means recent polls are failing (fail-soft):
+                      the last known-good reading is kept and shown.
+                    format: date-time
+                    type: string
+                  summary:
+                    description: |-
+                      Summary is a compact human-readable rendering of the current
+                      reading for the SKY printer column, e.g. "19% ✓" / "87% ✗".
+                      Computed by the controller alongside the other fields so the
+                      printer column doesn't need string formatting in JSONPath.
+                    type: string
+                  usable:
+                    description: |-
+                      Usable reports whether CloudCoverPercent is below the
+                      configured usability threshold (WEATHER_USABLE_THRESHOLD_PERCENT,
+                      default 40). False if no reading has been taken yet.
+                    type: boolean
+                type: object
+              verified:
+                description: |-
+                  Verified reflects that the agent completed the ZWO auth
+                  handshake and successfully registered with the gateway.
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/gitops/tools/apps/tycho/operator/fleet.tycho.dev_targetmasters.yaml
+++ b/gitops/tools/apps/tycho/operator/fleet.tycho.dev_targetmasters.yaml
@@ -1,0 +1,194 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: targetmasters.fleet.tycho.dev
+spec:
+  group: fleet.tycho.dev
+  names:
+    kind: TargetMaster
+    listKind: TargetMasterList
+    plural: targetmasters
+    shortNames:
+    - tmaster
+    singular: targetmaster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.sourceID
+      name: Source
+      type: string
+    - jsonPath: .spec.target
+      name: Target
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.combinedSessionIDs
+      name: Sessions
+      type: string
+    - jsonPath: .status.actualCombinedSessionIDs
+      name: Actual
+      type: string
+    - jsonPath: .status.revision
+      name: Revision
+      type: integer
+    - jsonPath: .status.masterJobRef.name
+      name: Job
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          TargetMaster is the cross-night depth-combine of one (source,
+          target)'s per-session results (tycho16, #49): whenever a session's
+          own combine succeeds and its target has >=2 nights of combinable
+          data, the operator spawns/refreshes this target's master combine
+          Job, deepening masters/{target}/master.fit night over night instead
+          of leaving per-session stacks siloed.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              TargetMasterSpec identifies the (source, target) a master combines
+              across all of that target's combinable per-session results. No
+              filter component: v0 combines every filter state for a target into
+              one master.
+            properties:
+              sourceID:
+                description: SourceID is the owning Seestar's tycho-agent source id.
+                minLength: 1
+                type: string
+              target:
+                description: |-
+                  Target is the target-slug shared by every contributing session's
+                  ImagingSessionSpec.Target (internal/targetmaster.SlugFromSessionID).
+                minLength: 1
+                type: string
+            required:
+            - sourceID
+            - target
+            type: object
+          status:
+            description: |-
+              TargetMasterStatus tracks the latest master combine Job's progress
+              and which sessions it covers.
+            properties:
+              actualCombinedSessionIDs:
+                description: |-
+                  ActualCombinedSessionIDs is the oldest-first SessionID list the
+                  current Revision's master Job ACTUALLY combined, per its
+                  completion report (job.py's TYCHO_TERMINATION_MESSAGE_PATH JSON,
+                  read off the Job's Pod termination message -- the operator's only
+                  ground-truth channel, since it has no S3 access). This is what the
+                  ntfy "N nights deep" wording and the tycho.job.master.succeeded
+                  event's nights/session_ids report -- CombinedSessionIDs must not
+                  be used for those (SPEC review H3, #57). Falls back to
+                  CombinedSessionIDs (spawn-time intent) when an older combine image
+                  predating the completion report, or a GC'd Pod, leaves no report
+                  to read -- best-effort, not a hard requirement, so a missing
+                  report degrades reporting instead of failing the combine.
+                items:
+                  type: string
+                type: array
+              combinedSessionIDs:
+                description: |-
+                  CombinedSessionIDs is the oldest-first ImagingSessionSpec.SessionID
+                  list the current Revision's master Job was ASKED to combine
+                  (targetmaster.CombinableSessions' result at spawn time). Used only
+                  to detect growth (a new night became combinable) versus a true
+                  duplicate trigger (no growth -- dedupe, no new revision) --
+                  spawn-time intent, not a claim about what actually landed in
+                  master.fit. See ActualCombinedSessionIDs for that (SPEC review H3,
+                  #57): a session reaching Done is no guarantee its result is
+                  RGB-combinable (combine_controller.markDone sets Done from k8s Job
+                  success alone, the operator has no S3 access to check frame kind),
+                  so the master Job can silently drop one of these sessions.
+                items:
+                  type: string
+                type: array
+              droppedSessionIDs:
+                description: |-
+                  DroppedSessionIDs is the subset of CombinedSessionIDs the current
+                  Revision's master Job excluded from the actual combine (frame-kind
+                  mismatch -- an all-mono session result, v0 policy issue #45), per
+                  the same completion report as ActualCombinedSessionIDs. Empty when
+                  nothing was dropped or no report was available.
+                items:
+                  type: string
+                type: array
+              masterCompletedAt:
+                description: |-
+                  MasterCompletedAt is when the current Revision's master Job
+                  finished (success or failure).
+                format: date-time
+                type: string
+              masterJobRef:
+                description: MasterJobRef names the k8s Job spawned for the current Revision.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              masterStartedAt:
+                description: MasterStartedAt is when the current Revision's master Job was created.
+                format: date-time
+                type: string
+              phase:
+                description: Phase is the master's current lifecycle state.
+                enum:
+                - Combining
+                - Done
+                - Failed
+                type: string
+              resultKey:
+                description: |-
+                  ResultKey is the Garage object key the current Revision's master
+                  Job writes the combined output to
+                  (masters/{target}/master.fit, schemas/object-layout.md).
+                type: string
+              revision:
+                description: |-
+                  Revision is the master combine Job revision MasterJobRef
+                  currently names: 1 for the first master Job (spawned once a
+                  target reaches 2 combinable nights), 2+ for a recombine spawned
+                  because a further night's session became combinable after an
+                  earlier revision already completed. Part of the Job's name
+                  (master-<target> for revision 1, master-<target>-r2 for revision
+                  2, ...), mirroring ImagingSessionStatus.Revision (#33).
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - fleet.tycho.dev_seestars.yaml
+  - fleet.tycho.dev_imagingsessions.yaml
+  - fleet.tycho.dev_targetmasters.yaml
+  - fleet.tycho.dev_fleetmasters.yaml
+  - rbac.yaml
+  - deployment.yaml
+images:
+  # Pin to a real build before applying: set newTag to a tag `make
+  # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
+  # job) actually published, e.g. a git short sha.
+  - name: zot.phillips-homelab.net/tycho-operator
+    newTag: "d8ae6fa"

--- a/gitops/tools/apps/tycho/operator/rbac.yaml
+++ b/gitops/tools/apps/tycho/operator/rbac.yaml
@@ -1,0 +1,58 @@
+# tycho-operator RBAC.
+#
+# ClusterRole is generated from the +kubebuilder:rbac markers in
+# operator/main.go — regenerate with:
+#
+#   controller-gen rbac:roleName=tycho-operator paths=./operator/... \
+#     output:rbac:dir=/tmp/rbacgen
+#
+# and copy the resulting role.yaml's `rules:` back in here (the
+# ClusterRoleBinding/ServiceAccount below are hand-maintained, not
+# generated).
+#
+# Cluster-scoped (not a Role) because Seestar/ImagingSession are
+# namespaced but the operator is meant to run as a single
+# cluster-wide instance watching one namespace's worth of CRs today
+# with room to watch more without an RBAC change later.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tycho-operator
+  namespace: tycho
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tycho-operator
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["fleet.tycho.dev"]
+    resources: ["imagingsessions", "seestars", "targetmasters", "fleetmasters"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["fleet.tycho.dev"]
+    resources: ["imagingsessions/status", "seestars/status", "targetmasters/status", "fleetmasters/status"]
+    verbs: ["get", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tycho-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tycho-operator
+subjects:
+  - kind: ServiceAccount
+    name: tycho-operator
+    namespace: tycho

--- a/gitops/tools/apps/tycho/scorer/deployment.yaml
+++ b/gitops/tools/apps/tycho/scorer/deployment.yaml
@@ -1,0 +1,98 @@
+# tycho-scorer Deployment.
+#
+# No Service/probes here, unlike tycho-gateway/tycho-agent/
+# tycho-operator: tycho-scorer is a pure JetStream pull consumer with
+# no HTTP server (see scorer/src/tycho_scorer/service.py — it opens no
+# listening port), so there's nothing for a readinessProbe/livenessProbe
+# to hit. Liveness in practice is "the pull loop is still fetching",
+# which Kubernetes can't observe without adding a health endpoint the
+# code doesn't have; revisit if that becomes a real operability gap.
+#
+# Assumptions the operator should confirm/adjust before applying (SPEC:
+# real-infra integration is validated by the operator, not this loop):
+#   - Runs in the `tycho` namespace, alongside tycho-gateway/
+#     tycho-agent/tycho-operator.
+#   - CNPG cluster `tycho-pg` in the `tycho` namespace has produced its
+#     `tycho-pg-app` secret (CNPG's `<cluster-name>-app` convention,
+#     `uri` key) — same secret the gateway already reads
+#     (deploy/gateway/deployment.yaml). The `score` table it writes to
+#     is created by the gateway's own migration
+#     (gateway/internal/catalog/migrations/0001_init.sql); the scorer
+#     is a second writer against it, not a second schema owner (see
+#     scorer/src/tycho_scorer/catalog.py's docstring).
+#   - `tycho-nats` is the same hand-minted NATS credential secret
+#     (`NATS_URL` key) tycho-gateway/tycho-operator already use — see
+#     their manifests' own notes that a dedicated tycho NATS user is
+#     the queued durable fix (issue #29).
+#   - `tycho-scorer-s3` is a hand-minted Secret (from tycho-config's
+#     Garage values, same values as tycho-combine-s3 — see
+#     deploy/operator/README.md's Combine Job template section) with
+#     keys S3_ENDPOINT, S3_REGION, S3_BUCKET, AWS_ACCESS_KEY_ID,
+#     AWS_SECRET_ACCESS_KEY, consumed via `envFrom` exactly like the
+#     operator's combine Job template consumes
+#     `COMBINE_S3_SECRET_NAME` — a separate K8s object from
+#     tycho-combine-s3 (SPEC: this loop doesn't touch combine/), same
+#     key names inside it, per scorer/src/tycho_scorer/service.py's
+#     env-contract docstring. Not provisioned by this manifest set.
+#   - `image` points at the registry `make images`/`make push` (repo
+#     root Makefile) and `.forgejo/workflows/ci.yml`'s tag-triggered
+#     job publish to (`REGISTRY ?= zot.phillips-homelab.net`). The tag
+#     below is a placeholder — pin it via this directory's
+#     `kustomization.yaml` `images[].newTag` (set to a real `make
+#     images`/CI build's tag, e.g. a git short sha) before applying.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tycho-scorer
+  namespace: tycho
+  labels:
+    app.kubernetes.io/name: tycho-scorer
+    app.kubernetes.io/part-of: tycho
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tycho-scorer
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tycho-scorer
+    spec:
+      # Satisfies PodSecurity "restricted", matching
+      # gateway/agent/operator.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: scorer
+          image: zot.phillips-homelab.net/tycho-scorer:latest # pin via kustomization.yaml images[].newTag — see comment above
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          envFrom:
+            # S3_ENDPOINT, S3_REGION, S3_BUCKET, AWS_ACCESS_KEY_ID,
+            # AWS_SECRET_ACCESS_KEY — same key names combine's Job
+            # contract documents (docs/adr/0003-combine-engine.md),
+            # dumped as env vars the same way the operator's combine
+            # Job template consumes COMBINE_S3_SECRET_NAME.
+            - secretRef:
+                name: tycho-scorer-s3
+          env:
+            - name: NATS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: tycho-nats
+                  key: NATS_URL
+            - name: POSTGRES_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: tycho-pg-app
+                  key: uri
+            # TYCHO_SCORER_MAX_DELIVER/TYCHO_SCORER_DURABLE are
+            # optional (defaults 5, "tycho-scorer" —
+            # scorer/src/tycho_scorer/service.py) and deliberately
+            # left unset here: no reason yet to override either.

--- a/gitops/tools/apps/tycho/scorer/kustomization.yaml
+++ b/gitops/tools/apps/tycho/scorer/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+images:
+  # Pin to a real build before applying: set newTag to a tag `make
+  # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
+  # job) actually published, e.g. a git short sha.
+  - name: zot.phillips-homelab.net/tycho-scorer
+    newTag: "714d5e0"

--- a/gitops/tools/apps/tycho/seestar-proxy/deployment.yaml
+++ b/gitops/tools/apps/tycho/seestar-proxy/deployment.yaml
@@ -1,0 +1,50 @@
+# seestar-proxy: TCP multiplexer in front of the scope's :4700 control
+# socket (github.com/astrophotograph/seestar-proxy, MIT, run from the
+# upstream release binary wrapped in a scratch image).
+#
+# Why: the firmware limits which clients get real control (master-cli /
+# verified-client arbitration — docs/seestar-fleet-context.md §8), so
+# every tycho tool sharing ONE upstream connection through this proxy
+# sidesteps the contention: the proxy is the scope's single control
+# client; agent, scopetui, and future tooling all connect here instead.
+# HTTP :80 file retrieval is NOT proxied — the agent still fetches FITS
+# from the scope directly (SCOPE_HOST vs SCOPE_CONTROL_HOST).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: seestar-proxy
+  namespace: tycho
+  labels:
+    app.kubernetes.io/name: seestar-proxy
+    app.kubernetes.io/part-of: tycho
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: seestar-proxy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: seestar-proxy
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: proxy
+          image: zot.phillips-homelab.net/seestar-proxy:latest # pinned via kustomization.yaml
+          args: ["--upstream", "10.20.20.53"] # S30 Pro home-LAN IP; travel-router setup will change this
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - name: control
+              containerPort: 4700
+            - name: imaging
+              containerPort: 4800
+            - name: dashboard
+              containerPort: 4090

--- a/gitops/tools/apps/tycho/seestar-proxy/kustomization.yaml
+++ b/gitops/tools/apps/tycho/seestar-proxy/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+  - deployment.yaml
+  - service.yaml
+images:
+  - name: zot.phillips-homelab.net/seestar-proxy
+    newTag: "7259295"

--- a/gitops/tools/apps/tycho/seestar-proxy/service.yaml
+++ b/gitops/tools/apps/tycho/seestar-proxy/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: seestar-proxy
+  namespace: tycho
+  labels:
+    app.kubernetes.io/name: seestar-proxy
+spec:
+  # LoadBalancer so scopetui on the LAN can reach control without a
+  # port-forward; in-cluster consumers use the DNS name.
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: seestar-proxy
+  ports:
+    - name: control
+      port: 4700
+      targetPort: control
+    - name: imaging
+      port: 4800
+      targetPort: imaging
+    - name: dashboard
+      port: 4090
+      targetPort: dashboard


### PR DESCRIPTION
Vendored from loop-bot/tycho deploy/ @ e21ee60. Tags match live exactly
(kubectl diff empty at adoption): operator d8ae6fa (COMBINE_IMAGE
9bb5cce), gateway f29f094, scorer 714d5e0, seestar-proxy 7259295,
agent 0b57ae0.

- CRDs carry Prune=false: pruning a CRD deletes every ImagingSession
- namespace.yaml removed: the live ns is tracked by tycho-db (that was
  the standing Namespace/tycho OutOfSync)
- app automation stays off until post-sync diff is clean
