### PR TITLE
deploy(tychofleet): 32ab869 — mint a fleet-tailnet key per scope

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:d4fa7ff
+          image: zot.phillips-homelab.net/tychofleet:32ab869
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Ships tychofleet #48 and #50.

The downloaded `tycho.yaml` now carries a Tailscale auth key alongside the setup code, so a member's client can join the fleet tailnet — the gateway is published there and nowhere else.

Verified the mint request body, since every one of these matters:

```js
capabilities.devices.create: {
  reusable: false,        // one key, one scope
  ephemeral: false,       // the node persists
  preauthorized: true,    // no admin approval needed
  tags: ["tag:scope"],    // what the fleet ACL confines to the gateway
}
expirySeconds: ~7 days
```

`tags` is the load-bearing one — a key minted without it would put a member's telescope on the fleet tailnet unconfined.

Also carries #48's `TYCHO_GATEWAY_PUBLIC_URL` split: the member-facing address is now distinct from the in-cluster one, and a missing public URL means **no config is served** rather than one pointing at an unreachable host.

847 tests passing. The pod needs a restart to pick up `TS_MINTER_CLIENT_ID`/`_SECRET` — `envFrom` resolves at pod start and the secret synced after the current pod started. The image change forces that anyway.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the TychoFleet deployment to use a newer container version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->