### PR TITLE
bump: gateway+operator 032736f, tychofleet 9bb8dfe

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:ed60dcf
+          image: zot.phillips-homelab.net/tychofleet:9bb8dfe
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -8,4 +8,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-gateway
-    newTag: "2563226"
+    newTag: "032736f"

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -12,4 +12,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "0ddfe9f"
+    newTag: "032736f"


### PR DESCRIPTION
Two merges.

tycho PR #107 finishes ADR 0005's provenance graph. combine_input held three rows, all master edges: a master could be traced to the three nights it pooled, and a night could not be traced to the frames it combined. The cause was structural rather than an oversight in the writer, since a master-mode combine emits a completion report naming exactly which inputs it kept and a session-mode combine emitted nothing, so the session event had nothing to carry. Session combines now report the same way, the event carries input keys, and the gateway records the edges.

Edges are written on the success event only, so existing sessions stay unrecorded until they next recombine. No historical backfill is attempted.

tychofleet PR #43 puts /fleet and /campaigns in the public navigation. Both pages were built and populated and reachable from nowhere for a signed-out visitor, found by the reachability audit in PR #42.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Tycho Fleet deployment to a newer release.
  * Updated the Tycho gateway and operator components to the latest available release.
  * These updates include improvements and fixes delivered in the newer component versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->