### PR TITLE
feat(tycho): fleet tailnet + ingress ProxyGroup

### DIFF
--- a/gitops/tools/apps/tailscale-fleet.yml
+++ b/gitops/tools/apps/tailscale-fleet.yml
@@ -44,3 +44,9 @@ spec:
   type: ingress
   replicas: 2
   tailnet: tycho-fleet
+  # Custom tag rather than the default [tag:k8s], so the fleet ACL can
+  # name the gateway precisely: tag:scope reaches tag:gateway and
+  # nothing else. With the default tag, granting scopes access to the
+  # gateway would grant them access to every operator-managed proxy.
+  tags:
+    - tag:gateway

--- a/gitops/tools/apps/tailscale-fleet.yml
+++ b/gitops/tools/apps/tailscale-fleet.yml
@@ -1,0 +1,46 @@
+# The Tycho fleet tailnet, and the ingress proxies that live on it.
+#
+# ADR 0009's enrolment has a member run tycho-client on their own machine
+# beside their scope, and that client reaches the gateway over the
+# tailnet (agent/internal/tailnet brings the binary up as an embedded
+# tsnet node and dials everything northbound through it). tycho-gateway
+# is ClusterIP, so before this no client anywhere could reach it.
+#
+# Deliberately the FLEET tailnet, not the homelab one: enrolling a
+# telescope should put a member on the fleet's network and nothing else.
+# Tailscale v1.96's cluster-scoped Tailnet CRD lets the single operator
+# serve both, so this is a second credential rather than a second
+# operator.
+#
+# The other half of the trust story lives in the fleet tailnet's ACL,
+# not in git: tag:scope must be able to reach tag:gateway:80 and nothing
+# else, and tagOwners must let the operator tag its own proxies.
+---
+apiVersion: tailscale.com/v1alpha1
+kind: Tailnet
+metadata:
+  name: tycho-fleet
+spec:
+  credentials:
+    # Cluster-scoped resource; the Secret is read from the operator's
+    # namespace. Created by tycho-fleet-oauth in tailscale-secrets.yml,
+    # carrying client_id + client_secret — an OAuth client, not an auth
+    # key: the operator mints its own device keys from it.
+    secretName: tycho-fleet-oauth
+---
+# Ingress proxies bound to the fleet tailnet. A plain
+# `tailscale.com/expose` Service cannot choose a tailnet — only
+# ProxyGroup, Connector and Recorder take spec.tailnet — so the gateway
+# attaches to this group by annotation instead.
+#
+# Two replicas so a proxy restart does not drop every member's client at
+# once.
+apiVersion: tailscale.com/v1alpha1
+kind: ProxyGroup
+metadata:
+  name: tycho-fleet-ingress
+  namespace: tailscale
+spec:
+  type: ingress
+  replicas: 2
+  tailnet: tycho-fleet

--- a/gitops/tools/apps/tailscale-secrets.yml
+++ b/gitops/tools/apps/tailscale-secrets.yml
@@ -18,3 +18,34 @@ spec:
     remoteRef:
       key: tailscale-config
       property: client_secret
+---
+# Fleet tailnet OAuth client (Tycho, ADR 0009).
+#
+# A member's scope joins the FLEET's tailnet, not the homelab one — blast
+# radius, and the trust story: enrolling a telescope should not put a
+# stranger on the house network. Tailscale v1.96's cluster-scoped Tailnet
+# CRD lets one operator serve both, so this is a second credential rather
+# than a second operator.
+#
+# Same shape as operator-oauth above: an OAuth *client* (id + secret),
+# not an auth key — the operator mints its own device keys from it.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: tycho-fleet-oauth
+  namespace: tailscale
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: staging
+  target:
+    creationPolicy: Owner
+  data:
+  - secretKey: client_id
+    remoteRef:
+      key: tycho
+      property: fleet_ts_client_id
+  - secretKey: client_secret
+    remoteRef:
+      key: tycho
+      property: fleet_ts_client_secret


### PR DESCRIPTION
First half of putting the gateway on the fleet tailnet, now that the operator is on 1.98.9 and the `Tailnet` CRD exists.

### What this adds

- `tycho-fleet-oauth` ExternalSecret in the `tailscale` namespace, mapping the `tycho` 1Password item's `fleet_ts_client_id` / `fleet_ts_client_secret` to the `client_id` / `client_secret` keys the CRD requires (verified against the CRD's own schema, not the docs).
- `Tailnet/tycho-fleet` — cluster-scoped, referencing that Secret.
- `ProxyGroup/tycho-fleet-ingress` — type ingress, 2 replicas so a proxy restart doesn't drop every member's client at once.

### What it does not add yet

The `Ingress` that actually publishes the gateway, because its host must be `tycho-gateway.<tailnet>.ts.net` and I don't have the fleet tailnet's MagicDNS name. Once the `Tailnet` resource reports ready I can read it and add the Ingress plus a `ProxyGroupPolicy` in the `tycho` namespace.

Worth noting `ProxyGroupPolicy` is not what I first assumed: it is **namespaced, in the namespace being granted access**, and its `ingress`/`egress` arrays name ProxyGroups usable by Ingress/Service resources there. I checked the CRD schema rather than shipping the guess.

### Still outside git

The fleet tailnet's ACL — `tagOwners` for the operator's tags, and `tag:scope → tag:gateway:80` and nothing else. That second rule is what makes "your scope joins the fleet's network, not the house" true, and it can't be expressed here.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Tycho Fleet network through a dedicated Tailscale tailnet configuration.
  * Added a highly available ingress proxy group with two replicas.
  * Added automated retrieval and management of the required OAuth credentials from the staging secret store.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->