### PR TITLE
bump(tychofleet): 69e00d6 to 1dee39e

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:69e00d6
+          image: zot.phillips-homelab.net/tychofleet:1dee39e
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Ships tychofleet PR #29: an alpha gate on fleet management, and campaign rows on the fleet page become clickable.

Migration 0014 adds members.can_manage_fleets (default off) and flags the founder on by email rather than by hardcoded id, so the only existing member keeps access the moment this deploys.

Team and fleet creation now 403 server-side for unflagged members. The owner console at /fleet/{slug}/ops is deliberately NOT gated, so revoking the flag later cannot strand a fleet that is already running scopes.

Gate green at the merge commit: 581 tests passing, lint and build clean.

Image pushed: zot.phillips-homelab.net/tychofleet:1dee39e (digest sha256:3d28622b).

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the deployed application image to the latest build.
  * No other deployment settings were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->