### PR TITLE
bump(tychofleet): 5e4fe00 to a1fb36a

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:5e4fe00
+          image: zot.phillips-homelab.net/tychofleet:a1fb36a
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Carries tychofleet PR #36.

The fleet page rendered the M13 master, its source and its preview image, and reported 0h 00m against three nights totalling about 3h 47m. The log said: op ANY/ALL (array) requires array on right side.

Not a schema problem. sql.array(xs) called without an explicit oid resolves its element type through a map populated from connection state, and with idle_timeout 20 the pool recycles connections, so the lookup intermittently misses. That is why the same idiom rendered correct figures on the campaign page earlier and zero here: identical code, different connection state. Passing the array oid explicitly always misses the map and falls through to the declared type, with no connection dependency.

Also adds a static check rejecting the untyped idiom in the catalog seam, since this class cannot be caught by tests that mock the driver.

Image pushed: zot.phillips-homelab.net/tychofleet:a1fb36a (sha256:0e4b907a).

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TychoFleet deployment to use the latest application image, bringing in the corresponding release updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->