### PR TITLE
bump(tycho): operator and gateway to 2563226

### DIFF
--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -8,4 +8,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-gateway
-    newTag: "3f7456c"
+    newTag: "2563226"

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -12,4 +12,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "3f7456c"
+    newTag: "2563226"


### PR DESCRIPTION
Carries tycho PR #105.

The catalog's result and combine_input tables come from ADR 0005 and have never had a writer, which the code itself documented. Seven masters exist as objects in Garage, including a three-night pooled M13, and nothing outside Kubernetes knows they do. The tychofleet RESULTS panel rendering 'no masters published yet' has been an accurate report of an empty table.

The gateway now consumes tycho.job.stack.succeeded and tycho.job.master.succeeded and writes result rows, upserting on object_key with a revision guard so a redelivered older revision cannot clobber a newer row. The operator's master event gains input_keys, naming the actual combined set by Garage object key, so combine_input edges are recorded from real keys rather than reconstructed inside the gateway.

Images pushed: tycho-gateway:2563226 (sha256:22965522), tycho-operator:2563226 (sha256:6608ba83).

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt