### PR TITLE
bump: gateway 1a212be, tychofleet 1509822

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:1dee39e
+          image: zot.phillips-homelab.net/tychofleet:1509822
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -8,4 +8,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-gateway
-    newTag: "605a1a6"
+    newTag: "1a212be"


### PR DESCRIPTION
Two images from tonight's merge round.

Gateway 1a212be carries tycho PR #102 Layer 1. The gateway hardcoded the literal 'accepted' on every catalog insert, so all 585 rows in the catalog claimed acceptance and frames the firmware itself rejected counted toward integration and attribution. It now records the device's verdict with a reason.

tychofleet 1509822 carries PR #30 and #31. #30 fixes catalog queries that named columns the catalog does not have, which failed silently and rendered as empty states indistinguishable from having no data; the corrected join was verified against the live catalog. #31 makes enrolment identity (campaign, member) so a member cannot chip in twice.

The agent is deliberately not bumped here. PR #102's Layer 2, the fetch-side skip of rejected frames, is agent-side and the agent is a StatefulSet actively capturing tonight. That one waits.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TychoFleet application deployment to a newer container image.
  * Updated the Tycho gateway to a newer container image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->