### PR TITLE
bump(tychofleet): a3a1dee to 9260f53

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:a3a1dee
+          image: zot.phillips-homelab.net/tychofleet:9260f53
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Carries tychofleet PR #34.

A member's telescope id was invented from their database row number, correct only while member ids and scope numbering happened to coincide. In production they do not: the founder is member 2 and his scope registered as seestar-1. That one mismatch produced three bugs, each previously fixed at the symptom: the deck's Your scopes panel rendering empty mid-capture, campaign attribution reporting 0h 00m against 359 matching frames, and getFleetMasters excluding the M13 master from the fleet that produced it.

Migration 0017 adds members.scope_id, seeded for the founder by email rather than row id. Every read path uses the recorded value and a member without one renders as absent; there is deliberately no fallback to the derived form, since a wrong-but-plausible value is what made all three failures invisible.

Image pushed: zot.phillips-homelab.net/tychofleet:9260f53 (sha256:02b0dd67).

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TychoFleet application deployment to a newer application build.
  * No runtime settings or deployment configuration changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->