### PR TITLE
deploy(tychofleet): fleet tailnet env — public gateway URL + key minter

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -55,6 +55,24 @@ spec:
               value: "http://garage.garage.svc.cluster.local:3900"
             - name: GARAGE_BUCKET
               value: "tycho"
+            - name: TYCHO_GATEWAY_PUBLIC_URL
+              # The address a MEMBER'S OWN MACHINE reaches, written into
+              # the tycho.yaml they download — distinct from
+              # TYCHO_GATEWAY_URL below, which is in-cluster DNS and
+              # means nothing off-cluster. Sending the wrong one is
+              # exactly how a real member got "couldn't reach
+              # http://tycho-gateway.tycho.svc.cluster.local".
+              #
+              # The gateway is published ONLY on the fleet tailnet, so
+              # this is a tailnet name: not public DNS, not a LAN
+              # address. The client joins that tailnet in-process (tsnet)
+              # using the key the site mints, so the member's machine
+              # needs no Tailscale of its own.
+              value: "https://tycho-gateway.tail92d9b0.ts.net"
+            - name: TS_TAILNET
+              # "-" resolves to the OAuth client's own tailnet, so the
+              # fleet tailnet name is not duplicated here.
+              value: "-"
             - name: TYCHO_GATEWAY_URL
               # ADR 0009: the site calls the gateway's /v1/scopes API to
               # add a scope, mint a one-time setup code, rename and

--- a/gitops/apps/tychofleet/external-secret.yaml
+++ b/gitops/apps/tychofleet/external-secret.yaml
@@ -55,6 +55,20 @@ spec:
     remoteRef:
       key: tycho
       property: SITE_API_TOKEN
+  # ADR 0009 / fleet tailnet: the site mints each member a one-time,
+  # tag:scope, pre-authorized Tailscale key so their client can join the
+  # fleet tailnet and reach the gateway. This OAuth client is scoped to
+  # auth_keys ONLY and carries tag:scope-minter — deliberately a
+  # different client from the Kubernetes operator's, so the site can
+  # issue keys and can never touch devices.
+  - secretKey: TS_MINTER_CLIENT_ID
+    remoteRef:
+      key: tycho
+      property: fleet_ts_minter_client_id
+  - secretKey: TS_MINTER_CLIENT_SECRET
+    remoteRef:
+      key: tycho
+      property: fleet_ts_minter_client_secret
   - secretKey: GARAGE_SECRET_ACCESS_KEY
     remoteRef:
       key: tychofleet


### PR DESCRIPTION
Deployment plumbing for the two enrolment loops, so nothing waits on config when they land.

### The two gateway URLs, deliberately different

```
TYCHO_GATEWAY_PUBLIC_URL = https://tycho-gateway.tail92d9b0.ts.net
TYCHO_GATEWAY_URL        = http://tycho-gateway.tycho.svc.cluster.local
```

The public one is written into the `tycho.yaml` a member downloads; the other is in-cluster DNS for the site's own server-side calls. Conflating them is how a real member got `couldn't reach http://tycho-gateway.tycho.svc.cluster.local` — tychofleet #48 split them, and this supplies the value.

Note the public address is a **tailnet** name, not public DNS: the gateway is published only on the fleet tailnet. The member's machine needs no Tailscale of its own, because the client joins in-process via tsnet using the key the site mints.

### Minter credentials

`TS_MINTER_CLIENT_ID` / `TS_MINTER_CLIENT_SECRET` from the `tycho` 1Password item (`fleet_ts_minter_client_id` / `_secret`), plus `TS_TAILNET="-"` so the tailnet name is not duplicated. That OAuth client is scoped to **`auth_keys` only** and carries `tag:scope-minter` — deliberately not the operator's client, so the site can issue keys and never touch devices.

Arrives in the pod via the existing `envFrom`, so the site will need a restart after the secret syncs — `envFrom` resolves at pod start.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled fleet connectivity through a member-reachable gateway address.
  * Added secure configuration for the fleet’s Tailscale OAuth credentials.
  * Configured the application to resolve its OAuth client through the appropriate tailnet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->