### PR TITLE
fix(tychofleet): allow egress to the Tailscale API

### DIFF
--- a/gitops/apps/tychofleet/network-policy.yaml
+++ b/gitops/apps/tychofleet/network-policy.yaml
@@ -38,6 +38,22 @@ spec:
         - ports:
             - port: "587"
               protocol: TCP
+    # api.tailscale.com, for minting each member a one-time tag:scope
+    # auth key at enrolment (ADR 0009 / fleet tailnet). Without this the
+    # egress lockdown blocks the mint and setup fails at the moment a
+    # member clicks — the site is otherwise entirely healthy, which is
+    # the failure shape this project keeps hitting.
+    #
+    # toEntities: world rather than toFQDNs because nothing in this
+    # cluster runs the Cilium DNS proxy yet, matching the note above.
+    # That means 443 to the internet generally, not just Tailscale —
+    # narrow it to a toFQDNs rule if the DNS proxy is ever enabled.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
     # The Tycho catalog (CATALOG_DSN -> tycho-pg-r). Every attribution
     # number the site shows -- pooled integration, campaign totals, a
     # master's per-source seconds, a scope's last heartbeat -- is read


### PR DESCRIPTION
Found by testing from inside the running pod after the rollout:

```
fetch('https://api.tailscale.com/...')  ->  BLOCKED: fetch failed
```

The site's CiliumNetworkPolicy allowed `toEntities: world` on **port 587 only** (SMTP). The key-minting call to `api.tailscale.com` needs 443, so every enrolment would have failed at the moment a member clicked *Add a scope* — with the site, the gateway, the tailnet and the ACL all perfectly healthy.

Same shape as the earlier gateway-egress rule in this file: a lockdown silently blocking one call, presenting as a broken feature rather than a network error.

Uses `toEntities: world` on 443 rather than `toFQDNs`, matching the existing note in this file that nothing in the cluster runs the Cilium DNS proxy yet. That is broader than ideal — it permits 443 outbound generally, not only Tailscale — and should be narrowed to a `toFQDNs` rule if the DNS proxy is ever enabled. Flagging rather than burying it.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled TychoFleet services to securely connect to external HTTPS endpoints.
  * Added support for member enrolment and authentication-key provisioning through Tailscale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->