### PR TITLE
bump(tycho): gateway and combine to 31451df

### DIFF
--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -8,4 +8,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-gateway
-    newTag: "032736f"
+    newTag: "31451df"

--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -102,7 +102,7 @@ spec:
             # operator fails closed at startup without them. See the
             # placeholder-image note above.
             - name: COMBINE_IMAGE
-              value: "zot.phillips-homelab.net/tycho-combine:9bb5cce" # PRs #96/#97: partition before load, and combinability is RGB-and-solved
+              value: "zot.phillips-homelab.net/tycho-combine:31451df" # PRs #96/#97: partition before load, and combinability is RGB-and-solved
             - name: COMBINE_S3_SECRET_NAME
               value: "tycho-combine-s3" # hand-minted from tycho-config values — see README
             # COMBINE_SCRATCH_SIZE is optional (default 10Gi): the


### PR DESCRIPTION
Carries tycho PR #108.

The Seestar firmware computes a stacked frame's TOTALEXP as STACKCNT times the current exposure, so changing exposure mid-session recounts every already-stacked frame at the new value. Session m-13-2026-07-27 has 17 frames at 10s and 188 at 20s, and its second stack reports 184 x 20 = 3680s where the true integration is 40x10 + 144x20 = 3280s. An 11 percent overstatement, on a session already pooled into a published master.

Deliberately does not compute a corrected value. Nothing records which frames the firmware included in a given stack, so a general correction is not derivable and inventing one would be the same class of plausible-but-unfounded number this codebase has spent a week removing. The condition is detected at ingest, recorded as session.totalexp_upper_bound, and carried into the combine's provenance header as TOTEXPUB so a downstream tool reading the FITS sees the caveat with the data.

The one affected session in production is backfilled. No other session currently has mixed exposures.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Tycho Gateway and Operator components to newer container image versions.
  * Includes the latest available fixes and improvements in the deployed components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->