### PR TITLE
bump(tycho): gateway f29f094 to 605a1a6

### DIFF
--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -8,4 +8,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-gateway
-    newTag: "f29f094"
+    newTag: "605a1a6"


### PR DESCRIPTION
Activates coordinate-based target grouping, which has never run in production.

The deployed gateway is from 2026-07-18 and predates the target coordinate work. It never emits target_ra_deg on the session-closed event, so the operator creates every ImagingSession without coordinates and correctly falls back to exact-slug target grouping. All seven existing sessions took that fallback.

The consequence is that the great-circle clustering in operator/internal/targetmaster has never executed against real data. That is the code path which makes two owners reporting M13 and M 13 pool into one master instead of two, so it matters before any second contributor joins.

The agent already writes RA/Dec into the manifest, and the operator already consumes the field. The gateway is the only broken link.

Image is built and pushed: zot.phillips-homelab.net/tycho-gateway:605a1a6 (digest sha256:0cf32522).

Verified after merge: a session closing should populate spec.targetRADeg/targetDecDeg, and the operator should stop logging the no-usable-sky-position warning.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Tycho Gateway image to a newer version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->