### PR TITLE
fix(tycho): ingress rule host must be the FQDN

### DIFF
--- a/gitops/tools/apps/tycho/gateway/ingress-tailnet.yaml
+++ b/gitops/tools/apps/tycho/gateway/ingress-tailnet.yaml
@@ -26,7 +26,11 @@ spec:
     - hosts:
         - tycho-gateway
   rules:
-    - host: tycho-gateway
+    # Fully-qualified: the operator rejects a short host outright
+    # ("rule with host "tycho-gateway" ignored, unsupported"). Only
+    # tls.hosts above takes the short form, which is what names the
+    # tailnet device.
+    - host: tycho-gateway.tail92d9b0.ts.net
       http:
         paths:
           - path: /


### PR DESCRIPTION
The Ingress synced but published nothing — no `ADDRESS`, no tailnet device. Its events had the reason:

```
Warning  InvalidIngressBackend  rule with host "tycho-gateway" ignored, unsupported
```

The rule's `host` must be fully qualified (`tycho-gateway.tail92d9b0.ts.net`). Only `tls.hosts` takes the short form, and that part was already right — the operator logged `hostname="tycho-gateway"` and created the Tailscale Service from it.

Worth noting the failure mode: the Ingress reported itself as existing and healthy, the ProxyGroup was Ready, and the only sign anything was wrong was a Warning event on the Ingress. Nothing surfaced it as an error.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the gateway ingress address to use its fully qualified tailnet hostname, improving reliable access through the configured network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->