### PR TITLE
chore(tailscale): operator 1.90.9 -> 1.98.9 for multi-tailnet support

### DIFF
--- a/gitops/tools/apps/tailscale.yml
+++ b/gitops/tools/apps/tailscale.yml
@@ -10,7 +10,7 @@ spec:
   project: default
   source:
     repoURL: https://pkgs.tailscale.com/helmcharts
-    targetRevision: "v1.90.9"
+    targetRevision: "1.98.9"
     chart: "tailscale-operator"
     helm:
       releaseName: tailscale-operator


### PR DESCRIPTION
One line, but it touches every tailnet-exposed service in the cluster, so it is deliberately standalone.

### Why

The `Tailnet` CRD — **one operator serving several tailnets** — landed in Tailscale **v1.96**. This cluster is on **v1.90.9** and has no `tailnets.tailscale.com` CRD:

```
connectors  dnsconfigs  proxyclasses  proxygroups  recorders     <- no tailnets
tailscale/k8s-operator:v1.90.9
```

Without it, Tycho's gateway cannot be exposed on a dedicated fleet tailnet — which is the whole point of members' scopes joining the fleet's network rather than the house.

`spec.tailnet` is supported on `ProxyGroup`, `Connector` and `Recorder`, not on a plain `tailscale.com/expose` Service, so the gateway will attach via a ProxyGroup bound to the fleet Tailnet. v1.96 also brings `ProxyGroupPolicy`, which restricts which namespaces may use a given ProxyGroup — worth having so nothing else can attach itself to the fleet tailnet by accident.

### Blast radius

This operator currently manages 12 proxies:

```
argocd-server   atuin   dev-rails   fanduel-egress   grafana
home-assistant  ntfy    open-webui  stock-bot-dash   stock-bot-pg
stock-bot-serve tipoff-serve
```

All 12 were Ready before the change; I have the snapshot and will verify each one after the sync, not just that the operator pod restarted. No breaking changes are documented for the operator between 1.90 and 1.98; recent notes are fixes (workload-identity token exchange, ProxyGroup MTU clamping).

Rollback is a one-line revert of `targetRevision`.

Also drops the stray `v` prefix — the chart index publishes plain semver, and no v-prefixed entries exist.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt