### PR TITLE
fix(tycho): break the cert/advertise deadlock with http-endpoint

### DIFF
--- a/gitops/tools/apps/tycho/gateway/ingress-tailnet.yaml
+++ b/gitops/tools/apps/tycho/gateway/ingress-tailnet.yaml
@@ -29,6 +29,19 @@ metadata:
     # Advertise-needs-cert, cert-needs-advertise: nothing errors, the
     # Ingress simply never gets an address.
     tailscale.com/tags: "tag:gateway"
+    # Breaks a cert/advertise deadlock. For an HTTPS-only Ingress the
+    # operator refuses to advertise the Tailscale Service until a cert
+    # exists (maybeUpdateAdvertiseServicesConfig), while the proxy's
+    # cert loop blocks until control grants the service cert domain —
+    # which control only does once a host advertises it. Neither side
+    # moves, nothing errors, and the Ingress simply never gets an
+    # address.
+    #
+    # http-endpoint switches to HTTP+HTTPS, which advertises WITHOUT
+    # waiting for a cert. The service then publishes, control grants the
+    # domain, and the proxy issues the cert. Once tls.crt is non-empty
+    # this annotation can be removed to go back to HTTPS-only.
+    tailscale.com/http-endpoint: "enabled"
 spec:
   ingressClassName: tailscale
   tls:


### PR DESCRIPTION
Tag alignment (#395) was necessary but **not sufficient**. Control still refuses the cert domain, confirmed live after the annotation synced:

```
tailscale cert tycho-gateway.tail92d9b0.ts.net
500: invalid domain "tycho-gateway.tail92d9b0.ts.net";
     must be one of ["tycho-fleet-ingress-0.tail92d9b0.ts.net"]
```

Cert Secret still 0 bytes, Ingress still without an address.

### The deadlock

- `maybeUpdateAdvertiseServicesConfig` (`cmd/k8s-operator/ingress-for-pg.go:800`): an HTTPS-only Ingress advertises only when a cert already exists.
- The proxy's cert loop parks in `waitForCertDomain` (`kube/certs/certs.go:212`) until control includes the service domain in the node's `CertDomains`.
- Control only grants that domain once a host advertises the service.

Advertise needs cert; cert needs advertise. Nothing errors.

`tailscale.com/http-endpoint: "enabled"` switches to HTTP+HTTPS, which advertises **without** waiting for a cert. The service publishes, control grants the domain, the proxy issues the cert — and the annotation can then be removed to return to HTTPS-only.

### This is worth filing upstream

Reaching the fallback is the evidence: an HTTPS-only HA Ingress on a non-default tailnet deadlocks. Two other warts from the same investigation are worth filing alongside it — the Tailnet reconciler does not watch its credentials Secret (so it dead-ends on `InvalidSecret` if ESO is slower than Argo, and never retries), and the in-memory client registry produces misleading `error`-level `client not found` logs on every restart, which is what sent me chasing the wrong cause for an hour.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt