### PR TITLE
deploy(tycho): IDENTITY_TOKEN is now seestar-1's own scope secret

### DIFF
--- a/gitops/tools/apps/tycho/externalsecret.yaml
+++ b/gitops/tools/apps/tycho/externalsecret.yaml
@@ -37,16 +37,18 @@ spec:
     remoteRef:
       key: tycho
       property: s3_secret_access_key
-  # SOURCE_AUTH_TOKEN (gateway) and IDENTITY_TOKEN (agent) must be equal, so
-  # both map to the single source_auth_token 1P field — they can't drift.
-  - secretKey: SOURCE_AUTH_TOKEN
-    remoteRef:
-      key: tycho
-      property: source_auth_token
+  # ADR 0009 retired the shared fleet token: agents no longer present one
+  # value that every scope holds. IDENTITY_TOKEN is now this scope's own
+  # secret, issued once by the gateway when its setup code was redeemed
+  # and unrecoverable afterwards — if it is lost, mint a new code from
+  # the owner's deck rather than looking for it somewhere.
+  #
+  # SOURCE_AUTH_TOKEN is gone: gateway/main.go no longer reads it, so
+  # leaving it here would be a live credential nothing consumes.
   - secretKey: IDENTITY_TOKEN
     remoteRef:
       key: tycho
-      property: source_auth_token
+      property: scope_secret_seestar_1
   # ADR 0009: the service credential the tychofleet site presents to the
   # gateway's /v1/scopes API (create a scope, mint a setup code, rename,
   # remove). Distinct from every other token here — the gateway refuses

--- a/gitops/tools/apps/tycho/gateway/deployment.yaml
+++ b/gitops/tools/apps/tycho/gateway/deployment.yaml
@@ -14,8 +14,9 @@
 #     differently. Not provisioned yet as of this writing.
 #   - `tycho-config` is the ESO-managed secret (ExternalSecret synced
 #     from 1Password by the homelab GitOps repo): S3_ACCESS_KEY_ID,
-#     S3_SECRET_ACCESS_KEY, SOURCE_AUTH_TOKEN (plus IDENTITY_TOKEN for
-#     the agent and see_start_pem for the fleet key). This manifest
+#     S3_SECRET_ACCESS_KEY, SITE_API_TOKEN (plus IDENTITY_TOKEN — this
+#     scope's own ADR 0009 credential — and see_start_pem for the fleet
+#     key). This manifest
 #     only references keys in it, never inlines values.
 #   - `image` points at the registry `make images`/`make push` (repo
 #     root Makefile) and `.forgejo/workflows/ci.yml`'s tag-triggered
@@ -92,11 +93,6 @@ spec:
                   # tycho-config is queued as the durable fix (issue #29).
                   name: tycho-nats
                   key: NATS_URL
-            - name: SOURCE_AUTH_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: tycho-config
-                  key: SOURCE_AUTH_TOKEN
             - name: SITE_API_TOKEN
               # ADR 0009: authenticates the tychofleet site to the
               # gateway's /v1/scopes API (create a scope, mint a setup


### PR DESCRIPTION
**Needs a new 1Password field first — see below.**

ADR 0009 retired the shared fleet token. `IDENTITY_TOKEN` moves off `source_auth_token` and onto a new field, `scope_secret_seestar_1`, holding the credential the gateway issued when this scope's setup code was redeemed.

`SOURCE_AUTH_TOKEN` is dropped from both the ExternalSecret and the gateway env — `gateway/main.go` no longer reads it, so leaving it in place would be a live credential nothing consumes.

### Verified against the live gateway before opening this

| request | result |
|---|---|
| issued secret, own scope | 204 |
| issued secret, someone else's scope | **403** |
| no credential | **401** |
| the retired shared token | **401** |
| upload start under own scope | 200, key `tycho-source-seestar-1/...` |
| upload start under another scope | **403** |
| replaying a redeemed setup code | **410** |

The upload path — which had no caller identity at all before today — refuses both a mismatched scope and an anonymous caller.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Tycho authentication to use the appropriate scope-specific identity credential.
  * Replaced the deprecated source authentication token with the site API token.
  * Removed obsolete secret injection and configuration references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->