### PR TITLE
feat(argocd): reconcile every 30s instead of 180s

### DIFF
--- a/gitops/core/apps/argocd/kustomization.yml
+++ b/gitops/core/apps/argocd/kustomization.yml
@@ -7,4 +7,5 @@ resources:
 
 patches:
   - path: params.yml
+  - path: reconciliation.yml
   - path: tailscale-patch.yml

--- a/gitops/core/apps/argocd/reconciliation.yml
+++ b/gitops/core/apps/argocd/reconciliation.yml
@@ -1,0 +1,16 @@
+# Application reconciliation interval. ArgoCD's default is 180s, and with
+# argocd-server on a ClusterIP with no ingress there is no path for a
+# GitHub webhook to reach it, so polling is the only trigger available.
+# Three minutes of apparent silence after every merge reads as a stuck
+# deploy; 30s keeps the feel of a push-triggered sync without exposing
+# the ArgoCD API to the internet for a convenience feature.
+#
+# Cost is a git ls-remote per application per interval. If that ever
+# shows up on the git host or in argocd-repo-server CPU, raise this
+# rather than reaching for the webhook.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+data:
+  timeout.reconciliation: 30s


### PR DESCRIPTION
Every gitops deploy has up to three minutes of apparent silence between the merge and anything happening. That reads as a stuck deploy and has prompted 'what is going on?' more than once this week.

The better answer is a webhook, but argocd-server is a ClusterIP with no ingress, so GitHub cannot reach it. Exposing the ArgoCD API through the Cloudflare tunnel to save three minutes is the wrong trade for a convenience feature, so this shortens the poll interval instead.

Cost is a git ls-remote per application per interval. If that ever shows up on the git host or in argocd-repo-server CPU, raise the interval rather than reaching for the webhook.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt