### PR TITLE
feat(loops): release-build cross-builds for Windows

### DIFF
--- a/loops/bin/release-build.sh
+++ b/loops/bin/release-build.sh
@@ -15,15 +15,64 @@ git checkout -q "$TAG" 2>/dev/null || echo "tag $TAG not a ref yet; building fro
 V=$(git describe --tags --always)
 
 mkdir -p /tmp/out /tmp/stage
-for pair in darwin/arm64 darwin/amd64 linux/amd64; do
+for pair in darwin/arm64 darwin/amd64 linux/amd64 windows/amd64; do
   os=${pair%/*}; arch=${pair#*/}
-  for c in scopetui fleetview; do
+  ext=""; [ "$os" = windows ] && ext=".exe"
+  # dummyscope only ships on windows: it is how a tester with no scope
+  # reachable from that machine still exercises the TUI end to end
+  # (`dummyscope.exe -frames-dir <dir> -launch-tui`). Elsewhere the
+  # simulator is a `make mock` concern, not a release artifact.
+  cmds="scopetui fleetview"
+  [ "$os" = windows ] && cmds="scopetui fleetview dummyscope"
+  for c in $cmds; do
     GOOS=$os GOARCH=$arch CGO_ENABLED=0 go build -trimpath \
       -ldflags="-s -w -X tycho.dev/agent/internal/version.Version=$V" \
-      -o "/tmp/stage/$c" "./agent/cmd/$c"
+      -o "/tmp/stage/${c}${ext}" "./agent/cmd/$c"
   done
-  tar -czf "/tmp/out/tycho-${V}-${os}-${arch}.tar.gz" -C /tmp/stage scopetui fleetview
-  rm -f /tmp/stage/scopetui /tmp/stage/fleetview
+  if [ "$os" = windows ]; then
+    # loop-dev has `unzip` but not `zip`. A Go toolchain is guaranteed here
+    # (this script cross-compiles with it), so use archive/zip rather than
+    # adding an apt package and rebuilding the image for one archive.
+    (cd /tmp/stage && cat > /tmp/mkzip.go <<'GOEOF'
+package main
+
+import (
+	"archive/zip"
+	"io"
+	"os"
+)
+
+func main() {
+	out, err := os.Create(os.Args[1])
+	if err != nil {
+		panic(err)
+	}
+	defer out.Close()
+	w := zip.NewWriter(out)
+	for _, name := range os.Args[2:] {
+		f, err := os.Open(name)
+		if err != nil {
+			panic(err)
+		}
+		hdr, err := w.Create(name)
+		if err != nil {
+			panic(err)
+		}
+		if _, err := io.Copy(hdr, f); err != nil {
+			panic(err)
+		}
+		f.Close()
+	}
+	if err := w.Close(); err != nil {
+		panic(err)
+	}
+}
+GOEOF
+    go run /tmp/mkzip.go "/tmp/out/tycho-${V}-${os}-${arch}.zip" scopetui.exe fleetview.exe dummyscope.exe)
+  else
+    tar -czf "/tmp/out/tycho-${V}-${os}-${arch}.tar.gz" -C /tmp/stage scopetui fleetview
+  fi
+  rm -f /tmp/stage/scopetui /tmp/stage/fleetview /tmp/stage/*.exe
   echo "built ${os}/${arch}"
 done
 
@@ -39,7 +88,8 @@ case "$code" in
   *) echo "release create failed: $code"; head -c 300 /tmp/r; exit 1 ;;
 esac
 
-for f in /tmp/out/*.tar.gz; do
+for f in /tmp/out/*.tar.gz /tmp/out/*.zip; do
+  [ -e "$f" ] || continue
   curl -s -o /dev/null -X POST "$F/repos/${REPO}/releases/${id}/assets?name=$(basename "$f")" \
     -H "Authorization: token ${FORGEJO_TOKEN}" -F "attachment=@${f}"
   echo "attached $(basename "$f")"


### PR DESCRIPTION
loopctl release runs loops/bin/release-build.sh, which had its own hardcoded platform matrix of darwin/arm64, darwin/amd64 and linux/amd64. The tycho repo's scripts/release.sh has always listed windows/amd64, so the two disagreed silently and every release the rig has cut was missing a Windows archive, including scopetui-v0.2.0.

Adds windows/amd64 with .exe suffixes and a zip archive rather than a tarball.

Bundles dummyscope.exe on Windows only. A tester on a cloud Windows box has no route to a telescope, and does not need one: dummyscope.exe -frames-dir <dir> -launch-tui boots the simulator and points scopetui at it on localhost, which exercises every Windows-specific risk in a TUI (console mode, ANSI handling, terminal size, cmd.exe versus PowerShell versus Windows Terminal). The ZWO protocol itself is OS-independent and already proven.

Archives with Go's archive/zip because loop-dev ships unzip but not zip, so this avoids rebuilding the image for one artifact.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows amd64 release builds.
  * Windows binaries are now packaged as ZIP archives alongside existing tarball formats for other platforms.

* **Bug Fixes**
  * Improved release cleanup to remove all generated executables.
  * Asset uploads now include available archive formats without failing when optional files are absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->