### PR TITLE
deploy: scope enrolment flow (ADR 0009)

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:9bb8dfe
+          image: zot.phillips-homelab.net/tychofleet:80d8f31
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -55,6 +55,13 @@ spec:
               value: "http://garage.garage.svc.cluster.local:3900"
             - name: GARAGE_BUCKET
               value: "tycho"
+            - name: TYCHO_GATEWAY_URL
+              # ADR 0009: the site calls the gateway's /v1/scopes API to
+              # add a scope, mint a one-time setup code, rename and
+              # remove. SITE_API_TOKEN arrives via envFrom below.
+              # In-cluster only; the network policy scopes egress to the
+              # gateway pods, not the whole namespace.
+              value: "http://tycho-gateway.tycho.svc.cluster.local"
           # SMTP_PASS, SESSION_SECRET, ADMIN_TOKEN, CATALOG_DSN,
           # GARAGE_ACCESS_KEY_ID, GARAGE_SECRET_ACCESS_KEY
           envFrom:

--- a/gitops/apps/tychofleet/external-secret.yaml
+++ b/gitops/apps/tychofleet/external-secret.yaml
@@ -46,6 +46,15 @@ spec:
     remoteRef:
       key: tychofleet
       property: GARAGE_ACCESS_KEY_ID
+  # ADR 0009: the site's service credential for the gateway's
+  # /v1/scopes API (add a scope, mint a setup code, rename, remove).
+  # Deliberately read from the `tycho` 1Password item, the same field
+  # the gateway's own ExternalSecret reads, so the two sides cannot
+  # drift apart the way two copies of one secret always eventually do.
+  - secretKey: SITE_API_TOKEN
+    remoteRef:
+      key: tycho
+      property: site_api_token
   - secretKey: GARAGE_SECRET_ACCESS_KEY
     remoteRef:
       key: tychofleet

--- a/gitops/apps/tychofleet/network-policy.yaml
+++ b/gitops/apps/tychofleet/network-policy.yaml
@@ -66,3 +66,17 @@ spec:
         - ports:
             - port: "3900"
               protocol: TCP
+    # ADR 0009: the scope-management API (add a scope, mint a setup
+    # code, rename, remove). Without this rule the egress lockdown
+    # silently blocks every scope action and the deck renders as though
+    # the member simply has no scopes — a plausible-looking empty state,
+    # which is how this project's worst bugs have always presented.
+    # Scoped to the gateway pods, not the whole tycho namespace.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: tycho
+            app.kubernetes.io/name: tycho-gateway
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP

--- a/gitops/tools/apps/tycho/agent/kustomization.yaml
+++ b/gitops/tools/apps/tycho/agent/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-agent
-    newTag: "94c067d"
+    newTag: "dffbc71"

--- a/gitops/tools/apps/tycho/externalsecret.yaml
+++ b/gitops/tools/apps/tycho/externalsecret.yaml
@@ -47,3 +47,12 @@ spec:
     remoteRef:
       key: tycho
       property: source_auth_token
+  # ADR 0009: the service credential the tychofleet site presents to the
+  # gateway's /v1/scopes API (create a scope, mint a setup code, rename,
+  # remove). Distinct from every other token here — the gateway refuses
+  # to start if it collides with one. The site's own ExternalSecret
+  # reads this same 1Password field so the two can never drift.
+  - secretKey: SITE_API_TOKEN
+    remoteRef:
+      key: tycho
+      property: site_api_token

--- a/gitops/tools/apps/tycho/gateway/deployment.yaml
+++ b/gitops/tools/apps/tycho/gateway/deployment.yaml
@@ -97,6 +97,16 @@ spec:
                 secretKeyRef:
                   name: tycho-config
                   key: SOURCE_AUTH_TOKEN
+            - name: SITE_API_TOKEN
+              # ADR 0009: authenticates the tychofleet site to the
+              # gateway's /v1/scopes API (create a scope, mint a setup
+              # code, rename, remove). Required — the gateway exits at
+              # startup if it is unset, or if it equals any other
+              # configured token.
+              valueFrom:
+                secretKeyRef:
+                  name: tycho-config
+                  key: SITE_API_TOKEN
           readinessProbe:
             httpGet:
               path: /healthz

--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -8,4 +8,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-gateway
-    newTag: "94c067d"
+    newTag: "dffbc71"


### PR DESCRIPTION
tycho `dffbc71` (gateway + agent), tychofleet `80d8f31`.

Ships tycho #114/#115 and tychofleet #44: server-issued scope ids, one-time setup codes, per-scope secrets, and **authentication on the upload path** — which until now had no notion of caller identity at all, so frames could be written under any source id by anyone who could reach the gateway.

### Wiring

- `SITE_API_TOKEN` added to both ExternalSecrets, **both reading the same `tycho` 1Password field** (`site_api_token`) rather than two copies. The gateway refuses to start if it collides with another token.
- `TYCHO_GATEWAY_URL` on the site; `SITE_API_TOKEN` arrives via the existing `envFrom`.
- **CiliumNetworkPolicy egress rule for the gateway pods.** Without it the site's lockdown blocks every scope action and the deck renders as though the member simply has no scopes — a plausible-looking empty state, which is how this project's worst bugs have always presented. Scoped to the gateway pods, not the namespace.

### Hard cutover, deliberately

`SOURCE_AUTH_TOKEN` is retired with no grace period. Between the gateway rolling out and the agent getting its per-scope secret, `seestar-1` cannot upload. Frames buffer and retry, so nothing is lost, and the scope is not imaging at midday. Re-credentialing is: mint a code, redeem it, put the issued secret in `IDENTITY_TOKEN`.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled Tycho Fleet to connect to the Tycho gateway for scope-management operations.
  - Added gateway API authentication using a securely managed site token.
  - Permitted the required network access between Tycho Fleet and the gateway.

- **Updates**
  - Updated Tycho Fleet, Tycho agent, and gateway components to newer container versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->