### PR TITLE
deploy(tychofleet): 66907c7 — client downloads + tycho-client naming

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:80d8f31
+          image: zot.phillips-homelab.net/tychofleet:66907c7
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Ships tychofleet #45 and #46.

**Downloads.** Setup screen 3 linked at a private Forgejo release asset, which returns 404 to any signed-out browser — the binary itself, not just the listing. Onboarding step 1 was a dead end. The client is now streamed from Garage through a session-gated route, using the credentials the site already holds for master previews. No new secret.

The route keeps `master-preview.jpg`'s safety property: it takes a platform from a fixed enum, resolves the key by listing `clients/`, and never streams a key a caller supplied.

**Naming.** `scopetui` → `tycho-client` throughout the site. The command new members are told to type is now `./tycho-client -conf tycho.yaml`, matching the archive they receive.

Release `tycho-client-v0.4.0` is cut and published to Garage under `clients/tycho-client-v0.4.0/` — all four platforms, **including Windows**, which no release had ever contained before today.

807 tests passing.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt