### PR TITLE
bump(tycho): agent 0b57ae0 to 3f7456c

### DIFF
--- a/gitops/tools/apps/tycho/agent/kustomization.yaml
+++ b/gitops/tools/apps/tycho/agent/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-agent
-    newTag: "0b57ae0"
+    newTag: "3f7456c"

--- a/gitops/tools/apps/tycho/agent/statefulset.yaml
+++ b/gitops/tools/apps/tycho/agent/statefulset.yaml
@@ -83,6 +83,17 @@ spec:
               # connection for all tooling — see deploy/seestar-proxy/);
               # HTTP :80 FITS retrieval stays direct via SCOPE_HOST.
               value: "seestar-proxy.tycho.svc.cluster.local"
+            - name: FETCH_REJECTED_FRAMES
+              # The firmware marks frames its own quality check rejected
+              # with "_failed_" in the filename. false (the default) skips
+              # fetching them: on 2026-07-29 they were 82 of the first 142
+              # frames, and ingest is the pipeline's binding constraint
+              # (docs/seestar-fleet-context.md section 10, a 7x deficit
+              # between what the scope writes and what the agent fetches).
+              # Set true to fetch everything, including rejects. Stated
+              # here rather than left to the default because whether the
+              # rejects are worth keeping long term is an open question.
+              value: "false"
             - name: KEY_PATH
               value: /etc/tycho-agent/fleet-key/fleet-key.pem
             - name: GATEWAY_URL


### PR DESCRIPTION
The agent has been 11 days stale because it is a StatefulSet and restarting it interrupts capture. The forecast is closed for the week, so this is the window.

Carries PR #102 Layer 2: the agent stops fetching frames the firmware already marked failed. On 2026-07-29 those were 82 of the first 142 ingested frames, all of which the gateway then recorded as accepted, so they counted toward integration time and attribution. Ingest is the binding constraint on this pipeline, measured at roughly 7x between what the scope writes and what the agent fetches, so not fetching a frame that was already discarded is the cheapest win available.

Also picks up 11 days of accumulated agent work, most of it the scopetui redesign.

FETCH_REJECTED_FRAMES is set explicitly to false rather than relying on the default, because whether rejects are worth keeping long term is genuinely undecided and the policy should be visible in the manifest.

Image pushed: tycho-agent:3f7456c (sha256:adbe851d).

Nothing is capturing: zero frames accepted in the last 10 minutes, no session mid-flight.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt