### PR TITLE
fix(gitops): SITE_API_TOKEN 1Password property is uppercase

### DIFF
--- a/gitops/apps/tychofleet/external-secret.yaml
+++ b/gitops/apps/tychofleet/external-secret.yaml
@@ -54,7 +54,7 @@ spec:
   - secretKey: SITE_API_TOKEN
     remoteRef:
       key: tycho
-      property: site_api_token
+      property: SITE_API_TOKEN
   - secretKey: GARAGE_SECRET_ACCESS_KEY
     remoteRef:
       key: tychofleet

--- a/gitops/tools/apps/tycho/externalsecret.yaml
+++ b/gitops/tools/apps/tycho/externalsecret.yaml
@@ -55,4 +55,4 @@ spec:
   - secretKey: SITE_API_TOKEN
     remoteRef:
       key: tycho
-      property: site_api_token
+      property: SITE_API_TOKEN


### PR DESCRIPTION
One-line fix. ESO reported:

```
error processing spec.data[5] (key: tycho), err: expected one
1Password ItemField matching: 'site_api_token' in 'tycho', got 0
```

The `tycho` item's existing fields are lowercase (`source_auth_token`, `s3_access_key_id`), which is why lowercase was the guess. The field is `SITE_API_TOKEN`.

The gateway is currently failing to start (`couldn't find key SITE_API_TOKEN in Secret tycho/tycho-config`), so this unblocks the rollout.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the site API token configuration to use the proper secret property, improving reliable authentication for Tycho services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->