### PR TITLE
bump(tychofleet): 76ad8ee to 69e00d6

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:76ad8ee
+          image: zot.phillips-homelab.net/tychofleet:69e00d6
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Ships tychofleet PR #28, the membership half of the fleet flow: a per-fleet join path, the owner console at /fleet/{slug}/ops with countersign and decline, campaign creation from that console, and closing the managed chip-in loop.

Gate green at the merge commit: build clean, 570 tests passing, lint clean. Both new pages were rendered and eyeballed before merge, not merged on green tests alone.

Carries one fix worth its own mention. getScopeCatalogInfo selected optics and site from the catalog's source table, which has neither, so Postgres rejected the whole statement including the last_heartbeat_at that does exist. queryCatalog caught it and returned degraded, which renders the identical empty state to a scope that has never checked in. The deck's Your scopes panel has been broken in production and looked exactly like working software with no data yet.

Image pushed: zot.phillips-homelab.net/tychofleet:69e00d6 (digest sha256:e41a03e9).

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TychoFleet application deployment to use the latest container image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->