### PR TITLE
bump(tychofleet): 8afcaeb to 43f48e4

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:8afcaeb
+          image: zot.phillips-homelab.net/tychofleet:43f48e4
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Carries tychofleet PR #41.

PR #38 stopped the public roster showing a member's email to strangers and deliberately kept showing a member their own address when signed in. That exemption was wrong. The fleet page's header says public, and within minutes of shipping it the founder screenshotted that page to report the address, which is precisely how an email that only you can see travels anyway.

No page reachable at a public URL now renders an email for any viewer, signed in or not. Signed-in-only surfaces (deck, owner console, admin) still may, and the PR classifies which surfaces are which.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt