### PR TITLE
fix(tychofleet): scope the 443 egress to api.tailscale.com

### DIFF
--- a/gitops/apps/tychofleet/network-policy.yaml
+++ b/gitops/apps/tychofleet/network-policy.yaml
@@ -29,6 +29,13 @@ spec:
               protocol: UDP
             - port: "53"
               protocol: TCP
+          # L7 DNS visibility, for pods this policy selects only. Cilium
+          # can enforce a toFQDNs rule only for names it has watched
+          # being resolved, so the api.tailscale.com rule below depends
+          # on this. It does not turn the DNS proxy on cluster-wide.
+          rules:
+            dns:
+              - matchPattern: "*"
     # smtp.fastmail.com submission. Port-scoped world egress rather than
     # toFQDNs — nothing in the cluster uses the Cilium DNS proxy yet and
     # this deploy is the wrong place to introduce it.
@@ -48,8 +55,15 @@ spec:
     # cluster runs the Cilium DNS proxy yet, matching the note above.
     # That means 443 to the internet generally, not just Tailscale —
     # narrow it to a toFQDNs rule if the DNS proxy is ever enabled.
-    - toEntities:
-        - world
+    # api.tailscale.com, for minting each member a one-time tag:scope
+    # auth key at enrolment (ADR 0009 / fleet tailnet).
+    #
+    # Was `toEntities: world` on 443 — i.e. every HTTPS host on the
+    # internet — because nothing here ran Cilium's DNS proxy. The DNS
+    # rule above enables it for this endpoint alone, which lets this be
+    # scoped to the single host the site actually calls.
+    - toFQDNs:
+        - matchName: "api.tailscale.com"
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
Narrows the rule I flagged when adding it in #399.

Key minting shipped as `toEntities: world` on 443 — **every HTTPS host on the internet** — because nothing here ran Cilium's DNS proxy, so `toFQDNs` could not be enforced. I noted it at the time rather than burying it; this is the follow-through.

Adding L7 DNS visibility to the existing kube-dns rule turns the proxy on **for the pods this policy selects and no others**, which lets the egress rule name the one host the site actually calls:

```yaml
- toFQDNs:
    - matchName: "api.tailscale.com"
  toPorts:
    - ports: [{port: "443", protocol: TCP}]
```

Resulting egress, in full — every rule now names either a specific in-cluster endpoint or a single external host, with SMTP the one remaining port-scoped exception:

| destination | port |
|---|---|
| kube-dns | 53 (+ L7 DNS) |
| world (SMTP submission) | 587 |
| **api.tailscale.com** | **443** |
| tycho-pg | 5432 |
| garage | 3900 |
| tycho-gateway | 8080 |

**Verify after merge:** minting must still work. If DNS learning misbehaves this fails closed — the site would be unable to mint, which surfaces as setup being unavailable rather than anything silent. I will re-run the live mint test through the pod to confirm.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Restricted Tailscale HTTPS traffic to the approved `api.tailscale.com` endpoint.
  * Added DNS visibility and wildcard DNS policy support for endpoint-level network monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->