### PR TITLE
bump(tychofleet): 1509822 to dd8aa59

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:1509822
+          image: zot.phillips-homelab.net/tychofleet:dd8aa59
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Carries tychofleet PR #32.

The campaign page's POOLED and NIGHTS figures were reading campaigns.accumulatedSec and campaigns.nights, columns defaulted to 0 that nothing in the codebase ever updates. The M13 campaign showed 0h 00m and 0 nights against a catalog holding 359 matched frames and a session at 4620s, with live catalog acceptance stats rendering correctly inches above them.

Both figures now derive from the catalog, from the same matched frame set the per-scope table already used, so headline and rows cannot disagree. When the catalog is unwired or degraded they render '--' rather than a zero, because a plausible-looking zero is exactly how last night's catalog outage stayed invisible.

Migration 0016 adds campaign_targets.info_url, an optional admin-entered reference link rendered under the target title. Deliberately not a Wikipedia resolver: the Tycho catalog has no concept of what an object is, and fetching an external site at render time would mean widening a network policy that currently allows DNS, SMTP and Postgres only.

Image pushed: zot.phillips-homelab.net/tychofleet:dd8aa59 (sha256:64d434e4).

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TychoFleet application to a newer release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->