### PR TITLE
feat(tychofleet): serve master previews from Garage

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:dd8aa59
+          image: zot.phillips-homelab.net/tychofleet:a3a1dee
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -51,7 +51,12 @@ spec:
               value: devs@lighttheham.com
             - name: SMTP_FROM
               value: admin@tychofleet.com
-          # SMTP_PASS, SESSION_SECRET, ADMIN_TOKEN, CATALOG_DSN
+            - name: GARAGE_ENDPOINT
+              value: "http://garage.garage.svc.cluster.local:3900"
+            - name: GARAGE_BUCKET
+              value: "tycho"
+          # SMTP_PASS, SESSION_SECRET, ADMIN_TOKEN, CATALOG_DSN,
+          # GARAGE_ACCESS_KEY_ID, GARAGE_SECRET_ACCESS_KEY
           envFrom:
             - secretRef:
                 name: tychofleet-config

--- a/gitops/apps/tychofleet/external-secret.yaml
+++ b/gitops/apps/tychofleet/external-secret.yaml
@@ -39,3 +39,14 @@ spec:
     remoteRef:
       key: tychofleet
       property: CATALOG_DSN
+  # Garage S3 key pair for reading master previews and FITS objects.
+  # Read-only would be better than reusing the pipeline's write key;
+  # see PR body.
+  - secretKey: GARAGE_ACCESS_KEY_ID
+    remoteRef:
+      key: tychofleet
+      property: GARAGE_ACCESS_KEY_ID
+  - secretKey: GARAGE_SECRET_ACCESS_KEY
+    remoteRef:
+      key: tychofleet
+      property: GARAGE_SECRET_ACCESS_KEY

--- a/gitops/apps/tychofleet/network-policy.yaml
+++ b/gitops/apps/tychofleet/network-policy.yaml
@@ -53,3 +53,16 @@ spec:
         - ports:
             - port: "5432"
               protocol: TCP
+    # Garage's S3 API, for the master preview JPEG and the FITS download
+    # (/fleet/{slug}/master-preview.jpg, master-download.fit). Reads are
+    # SigV4-signed; the site holds a Garage key pair, so this rule alone
+    # grants nothing without those credentials. Scoped to the Garage
+    # pods, not the whole namespace.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: garage
+            app.kubernetes.io/name: garage
+      toPorts:
+        - ports:
+            - port: "3900"
+              protocol: TCP


### PR DESCRIPTION
Carries tychofleet PR #33. The RESULTS panel finally renders a real master: per-source attribution table, preview image, and a FITS download link.

Three pieces:

1. Cilium egress to the Garage pods on 3900, scoped by pod label rather than opening the namespace. The policy's own comment already anticipated needing this.
2. GARAGE_ENDPOINT and GARAGE_BUCKET as plain deployment env.
3. Two external-secret keys for the Garage S3 key pair.

REQUIRES a manual step before it works: GARAGE_ACCESS_KEY_ID and GARAGE_SECRET_ACCESS_KEY must be added to the 1Password tychofleet item. Until they are, the preview route fails soft to a 404 and the rest of the panel still renders, so merging early is safe.

Worth flagging for a follow-up: the obvious credentials to copy are the pipeline's own tycho-combine-s3 key pair, which is read-write on the bucket. A public web app holding write credentials to the science data is the same tradeoff already accepted for the catalog Postgres user. A read-only Garage key for the site would be better and is not much work.

Image pushed: zot.phillips-homelab.net/tychofleet:a3a1dee (sha256:1b5e6e68).

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt