### PR TITLE
deploy(tycho): d76e721 — session ids namespaced by scope

### DIFF
--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-gateway
-    newTag: "d8d54ab"
+    newTag: "d76e721"

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -12,4 +12,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "032736f"
+    newTag: "d76e721"


### PR DESCRIPTION
Ships tycho #121 and #122 — the P0-1 finding from yesterday's senior review, and the only one whose cost was tied to a date rather than a backlog.

### The problem

Session ids are `slugify(target)-YYYY-MM-DD` — `m-13-2026-07-27` — with no scope in them, and that string was simultaneously the `session` primary key, the `ImagingSession` CR name, and the quiescence tracker's map key. `sub` had no `source_id` column at all. Two scopes shooting the same target on the same night filed the second's frames under the first's session row.

### Verified against a copy of production, twice

Dumped the live database into a throwaway Postgres and ran the migration — first on the branch, then again on merged `main`:

```
BEFORE   seestar-1 | 8 sessions | 798 subs | 3353010 integ_secs
AFTER    seestar-1 | 8 sessions | 798 subs | 3353010 integ_secs
```

Identical. That integration total is the number the public attribution page renders. 798/798 subs backfilled, `PRIMARY KEY (source_id, id)` in place.

Then proved the actual fix by inserting a second scope with a colliding session id — **two rows, one per source**.

### The eight existing CRs

Renaming would have orphaned them, five of them `Done` with completed stacks, including the three M13 sessions behind the masters on the public site. The operator now looks CRs up **by spec fields rather than object name**, so they keep their history:

> *"Without this, upgrading the operator would silently orphan every CR a prior version created: the next close for the same (source, session) would find nothing at `name` and mint a second, empty-history CR alongside the original."*

### Caveat

Postgres-backed tests still skip in CI, so my runs against a production copy are the only real execution of this migration. Getting a Postgres service into CI is on the review list and would make this repeatable rather than manual.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Tycho gateway and operator components to a newer container image version.
  * Includes the latest available fixes and improvements for these components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->