### PR TITLE
bump(tychofleet): a1fb36a to 1dca48b

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:a1fb36a
+          image: zot.phillips-homelab.net/tychofleet:1dca48b
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Carries tychofleet PR #37, the last piece of putting the pooled master on the site.

The fleet page rendered the M13 master, its source and its preview image, and showed 0h 00m for its per-source seconds, with no error in the log. The reader resolved a master's combine_input edges by joining sub_object_key to the sub table. Those edges hold per-session result keys, so the join matched nothing and returned an empty set rather than failing.

combine_input.sub_object_key is polymorphic: a session-level result's inputs are raw subs, a master's inputs are per-session results. ADR 0005 declared the column as a foreign key into sub, assuming every combine input is a frame; the gateway's writer took the correct reading for masters and dropped the constraint. This fixes the reader to match, and pins it with a test using result-key edges so it cannot regress to what the column name implies.

Expected on the live data: three sources, 5340 + 3680 + 4620 seconds, about 3h 47m.

Image pushed: zot.phillips-homelab.net/tychofleet:1dca48b (sha256:d643ba53).

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt