### PR TITLE
bump(tycho): operator to 0ddfe9f

### DIFF
--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -12,4 +12,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "2563226"
+    newTag: "0ddfe9f"


### PR DESCRIPTION
Carries tycho PR #106.

A combine's start time is now stamped when its Job is created, not when the phase transitions. Any route into Combining other than the normal one left the previous revision's start time in place, so duration_seconds measured from a combine that had finished days earlier. Two rows in the catalog read 9.8 days and 14.6 hours for jobs that took about a minute.

Covers both the session path and both master kinds. Also adds operator/cmd/correct-result-duration, which republishes corrected events through the gateway's result writer rather than touching SQL directly, since result rows are only ever written by the event consumer.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Tycho operator image to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->