### PR TITLE
retire(tycho): scale the headless agent to 0

### DIFF
--- a/gitops/tools/apps/tycho/agent/statefulset.yaml
+++ b/gitops/tools/apps/tycho/agent/statefulset.yaml
@@ -43,7 +43,17 @@ metadata:
     app.kubernetes.io/part-of: tycho
 spec:
   serviceName: tycho-agent
-  replicas: 1
+  # RETIRED 2026-08-01. The headless agent and the tycho-client a member
+  # downloads are two front ends over the same fieldrun pipeline, and
+  # both were talking to the SAME telescope — one physical scope
+  # (serial 5741d34d) reporting under two source ids, which would
+  # double-count every night it captured.
+  #
+  # The client is now the path: it enrols itself, joins the fleet
+  # tailnet in-process, and needs no Kubernetes. Scaled to 0 rather than
+  # deleted so the PVC-backed buffer survives — anything it had not yet
+  # uploaded is still on disk if this ever needs to come back.
+  replicas: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: tycho-agent


### PR DESCRIPTION
The headless `tycho-agent` StatefulSet and the `tycho-client` a member downloads are two front ends over the same `fieldrun` pipeline — and both were talking to the **same telescope**. One physical scope, serial `5741d34d`, reporting under two source ids:

```
seestar-1      Seestar S30 Pro · 5741d34d   heartbeat 55s   8 sessions
scp_5cc7bacb   Seestar S30 Pro · 5741d34d   heartbeat 72s   0 sessions
```

Left running, both would fetch and upload the same frames and the same night would be attributed twice. Worth noting the device attestation shipped today is what made this visible at all — without a serial, two source ids look like two telescopes.

The client is now the path: it enrols itself, joins the fleet tailnet in-process, and needs no Kubernetes.

### Safety

Scaled to **0, not deleted**, so the PVC-backed buffer survives — anything unuploaded stays on disk if this ever needs to come back. Verified nothing is pending first: the newest frame in the catalog is 2 days 17 hours old and the agent's log shows no queued uploads.

Note it could only be retired through git — `selfHeal: true` means scaling it by hand gets reverted by Argo within seconds.

### After this

The founder re-enrols the client against `seestar-1` (which owns all 798 subs and the M13 masters), then the temporary `scp_5cc7bacb` scope is removed.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Retired the Tycho agent service by scaling it down to zero replicas.
  * Preserved existing buffered files for potential future reactivation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->