### PR TITLE
bump(tychofleet): 9260f53 to 5e4fe00

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:9260f53
+          image: zot.phillips-homelab.net/tychofleet:5e4fe00
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Carries tychofleet PR #35, the catalog SQL audit.

Four separate times a query has named a column the catalog does not have. Postgres rejects the statement, the client catches it and returns degraded, and the caller renders the same empty state it shows when there is genuinely no data. A broken query and an idle telescope look identical on the page, which is why each instance survived review, tests and a deploy.

The root cause is that a loop cannot see the catalog: SQL gets written against a plausible mental model and the tests mock the same model. This commits a dump of the live schema as a fixture and adds a test that extracts column references from every sql template in the seam and asserts each names a real table/column pair. A query the scanner cannot parse fails loudly rather than passing.

The audit found a fifth instance nobody had reported: the morning report queried a rejection reason from the score table, which has only fwhm_px, star_count, streak_detected, score, scored_at and object_key.

getFleetMasters now derives a master's source from its object key rather than selecting a column that does not exist, so the M13 master should finally render on its fleet page.

Image pushed: zot.phillips-homelab.net/tychofleet:5e4fe00 (sha256:be53c776).

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt