### PR TITLE
bump(tychofleet): 43f48e4 to ed60dcf

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:43f48e4
+          image: zot.phillips-homelab.net/tychofleet:ed60dcf
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Carries tychofleet PR #42.

PR #40 built the master's page at /gallery/<slug> and nothing in the navigation reached it: the nav's gallery link went to an index that listed no masters, so the only ways in were the fleet page's RESULTS link or typing the URL. The previous loop was asked to audit links for dead destinations, which it did correctly; the question that mattered was reachability, which it was not asked.

The gallery index now lists published masters with preview, integration, scopes and nights, per design screen 2c's tile description and its no-lead-imager rule. The PR includes a reachability table for every route: reachable from the nav signed out, signed in, or deliberately direct-link only.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt