### PR TITLE
tmp(tycho): grant agent debug to map get_device_state

### DIFF
--- a/gitops/tools/apps/tycho/agent/statefulset.yaml
+++ b/gitops/tools/apps/tycho/agent/statefulset.yaml
@@ -118,7 +118,15 @@ spec:
               # for the control API (AGENT_API_ADDR :9090, service-api.yaml).
               # status,events,settings for the POC; "dispatch"/"debug" stay
               # withheld until there's a real owner UI to grant them from.
-              value: "status,events,settings"
+              #
+              # TEMPORARY 2026-07-31: "debug" added to run get_device_state
+              # and friends against real hardware, mapping what the scope
+              # reports about itself for the scope-identity design. debug is
+              # a raw RPC passthrough and can reach methods that move
+              # hardware, so this comes back out as soon as the shapes are
+              # recorded. If you are reading this and the date is not today,
+              # the revert was forgotten: take it out.
+              value: "status,events,settings,debug"
             # AGENT_API_TOKEN (bearer token the control API requires in an
             # `authorization: Bearer <token>` header) is deliberately unset
             # here: no 1Password field for it exists in tycho-config yet.


### PR DESCRIPTION
Temporary and to be reverted in the same session.

get_device_state has a wrapper in agent/internal/zwo and no caller anywhere, and the wrapper's own comment says the response shape is not pinned down (BRIEF.md open question). So nobody knows what a Seestar reports about itself, and that is precisely what scope identity should be derived from: today a scope's identity is a string the owner types into SOURCE_ID, which nothing verifies.

The scope is powered on now, so this is cheap reconnaissance. The agent currently holds status,events,settings and refuses Call with PermissionDenied, which is ADR 0004's capability model working correctly on real hardware.

debug is a raw passthrough and can reach methods that move hardware, so the grant comes back out as soon as the response shapes are written down. The added comment says so and tells a future reader to remove it if the date has passed.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled additional debugging capabilities for Tycho, including device-state inspection and raw control operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->