### PR TITLE
deploy(tychofleet): ee2076f — re-enrol serves a config again

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:15658a3
+          image: zot.phillips-homelab.net/tychofleet:ee2076f
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Ships tychofleet #54.

Re-enrolment reached the setup screen, offered a fresh code, and then **410'd on the config download** — because `tycho-yaml.ts` decided "is this scope mid-setup?" from the raw `enrolled` flag, while `resolveSetupMode` had already been taught to consult `pendingCode`. Four sites answered that question independently and only one knew the new fact.

Fixed structurally rather than per-route: one exported predicate, called everywhere.

```ts
export function setupInProgress(scope): boolean {
  return scope.pendingCode || !scope.enrolled;
}
```

Both properties are now tested by name — the founder's case (*enrolled AND a live code → serves the config*) and the anti-fishing case it must not break (*enrolled, no pending code → still 410*). The deck also stops calling a re-enrolling scope `● online`.

863 tests passing.

### Note for the record

This is the fourth bug in 24 hours of one species: a fact known in one place and independently re-derived, differently, somewhere else — `owner_member_id` number-vs-string, `resolveSetupMode` vs historical attestation, the gateway requiring upload auth the client never sent, and this. Each shipped green because each side was internally consistent. This is the first fix of the four that eliminated the duplication rather than adding a case to it.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TychoFleet deployment to a newer application build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->