### PR TITLE
bump(tychofleet): 1dca48b to 9408a2e

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:1dca48b
+          image: zot.phillips-homelab.net/tychofleet:9408a2e
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Carries tychofleet PR #38. Two corrections, both live.

Privacy: the public fleet roster fell back to a member's email address when their display name was unset, so a page whose own header says public was showing a personal address to any visitor, indexable. Design screen 2c is explicit that a name should be whatever the member chose, a first initial or a pseudonym. A member's own email is now gated on their session and strangers never see one.

Dead columns: campaigns.accumulatedSec and campaigns.nights default to 0 and nothing in the codebase ever wrote them. PR #32 replaced them on the campaign page and left the deck and the campaigns index reading zeros, which is why the deck showed 0h 00m pooled against real data. All five render sites now read the catalog, campaign-progress.ts (a helper that returned the dead values behind a plausible name) is deleted, and migration 0018 drops both columns so the trap cannot be re-entered.

Image pushed: zot.phillips-homelab.net/tychofleet:9408a2e (sha256:ba889520).

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt