### PR TITLE
deploy: review fixes — upload auth, fail-closed provisioner, stream timeout

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:32ab869
+          image: zot.phillips-homelab.net/tychofleet:15658a3
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -55,6 +55,16 @@ spec:
               value: "http://garage.garage.svc.cluster.local:3900"
             - name: GARAGE_BUCKET
               value: "tycho"
+            - name: PROVISIONER
+              # Selects the Tailscale auth-key provisioner for the legacy
+              # waitlist/approve invite path. There is deliberately NO
+              # default any more: it used to fall back to a fake that
+              # minted tskey-fake-000001, which the approve flow then
+              # emailed as a working invite — every screen reported
+              # success and the member's agent silently never joined.
+              # The app now throws at startup if this is unset, so this
+              # line is load-bearing.
+              value: "tailscale"
             - name: TYCHO_GATEWAY_PUBLIC_URL
               # The address a MEMBER'S OWN MACHINE reaches, written into
               # the tycho.yaml they download — distinct from

--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-gateway
-    newTag: "2676d23"
+    newTag: "d8d54ab"


### PR DESCRIPTION
Ships tycho #119/#120 and tychofleet #52/#53, from tonight's senior reviews.

### tycho `d8d54ab`

**The client now authenticates uploads.** It sent the per-scope secret on register and heartbeat only; the gateway requires it on every upload endpoint (verified live — an unauthenticated upload start returns 401). So the next captured frame would have failed to upload, stayed in the buffer, and said nothing, because the enrol-mode logger is discarded unless `TYCHO_CLIENT_LOG` is set.

It was invisible because the test fake checked auth on register/heartbeat and not on uploads — while its own comment claimed otherwise. `checkAuth` now has **five call sites instead of two**, covering all three upload handlers.

Also: the gateway reports `pending_code` and clears stale attestation on redemption, fixing the re-enrol loop (screen 4 appearing immediately, Yes/No both returning to it). Verified nothing in that path touches sessions or subs.

### tychofleet `15658a3`

**`PROVISIONER` is now required and set here.** It defaulted to a fake that minted `tskey-fake-000001`; the approve flow stored it, emailed a working-looking invite, and the member's agent silently never joined the tailnet. Confirmed unset in the live pod. The app now throws at startup naming the variable — **so this env line is load-bearing, not decorative**. `"tailscale"` is checked against the switch in `provision/index.ts`.

**The 3s abort no longer truncates downloads.** `AbortSignal.timeout` stayed attached through body consumption, so an 88MB FITS on a 10Mbps link died at 3s of a ~70s transfer — including the client binary a new member needs. Now aborts only if `fetch` hasn't settled, and states plainly that body consumption has no deadline.

858 tests passing.

### After this

A client release carrying the upload fix still needs cutting and publishing — until then a member's downloaded binary cannot upload.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Tailscale-based authentication key provisioning for TychoFleet.

* **Bug Fixes**
  * Prevented fallback to fake authentication keys.
  * Updated TychoFleet and Tycho Gateway services to newer releases for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->