### PR TITLE
deploy(tycho): agent+gateway 94c067d — device attestation

### DIFF
--- a/gitops/tools/apps/tycho/agent/kustomization.yaml
+++ b/gitops/tools/apps/tycho/agent/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-agent
-    newTag: "3f7456c"
+    newTag: "94c067d"

--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -8,4 +8,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-gateway
-    newTag: "31451df"
+    newTag: "94c067d"


### PR DESCRIPTION
Ships tycho #111 (ADR 0008 §1/§3/§5).

Agent and gateway move together deliberately: the agent begins sending attested fields on registration, and the gateway needs migration `0006_source_attestation.sql` applied before it can store them.

After this syncs, `source.model` for `seestar-1` should stop being the literal `seestar` and become `Seestar S30 Pro`, with `serial`, `hardware_id`, `firmware_version` and `attested_at` populated from the device itself — provided the scope is powered on when the agent registers. If it is off, the source registers unattested and picks up attestation on a later restart; that path is deliberate, not a failure.

Note this records fingerprints but does not yet enforce them. `RegisterSource` is still an upsert, so any agent can still claim any source id — that is ADR 0008 §2 and a later loop, which can only be specced once a real fingerprint exists to enforce against.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Tycho agent and gateway components to a newer container release.
  * Includes the latest fixes and improvements delivered in the updated release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->