### PR TITLE
revert(tycho): withdraw the agent debug grant

### DIFF
--- a/gitops/tools/apps/tycho/agent/statefulset.yaml
+++ b/gitops/tools/apps/tycho/agent/statefulset.yaml
@@ -119,14 +119,16 @@ spec:
               # status,events,settings for the POC; "dispatch"/"debug" stay
               # withheld until there's a real owner UI to grant them from.
               #
-              # TEMPORARY 2026-07-31: "debug" added to run get_device_state
-              # and friends against real hardware, mapping what the scope
-              # reports about itself for the scope-identity design. debug is
-              # a raw RPC passthrough and can reach methods that move
-              # hardware, so this comes back out as soon as the shapes are
-              # recorded. If you are reading this and the date is not today,
-              # the revert was forgotten: take it out.
-              value: "status,events,settings,debug"
+              # "debug" was granted briefly on 2026-07-31 to map
+              # get_device_state against real hardware, and removed the same
+              # session. Note for anyone tempted to grant it again: that
+              # response carries the scope's AP password, its device PIN and
+              # the owner's lat/lon, so a raw passthrough is a credential
+              # disclosure channel, not just a hardware-movement risk. The
+              # method takes a "keys" argument and honours it, so a purpose
+              # -built RPC can fetch device/camera identity without ever
+              # receiving the secrets. Build that instead of re-granting.
+              value: "status,events,settings"
             # AGENT_API_TOKEN (bearer token the control API requires in an
             # `authorization: Bearer <token>` header) is deliberately unset
             # here: no 1Password field for it exists in tycho-config yet.


### PR DESCRIPTION
Reverts #377. The reconnaissance is done.

## What the scope reports about itself

`get_device_state` answers BRIEF.md's open question. The identity-bearing fields:

| field | value on the S30 Pro |
|---|---|
| `device.sn` | `5741d34d` — matches the `TELESCOP` suffix in every FITS header |
| `device.cpuId` | `de079cbf89464ff2` — SoC id, independent of `sn` |
| `device.product_model` | `Seestar S30 Pro` |
| `device.firmware_ver_string` / `_int` | `8.46` / `2846` |
| `device.ios_ver` | `SEESTAR_v1.08_rv1126b 20260316` |
| `device.focal_len`, `fnumber` | `160`, `5` |
| `camera.pixel_size_um` | `2.9` (main train) |
| `second_camera.pixel_size_um` | `1.6` (wide cam) |

That is everything needed for make/model/firmware typing, from the device rather than from a string an owner typed into `SOURCE_ID`.

## The security finding, which is why this comment changed rather than reverting cleanly

The full response also carries `ap.passwd` (the scope's WiFi AP password), `setting.password` (device PIN) and `location_lon_lat` (owner's coordinates to ~10m). So `debug` is a **credential disclosure channel**, not only the hardware-movement risk the original comment described. Anything that caches or logs a raw device state would put a password in the catalog and a home address within reach of a public site.

The mitigation is in the protocol already: `get_device_state` takes a `keys` argument and honours it. Verified against the live scope —

```
get_device_state {"keys":["device","camera","second_camera"]}
  -> returns exactly those three; no ap, no setting, no location
```

So a purpose-built identity RPC can read make/model/firmware while never receiving the secrets. The replacement comment says this, so the next person to want device data builds that instead of re-granting debug.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Removed unnecessary debug access from the agent.
  * Retained status, events, and settings access.
  * Documented safer alternatives for retrieving device identity information without exposing secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->