### PR TITLE
chore(tycho): re-enable automated sync — adoption complete, diff clean

### DIFF
--- a/gitops/tools/apps/tycho.yml
+++ b/gitops/tools/apps/tycho.yml
@@ -15,8 +15,8 @@ spec:
     repoURL: https://github.com/AlverezYari/phillips-homelab.git
     targetRevision: main
   syncPolicy:
-    # Automation temporarily off while adopting the hand-applied tycho
-    # workloads (operator/gateway/scorer/seestar-proxy/agent) into this
-    # app. Re-enable (prune+selfHeal) once `argocd app diff` is clean.
+    automated:
+      prune: true
+      selfHeal: true
     syncOptions:
       - CreateNamespace=true


### PR DESCRIPTION
CRDs carry Prune=false so an accidental manifest removal can never
cascade into ImagingSession loss.
