### PR TITLE
fix(tycho): tag the Tailscale Service to match its host nodes

### DIFF
--- a/gitops/tools/apps/tycho/gateway/ingress-tailnet.yaml
+++ b/gitops/tools/apps/tycho/gateway/ingress-tailnet.yaml
@@ -20,6 +20,15 @@ metadata:
   namespace: tycho
   annotations:
     tailscale.com/proxy-group: tycho-fleet-ingress
+    # The Tailscale Service this Ingress creates must carry the SAME tag
+    # as the proxy nodes that host it. Without this it inherits the
+    # operator default (tag:k8s) while the ProxyGroup nodes carry
+    # tag:gateway, and control then refuses to grant the service cert
+    # domain to those nodes — the cert Secret stays 0 bytes, and the
+    # operator will not advertise an HTTPS-only Ingress without a cert.
+    # Advertise-needs-cert, cert-needs-advertise: nothing errors, the
+    # Ingress simply never gets an address.
+    tailscale.com/tags: "tag:gateway"
 spec:
   ingressClassName: tailscale
   tls:


### PR DESCRIPTION
Root cause found. **Not** the operator bug I hypothesised — that multi-tailnet client-selection bug was real but fixed in March (PR #18749) and is in v1.98.9.

### What was actually wrong

The `client not found: tycho-fleet` errors are **transient restart noise**. That client registry is in-memory, populated only at the end of a successful Tailnet reconcile, so every operator restart empties it and the other controllers race it for ~1s. The logs show it self-healing at 22:58:34, with no such errors since. The Ingress reconciler was running fine and exiting silently because its status never changed.

The real blocker is a **cert deadlock from a tag mismatch**:

- The VIPService got the operator's default `tag:k8s` (the Ingress had no `tailscale.com/tags`), while the ProxyGroup nodes carry `tag:gateway`.
- Control therefore refuses the cert domain — confirmed live inside the pod:
  ```
  tailscale cert tycho-gateway.tail92d9b0.ts.net
  invalid domain; must be one of ["tycho-fleet-ingress-0.tail92d9b0.ts.net"]
  ```
- Cert Secret `tycho-gateway.tail92d9b0.ts.net` exists with `tls.crt`/`tls.key` both **0 bytes**.
- `maybeUpdateAdvertiseServicesConfig` only advertises an HTTPS-only Ingress when a cert exists, and the proxy's cert loop blocks in `waitForCertDomain` until control grants the domain. Neither side moves.

Upstream's own e2e ACL keeps service tags, node tags and autoApprover tags identical — that is the shape this restores.

### Also needed: one line in the fleet ACL

```jsonc
"autoApprovers": { "services": {
  "svc:tycho-gateway": ["tag:gateway"],
  "tag:gateway": ["tag:gateway"],     // <- add this, the tag-keyed form
}},
```

### If this doesn't unblock it

Adding `tailscale.com/http-endpoint: "enabled"` flips the Ingress to HTTP+HTTPS, which advertises **without** waiting for a cert — breaking the deadlock deterministically, after which the annotation can come back off. If that proves necessary it is genuine evidence of an upstream deadlock worth filing.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated gateway networking configuration to ensure generated Tailscale services use the correct gateway tag, improving connectivity with fleet proxy nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->