### PR TITLE
deploy(tychofleet): d4fa7ff — fix add-a-scope 400 + honest error text

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:66907c7
+          image: zot.phillips-homelab.net/tychofleet:d4fa7ff
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Ships tychofleet #47. Both bugs the founder hit within a minute of trying the flow.

**The 400.** The site's member ids are SQLite integers, so it sent `owner_member_id: 7`; the gateway declares that field a string and rejected the request. Reproduced against the live gateway:

```
{"owner_member_id":7}    -> 400  cannot unmarshal number into Go
                                  struct field .owner_member_id of type string
{"owner_member_id":"7"}  -> 201  {"scope_id":"scp_0b0e9ffa"}
```

Two loops built to a contract that named the field and not its type, so each side's tests asserted its own assumption and both were green.

**The message.** A 400 rendered as *"Couldn't reach the scope service — try again shortly"*, sending someone to check DNS and firewalls for a request-shape bug — while the site's own log said `returned 400, expected 201`. `unreachable` and `rejected` are now distinct states: a rejection says something is wrong on our side and that retrying will not help.

The deeper fix is the test stub: it accepted any type, which is why a green suite shipped a broken flow. It now rejects a number the way the real gateway does.

813 tests passing.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TychoFleet deployment to use the latest application image.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->