### PR TITLE
deploy(tycho): 2676d23 — serve the interop key, fix -conf sufficiency

### DIFF
--- a/gitops/tools/apps/tycho/agent/kustomization.yaml
+++ b/gitops/tools/apps/tycho/agent/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-agent
-    newTag: "dffbc71"
+    newTag: "2676d23"

--- a/gitops/tools/apps/tycho/gateway/deployment.yaml
+++ b/gitops/tools/apps/tycho/gateway/deployment.yaml
@@ -93,6 +93,17 @@ spec:
                   # tycho-config is queued as the durable fix (issue #29).
                   name: tycho-nats
                   key: NATS_URL
+            - name: DEVICE_INTEROP_KEY_PEM
+              # ADR 0009 + device-key-provisioning: the gateway serves
+              # this to an authenticated scope over GET /v1/device-key so
+              # the client never ships or stores it. Same material the
+              # agent already mounts at KEY_PATH (tycho-config's
+              # see_start_pem) — one copy, so it can be rotated in one
+              # place the day ZWO changes it in firmware.
+              valueFrom:
+                secretKeyRef:
+                  name: tycho-config
+                  key: see_start_pem
             - name: SITE_API_TOKEN
               # ADR 0009: authenticates the tychofleet site to the
               # gateway's /v1/scopes API (create a scope, mint a setup

--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -8,4 +8,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-gateway
-    newTag: "dffbc71"
+    newTag: "2676d23"


### PR DESCRIPTION
Ships tycho #117.

**The bug a real user hit.** The setup screen tells every new member to run `./tycho-client -conf tycho.yaml`; the binary answered with a usage string demanding `-key key.pem`. That file is the shared fleet interop RSA key the Seestar's `get_verify_str` handshake requires — deliberately not in the repo, and something a member who signed up an hour ago cannot obtain. So onboarding stopped dead at step 3.

**Served, not shipped.** `GET /v1/device-key`, authenticated with the per-scope secret, refused for a revoked scope. The client holds it **in memory only** and refetches each start. `TestEnrolMode_DeviceKeyNeverLeaks` runs a full enrolment and asserts the PEM appears in neither `tycho.yaml`, nor any buffer file, nor any rendered TUI frame.

Bundling it would have put the key in a published artifact, identical for everyone and unrotatable without a release. Serving it means one copy, rotatable centrally the day ZWO changes it in firmware — the endpoint already takes a `firmware` parameter (ignored for now) as the seam for that.

Honest limit, stated in the code as well as here: anyone who signs up can obtain this key. It is access-controlled provisioning, not secrecy.

**No new secret.** `DEVICE_INTEROP_KEY_PEM` reads `tycho-config/see_start_pem` — the same material the agent already mounts at `KEY_PATH`. The gateway refuses to start if it collides with any other configured value.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled the gateway to securely access its device interoperability key.

* **Updates**
  * Updated the Tycho agent and gateway components to newer versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->