### PR TITLE
fix(release): name archives after the tag being released

### DIFF
--- a/loops/bin/release-build.sh
+++ b/loops/bin/release-build.sh
@@ -12,7 +12,13 @@ F=http://forgejo-http.forgejo.svc.cluster.local:3000/api/v1
 git clone -q "https://oauth2:${FORGEJO_TOKEN}@code.phillips-homelab.net/${REPO}.git" /tmp/src
 cd /tmp/src
 git checkout -q "$TAG" 2>/dev/null || echo "tag $TAG not a ref yet; building from default branch"
-V=$(git describe --tags --always)
+# The version in the archive names is the tag being released, not
+# `git describe`. describe runs before this release's tag exists, so it
+# resolves to the PREVIOUS tag — which is how every release so far has
+# been named after its predecessor (the v0.4.0 archives came out as
+# "tycho-client-scopetui-v0.3.0-2-g35bb44d-..."). Fall back to describe
+# only when TAG is somehow empty.
+V=${TAG:-$(git describe --tags --always)}
 
 mkdir -p /tmp/out /tmp/stage
 for pair in darwin/arm64 darwin/amd64 linux/amd64 windows/amd64; do


### PR DESCRIPTION
`git describe` runs before the release's own tag exists, so it resolves to the **previous** tag. Every release so far has therefore been named after its predecessor:

| release | archives were named |
|---|---|
| `scopetui-v0.3.0` | `tycho-list-25-gdffbc71-…` (the deleted `list` tag) |
| `tycho-client-v0.4.0` | `tycho-client-scopetui-v0.3.0-2-g35bb44d-…` |

The second one reads as though the rename never happened, which is exactly the confusion the rename was meant to end.

Uses `TAG` — already passed in as env — and falls back to `describe` only if it is empty.

I'll delete and re-cut `tycho-client-v0.4.0` once this lands; it is minutes old and nothing has consumed it.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release builds now use the explicitly provided release tag when available.
  * Builds fall back to the repository’s version information only when no tag is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->