### PR TITLE
bump(tychofleet): 9408a2e to 8afcaeb

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:9408a2e
+          image: zot.phillips-homelab.net/tychofleet:8afcaeb
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Two merges.

PR #39, the roster bug. joinOpenFleet writes principalType member; getFleetRoster read only principalType team. A member who joined an open fleet through the button shipped in PR #28 was a real row in fleet_members, correctly recognised by isFleetMember and isFleetOperator, and invisible on the roster, in the fleet's scope count, in its pooled integration, and in its master matching. Found by rendering the site locally against the real catalog with a member-principal fleet: ROSTER 0 scopes, 0 people, and the master did not resolve. Production hid it because Fleet Zero uses a team principal.

The roster's team-only behaviour was deliberate and documented on the grounds that the creation wizard only ever attaches a team. That was true until PR #28 shipped a join button, and the comment was never revisited. Both principal types now resolve, deduped, with service_account deliberately excluded.

PR #40, the community flow: the master's own page at /gallery/<slug> per design screen 2c with the full sources table and generated credit line, a public observer page keyed on scope id, and links wired from every attribution surface.

The two branches conflicted only in PROGRESS.md; the three source files auto-merged and the union passes 701 tests.

Image pushed: zot.phillips-homelab.net/tychofleet:8afcaeb (sha256:e6e23521).

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TychoFleet application to a newer container image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->