### PR TITLE
feat(tychofleet): wire the Tycho catalog

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -51,7 +51,7 @@ spec:
               value: devs@lighttheham.com
             - name: SMTP_FROM
               value: admin@tychofleet.com
-          # SMTP_PASS, SESSION_SECRET, ADMIN_TOKEN
+          # SMTP_PASS, SESSION_SECRET, ADMIN_TOKEN, CATALOG_DSN
           envFrom:
             - secretRef:
                 name: tychofleet-config

--- a/gitops/apps/tychofleet/external-secret.yaml
+++ b/gitops/apps/tychofleet/external-secret.yaml
@@ -32,3 +32,10 @@ spec:
     remoteRef:
       key: tychofleet
       property: ADMIN_TOKEN
+  # Read-only view of the Tycho catalog. Absent -> the site's catalog
+  # client returns "not-wired" and every attribution panel renders empty,
+  # which reads exactly like having no data yet.
+  - secretKey: CATALOG_DSN
+    remoteRef:
+      key: tychofleet
+      property: CATALOG_DSN

--- a/gitops/apps/tychofleet/network-policy.yaml
+++ b/gitops/apps/tychofleet/network-policy.yaml
@@ -1,6 +1,6 @@
-# Lockdown: ingress only from the Cloudflare tunnel; egress DNS plus
-# SMTP submission (Fastmail, magic-link mail). Litestream phase 3 will
-# need an egress rule to garage:3900 like lighttheham's.
+# Lockdown: ingress only from the Cloudflare tunnel; egress DNS, SMTP
+# submission (Fastmail, magic-link mail) and the Tycho catalog. Litestream
+# phase 3 will need an egress rule to garage:3900 like lighttheham's.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -37,4 +37,19 @@ spec:
       toPorts:
         - ports:
             - port: "587"
+              protocol: TCP
+    # The Tycho catalog (CATALOG_DSN -> tycho-pg-r). Every attribution
+    # number the site shows -- pooled integration, campaign totals, a
+    # master's per-source seconds, a scope's last heartbeat -- is read
+    # from here; without this rule the catalog client times out and every
+    # one of those panels renders its "not wired" empty state, which is
+    # indistinguishable from having no data. Scoped to the CNPG instance
+    # pods in the tycho namespace on 5432, not the whole namespace.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: tycho
+            cnpg.io/cluster: tycho-pg
+      toPorts:
+        - ports:
+            - port: "5432"
               protocol: TCP


### PR DESCRIPTION
Turns on every attribution number the site is supposed to show.

The catalog adapter has existed since the attribution work and has never connected. Two independent reasons, both silent:

1. CATALOG_DSN was never set, so the client returns not-wired before opening a socket.
2. The CiliumNetworkPolicy allows egress to DNS and SMTP only. Verified from inside the pod tonight: the postgres service, its pod IP, and 1.1.1.1 all time out.

The failure mode is the problem. Every panel degrades to an empty state that looks exactly like having no data yet. Tonight, mid-capture, the M13 campaign showed 0h 00m against 63 catalog frames whose coordinates sit 0.16 degrees from the campaign target, and Your scopes said nothing has reported while the agent was heartbeating every few seconds.

This adds the egress rule, scoped to the CNPG instance pods on 5432 rather than the whole tycho namespace, and the CATALOG_DSN external-secret key. The deployment already uses envFrom on the whole secret, so it needs no change.

After merge, watch: pooled integration on /fleet/fleet-zero, the M13 total on /campaign/2, and the heartbeat age in Your scopes on the deck.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt