### PR TITLE
feat(tycho): publish the gateway on the fleet tailnet

### DIFF
--- a/gitops/tools/apps/tycho/gateway/ingress-tailnet.yaml
+++ b/gitops/tools/apps/tycho/gateway/ingress-tailnet.yaml
@@ -1,0 +1,54 @@
+# Publishes tycho-gateway on the Tycho fleet tailnet.
+#
+# This is the address in every member's tycho.yaml. A member runs
+# tycho-client beside their scope; it brings itself up as an embedded
+# tsnet node (agent/internal/tailnet) and reaches the gateway here to
+# redeem its setup code, fetch the device interop key, register,
+# heartbeat and upload.
+#
+# L7 Ingress rather than an L3 Service so Tailscale terminates TLS at the
+# proxy and members get a real https:// endpoint with a valid cert,
+# rather than plain HTTP carrying a per-scope secret.
+#
+# Attaches to the fleet ProxyGroup by annotation: a plain
+# `tailscale.com/expose` Service cannot choose a tailnet, and this must
+# land on the fleet tailnet rather than the homelab one.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tycho-gateway-tailnet
+  namespace: tycho
+  annotations:
+    tailscale.com/proxy-group: tycho-fleet-ingress
+spec:
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - tycho-gateway
+  rules:
+    - host: tycho-gateway
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: tycho-gateway
+                port:
+                  number: 80
+---
+# Only this namespace may attach to the fleet tailnet's ingress proxies.
+# ProxyGroupPolicy is namespaced in the namespace being GRANTED access,
+# and its `ingress` list names the ProxyGroups that Ingress resources
+# here may use (verified against the CRD schema — it is not the reverse).
+#
+# Without it, any namespace in the cluster could annotate an Ingress onto
+# tycho-fleet-ingress and publish itself to every member's telescope.
+apiVersion: tailscale.com/v1alpha1
+kind: ProxyGroupPolicy
+metadata:
+  name: tycho-fleet-ingress
+  namespace: tycho
+spec:
+  ingress:
+    - tycho-fleet-ingress

--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
+  - ingress-tailnet.yaml
 images:
   # Pin to a real build before applying: set newTag to a tag `make
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered


### PR DESCRIPTION
The fleet tailnet is up — `Tailnet/tycho-fleet` is `TailnetReady=True`, both `tycho-fleet-ingress` proxies are 1/1, and they registered carrying `Tags: ['tag:gateway']`, which confirms your ACL's `tagOwners` is correct. Tailnet is `tail92d9b0.ts.net`.

This publishes the gateway on it: **`https://tycho-gateway.tail92d9b0.ts.net`** — the address that goes in every member's `tycho.yaml`.

L7 Ingress rather than an L3 Service so Tailscale terminates TLS at the proxy and members get a valid cert, instead of plain HTTP carrying a per-scope secret. A `tailscale.com/expose` Service cannot choose a tailnet, so the ProxyGroup annotation is what lands this on the fleet tailnet rather than the homelab one.

Also adds a `ProxyGroupPolicy` in `tycho` — namespaced in the namespace being *granted* access, with `ingress` naming the ProxyGroups usable there (checked against the CRD schema; it is not the reverse). Without it, any namespace in the cluster could attach an Ingress to these proxies and publish itself to every member's telescope.

### One thing to check on your side

Tailscale must have **HTTPS certificates enabled** for the fleet tailnet (admin console → DNS → HTTPS Certificates), or the proxy cannot provision a cert and the Ingress will come up without working TLS. If that is off, this presents as a TLS failure from the client rather than an obvious error here.

### Note for next time

`Tailnet/tycho-fleet` initially sat at `TailnetReady=False (InvalidSecret)` because Argo applied it before ESO had created the Secret, and the reconciler does not watch Secrets — so it never retried. A no-op annotation fixed it. Worth knowing that ordering race exists whenever a Tailnet lands alongside its ExternalSecret.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure TLS access to the Tycho Gateway through the fleet tailnet at `tycho-gateway`.
  * Configured traffic routing to the gateway service on port 80.
  * Restricted ingress attachment permissions to the Tycho namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->