### PR TITLE
chore(loops): land every SPEC written over the last two days

### DIFF
--- a/loops/specs/catalog-session-namespacing/SPEC.md
+++ b/loops/specs/catalog-session-namespacing/SPEC.md
@@ -1,0 +1,115 @@
+# SPEC — catalog-session-namespacing: two scopes, one session row
+
+Repo: `loop-bot/tycho`. Gate: `make build test lint`.
+
+Scope: **`gateway/` only.** A sibling loop (`operator-session-namespacing`)
+is doing the operator half in parallel — stay out of `operator/` and
+`agent/`.
+
+## The failure
+
+Session ids are minted client-side as `slugify(target)-YYYY-MM-DD`
+(`agent/internal/uploader/session.go:31`) — e.g. `m-13-2026-07-27`.
+**There is no scope in that string**, and it is the primary key of
+`session` (`0001_init.sql`).
+
+`sub` has **no `source_id` column at all**; attribution runs entirely
+through `sub.session_id`'s foreign key (`catalog.go:80-84` documents the
+choice deliberately).
+
+So when two scopes shoot the same target on the same night,
+`postgres.go:302-305`'s
+
+```sql
+INSERT INTO session (...) VALUES (...) ON CONFLICT (id) DO NOTHING
+```
+
+files the second scope's frames under **the first scope's session row**.
+Every downstream consumer then attributes those frames to the wrong
+telescope, and the combine runs over one scope's object prefix while the
+row claims both.
+
+This has not happened yet: there is exactly one real source
+(`seestar-1`, 8 sessions, 798 subs). That is why this is worth doing
+today.
+
+## Why today and not next month
+
+Right now the backfill is **mechanical and lossless**: every
+`sub.source_id` is recoverable unambiguously from its `object_key`,
+which begins `tycho-source-<sourceID>/`. One source, no ambiguity.
+
+The day a second scope shares a session id, that stops being true.
+`session.source_id` is already wrong for half the rows, a combine has
+already run over the wrong prefix and produced a stack, and the CR
+history is conflated. Per-frame attribution stays recoverable from
+object keys; the derived artifacts do not.
+
+The migration does not get slower. It goes from lossless to partly
+unrecoverable, on a date you do not control.
+
+## What to build
+
+### 1. `sub.source_id`, backfilled from the object key
+
+Add `source_id` to `sub`, backfilled by parsing the existing
+`object_key` prefix (`tycho-source-<sourceID>/...`). Make it `NOT NULL`
+once backfilled.
+
+- A row whose `object_key` does not parse must **fail the migration
+  loudly**, not default to something. There are 798 rows and all of them
+  parse today; if one doesn't, we want to know rather than to guess.
+- State in PR.md how many rows the backfill touched and how you verified
+  the parse against the real key shape.
+
+### 2. `session` keyed by `(source_id, id)`
+
+The session id stays exactly as the agent mints it — **do not change
+`SessionID`**, and do not change object keys. What changes is that a
+session id is unique *within a source*, not globally.
+
+- Primary key becomes `(source_id, id)`.
+- `ON CONFLICT` on insert becomes the composite.
+- Every query joining or filtering `session` gains the source
+  predicate. Audit them all — `grep` for `session` across `gateway/` and
+  put the list in PR.md with what each now filters on.
+- `sub.session_id`'s foreign key must follow the new key.
+
+### 3. Do not break the existing data
+
+`seestar-1` has 8 sessions and 798 subs, including the M13 masters that
+are live on the public site. The migration must be exact, and the tests
+must prove the existing shape survives:
+
+- [ ] After migration, all 798 subs carry `source_id = 'seestar-1'`.
+- [ ] All 8 sessions are intact and still joined to their subs.
+- [ ] Per-source integration totals are **unchanged** before and after —
+  this is the number the public attribution page renders, and it must
+  not move.
+
+### 4. The test that proves the point
+
+- [ ] Two different sources inserting the **same session id on the same
+  night** produce two distinct session rows, each owning only its own
+  subs. That is the entire reason for this loop; without that test the
+  change is unproven.
+- [ ] Per-source attribution for that pair is correct — scope A's
+  seconds do not include scope B's frames.
+
+## Warts / traps
+
+- Postgres-backed tests **skip silently** without
+  `TYCHO_TEST_DATABASE_URL`, so a green gate does not mean they ran.
+  Write them anyway, say so in PR.md, and say which of your assertions
+  are skip-gated. If you can run them, say how.
+- Do not touch `operator/` or `agent/` — the sibling loop owns the
+  operator, and the agent's `SessionID` is deliberately unchanged.
+- `combine_input.sub_object_key` is deliberately polymorphic (ADR 0005 +
+  the gateway's own migration note). Do not "fix" it here.
+- Migration numbering: next after the highest in
+  `gateway/internal/catalog/migrations/`.
+- `docs/adr/**` is a record, not a scratchpad.
+
+Finish: `/workspace/PR.md` with the backfill row count, the audit of
+every session query, before/after per-source integration totals proving
+they did not move, and the two-scopes-one-night test.

--- a/loops/specs/client-upload-auth/SPEC.md
+++ b/loops/specs/client-upload-auth/SPEC.md
@@ -1,0 +1,99 @@
+# SPEC — client-upload-auth: the client does not authenticate uploads
+
+Repo: `loop-bot/tycho`. Gate: `make build test lint`.
+
+**URGENT.** This breaks ingest. A senior review found it; it is confirmed
+in the code and against the live gateway.
+
+## The failure
+
+The gateway now requires the per-scope secret on every upload endpoint
+(ADR 0009 §2, shipped and verified live: an unauthenticated upload start
+returns **401**). The client does not send it:
+
+```go
+Register      -> c.doAuthed(...)   // sets Authorization: Bearer <secret>
+Heartbeat     -> c.doAuthed(...)   // sets Authorization
+StartUpload   -> c.do(...)         // NO Authorization        client.go:207
+UploadStatus  -> c.do(...)         // NO Authorization        client.go:224
+UploadPart    -> hand-built req    // NO Authorization        client.go:233-247
+CompleteUpload-> c.do(...)         // NO Authorization        client.go:270
+```
+
+`do` (`client.go:278`) sets no auth header; only `doAuthed`
+(`client.go:288`) does.
+
+**Consequence: the next frame a scope captures cannot be uploaded.** It
+401s, the frame stays in the buffer, and — because `retry.go` treats
+401/403 as terminal and the enrol-mode logger is discarded unless
+`TYCHO_CLIENT_LOG` is set — the member is told nothing. A night of
+photons cannot be recaptured.
+
+This has not bitten yet only because no frames have been captured since
+the client took over.
+
+## Why it was invisible
+
+`agent/internal/fakegateway` calls `checkAuth` at exactly two sites —
+register (`fakegateway.go:372`) and heartbeat (`:386`). The three upload
+handlers (`:402`, `:430`, `:464`) never call it. So client and fake
+agree perfectly, and every upload test passes.
+
+Worse, the fake's own comments (`fakegateway.go:50-52`, `:334`) claim
+`checkAuth` "authenticates register/heartbeat/**upload** calls against
+the per-scope secret ADR 0009 actually issues." **The fake documents a
+property it does not have**, which is what stopped anyone checking.
+
+## What to build
+
+### 1. Authenticate every upload call
+
+`StartUpload`, `UploadStatus`, `UploadPart`, `CompleteUpload` all carry
+`Authorization: Bearer <per-scope secret>`, exactly as register and
+heartbeat do. Prefer routing them through the same helper rather than
+adding the header in four places — four call sites is four chances for
+the next endpoint to be forgotten.
+
+`UploadPart` builds its request by hand for streaming reasons; keep the
+streaming, add the header.
+
+### 2. Make the fake enforce it
+
+`fakegateway` must call `checkAuth` on **all** upload handlers, with the
+same scope-binding it already applies to register/heartbeat (secret for
+scope A must not authenticate a request for scope B — that logic exists
+at `fakegateway.go:288-301`, use it).
+
+Correct the two comments that claim upload calls are already
+authenticated. A fake that lies is worse than no fake.
+
+### 3. The test that would have caught it
+
+- [ ] An upload attempted **without** a credential is refused by the
+  fake, and the client's own upload path is asserted to send
+  `Authorization` on all four calls — assert on the request the fake
+  received, not on a mock's return value.
+- [ ] A full streaming upload still succeeds end to end with a valid
+  credential (the existing streaming tests must keep passing).
+- [ ] Scope A's secret cannot upload under scope B's path.
+- [ ] A 401 on upload surfaces to the member rather than dying in a
+  discarded logger. If that needs plumbing beyond this loop, say so in
+  PR.md rather than silently leaving it — the review found the enrol
+  mode logger goes to `io.Discard` unless `TYCHO_CLIENT_LOG` is set
+  (`main.go:2553-2560`) and `fieldrun.go:413` has no error channel back
+  to the TUI.
+
+## Warts / traps
+
+- Do not change the gateway. Its behaviour is correct and verified
+  against production; the client is the side that is wrong.
+- Do not change enrolment, the tailnet path, `DescribeDevice` or the
+  keys allowlist.
+- The secret is already on `GatewayClient` (`identityToken`,
+  `client.go:64`). No new plumbing needed to obtain it.
+- Never log the secret, and do not echo response bodies into errors on
+  the authed paths — `devicekey.go:78-80` is the discipline to copy.
+
+Finish: `/workspace/PR.md` showing all four calls carrying the header,
+the fake refusing an unauthenticated upload, and what a member now sees
+when a credential is rejected mid-upload.

--- a/loops/specs/device-key-provisioning/SPEC.md
+++ b/loops/specs/device-key-provisioning/SPEC.md
@@ -1,0 +1,129 @@
+# SPEC — device-key-provisioning: serve the interop key, don't ship it
+
+Repo: `loop-bot/tycho`. Gate: `make build test lint`.
+
+Read `docs/adr/0009-scope-credentials.md` first — this extends it.
+
+## The failure, which stops onboarding dead
+
+The founder ran the exact command the site tells every new member to
+type:
+
+```
+$ ./tycho-client -conf tycho.yaml
+usage: tycho-client -conf tycho.yaml -key key.pem [-scope host:port]
+```
+
+Two problems, both in the way of a working first run.
+
+**1. `-conf` is not sufficient.** Enrol mode still requires `-key` on
+the command line (`agent/cmd/tycho-client/main.go`, the
+`enrolMode && *keyPath == ""` case), so the client exits on argument
+validation before it ever looks for a scope.
+
+**2. The user has no key to give it.** `-key` is the **shared fleet
+interop RSA private key** — what the Seestar's `get_verify_str`
+challenge-response requires (`agent/internal/zwo/auth.go`,
+`docs/seestar-fleet-context.md` §1). It is deliberately absent from
+this repo. A member who signed up an hour ago has no way to obtain it,
+so even with the flag fixed, the handshake would fail.
+
+## The decision
+
+**The gateway serves the interop key to an authenticated scope. The
+client holds it in memory only and never writes it to disk.**
+
+The client authenticates to Tycho *before* it needs to reach the
+hardware — it redeems its setup code, gets its per-scope credential,
+and only then wants to talk to the scope. That ordering is what makes
+this possible.
+
+Why served rather than shipped, so nobody undoes it later: bundling the
+key would put it in a published artifact, unrotatable without a
+release, identical for everyone, forever. Serving it means it is in
+exactly one durable place, is provisioned to identified members rather
+than published, is revocable per scope, and — the part that actually
+matters operationally — **can be rotated centrally the day ZWO changes
+it in firmware, with no client release at all.**
+
+Be honest in comments and PR.md about the limit: anyone who signs up can
+obtain it. This is access-controlled provisioning, not secrecy. Do not
+write anything claiming the key is protected or secret.
+
+### Gateway
+
+```
+GET /v1/device-key
+  Authorization: Bearer <scope secret>
+  -> 200 {"key_pem": "...", "key_id": "..."}
+  -> 403 if the scope's credential is revoked
+```
+
+- Authenticated with the **per-scope secret**, exactly like register and
+  heartbeat. Reuse that middleware; do not invent a second auth path.
+- **A revoked scope is refused.** Removing a scope from a deck must
+  actually cut off device access, not merely stop uploads.
+- The key comes from configuration (`DEVICE_INTEROP_KEY_PEM`, a new
+  required env var fed from the existing secret — the deployment
+  already mounts this key material for the agent as `see_start_pem`).
+  Follow the precedent already in `gateway/main.go`: fail to start if it
+  is missing, and fail to start if it collides with another token.
+- Accept an optional `firmware` query parameter and **ignore it for
+  now**, returning the single configured key. Record in PR.md that this
+  is the seam for serving different material per firmware when ZWO
+  rotates it. Do not build multi-key selection this loop.
+- The key must never appear in a log line, an error, an event, or a
+  metric. Check your error wrapping — this is the same discipline the
+  attestation loop applied to `get_device_state`.
+
+### Client
+
+- Enrol mode (`-conf tycho.yaml`) **requires no other flags.** That is
+  the headline: the command on the setup screen must work as written.
+- After redeeming (or loading a persisted credential), fetch the key
+  from the gateway and keep it **in memory only**. Never write it to
+  `tycho.yaml`, never to a temp file, never to the buffer directory.
+  Refetch on every start.
+- `-key` remains an **override** for the field and direct modes that
+  legitimately take a local PEM. Passing `-key` in enrol mode uses the
+  local file instead of fetching — useful for offline work and for the
+  headless deployment, which supplies its own.
+- A 403 (revoked) stops cleanly with a plain sentence pointing at the
+  owner's deck. Do not hot-loop, do not delete the buffer.
+- If the fetch fails transiently, that is "couldn't reach the service" —
+  distinct from "rejected". This repo shipped that exact conflation on
+  the site today; do not repeat it here.
+
+## Tests
+
+- [ ] `tycho-client -conf tycho.yaml` with **no other flags** proceeds
+  past argument validation. This is the regression that sent a real
+  user to a usage string; it needs a test naming that.
+- [ ] The fetched key never reaches disk — assert against the config
+  file's contents after a run, and against the buffer directory.
+- [ ] The key appears in no log line and no rendered TUI frame — assert
+  against captured output, the way the attestation loop asserted against
+  a serialised message.
+- [ ] A revoked scope's credential gets 403 from `/v1/device-key`.
+- [ ] An unauthenticated request to `/v1/device-key` gets 401.
+- [ ] `-key` still overrides in enrol mode, and field/direct modes are
+  unchanged.
+
+## Warts / traps
+
+- Do not put the key in `tycho.yaml`, in the repo, in a test fixture, or
+  in a release artifact. If you need one in a test, generate a throwaway
+  RSA key at test time.
+- Do not change enrolment, the setup code, the scope API, the upload
+  auth or `DescribeDevice` — all shipped today and verified against a
+  live gateway and real hardware.
+- The headless `tycho-agent` StatefulSet mounts its own key at
+  `KEY_PATH` and must keep working untouched. It is not an enrol-mode
+  client.
+- `docs/adr/**` is a record. If this warrants an ADR amendment, say so
+  in PR.md rather than editing 0009.
+
+Finish: `/workspace/PR.md` with a transcript of `tycho-client -conf
+tycho.yaml` running with no other flags, proof the key is absent from
+the config file and every log line afterwards, the revoked-scope
+behaviour, and a note on the firmware-rotation seam.

--- a/loops/specs/gate-postgres-ci/SPEC.md
+++ b/loops/specs/gate-postgres-ci/SPEC.md
@@ -1,0 +1,108 @@
+# SPEC — gate-postgres-ci: the auth resolver has never been executed by a test
+
+Repo: `loop-bot/tycho`. Gate: `make build test lint`.
+
+## The failure
+
+Eight tests in `gateway/internal/catalog` skip unless
+`TYCHO_TEST_DATABASE_URL` is set. **Nothing sets it** — not the
+Makefile, not `ci/main.go`, not `.forgejo/workflows/ci.yml`. So they
+have never run anywhere, and a green gate says nothing about them.
+
+Worse, six `Postgres` methods are not covered **even by those skipped
+tests** — they have no test at all, in any configuration:
+
+| method | `postgres.go` | what it is |
+|---|---|---|
+| **`ResolveCredential`** | `:252` | **authorises every authenticated request in the system** |
+| **`RevokeScope`** | `:142` | the "a revoked credential is refused everywhere" guarantee |
+| `ListScopes` | `:94` | the deck's read path |
+| `UpdateScopeLabel` | `:125` | |
+| `Heartbeat` | `:267` | |
+| `SetSessionTarget` | `:378` | manifest → session target |
+
+`main.go:227-230` passes `pg` as the `CredentialResolver` to upload,
+source **and** devicekey. The query behind every authorisation decision
+in Tycho has never been executed by a test.
+
+And the enrolment→authentication contract is untested end to end. The
+SHA-256 digest is implemented **three times** — `scope/credential.go:110`
+(`HashToken`), `authmw/authmw.go:123` (deliberately not shared, per its
+own comment), and again in `authmw_test.go:76`. **No test feeds
+`scope.Redeem`'s returned secret into `authmw.ScopeSecret`.** What makes
+a freshly enrolled scope able to authenticate at all is held together by
+a comment explaining why the duplication is safe.
+
+`storage/s3.go` (226 lines) and `eventbus/nats.go` have **no test file
+at all**.
+
+## Why now
+
+Yesterday's session-namespacing migration had to be verified by hand
+against a dump of production, three times, because CI cannot run a
+migration. That is not repeatable and it does not scale. Every future
+schema change has the same problem.
+
+## What to build
+
+### 1. Postgres in CI
+
+Add a Postgres service to the CI pipeline and set
+`TYCHO_TEST_DATABASE_URL` so the eight skip-gated tests actually run.
+
+`ci/main.go` builds with Dagger; `.forgejo/workflows/ci.yml` drives it.
+Work out where the service belongs and say why in PR.md. If the runner
+genuinely cannot host a service container, say so explicitly with what
+you tried — do not quietly leave the skips in place.
+
+`make test` should also use it when a database is available, and skip
+loudly (not silently) when not. The existing python legs already have a
+"loud skip" convention — follow it.
+
+### 2. Tests for the six uncovered methods
+
+Real tests against a real Postgres. `ResolveCredential` and
+`RevokeScope` are the ones that matter:
+
+- [ ] `ResolveCredential` resolves a valid credential to the right
+  scope, and returns nothing for an unknown one.
+- [ ] A **revoked** scope's credential resolves to nothing — the
+  property the whole revocation story rests on.
+- [ ] `RevokeScope` is idempotent, and does not touch sessions, subs or
+  results.
+
+### 3. The contract test that does not exist
+
+- [ ] **Redeem a code via `scope.Redeem`, then authenticate with the
+  returned secret via `authmw.ScopeSecret`.** Roughly twenty lines. It
+  is the only thing that proves a newly enrolled scope can actually
+  authenticate, across two independent implementations of the same
+  hash.
+
+### 4. Do not paper over what you cannot fix
+
+If Postgres in CI proves impossible on this runner, the fallback is to
+make the skips **loud and counted** — a failing gate under `STRICT=1`,
+not a silent pass — and to say plainly in `docs/dev/testing.md` and
+`docs/MATURITY.md` what is unverified.
+
+Note `MATURITY.md:37` currently says "three Go tests skip". It is
+**eight**, across six files. And `docs/dev/testing.md` — the document
+whose entire job is enumerating the gate's blind spots — **never
+mentions Postgres at all.** Fix both regardless of the outcome.
+
+## Warts / traps
+
+- Do not change production code to make it testable in ways that alter
+  behaviour. If a method resists testing, say so.
+- Do not touch `agent/` or the enrolment flow — shipped and verified
+  against real hardware.
+- The gate now runs `-race -count=1` by default. Keep it.
+- Migration `0008` rekeyed `session` to `(source_id, id)` and added
+  `sub.source_id`. Any fixture you build must match current schema, not
+  the old one.
+- `docs/adr/**` is a record, not a scratchpad.
+
+Finish: `/workspace/PR.md` with the eight tests actually running (paste
+the output), the new coverage numbers for `postgres.go`, the
+redeem→authenticate contract test, and the corrected blind-spot docs.

--- a/loops/specs/gate-race-detector/SPEC.md
+++ b/loops/specs/gate-race-detector/SPEC.md
@@ -1,0 +1,101 @@
+# SPEC — gate-race-detector: `-race` is red, and nothing runs it
+
+Repo: `loop-bot/tycho`. Gate: `make build test lint`.
+
+## The failure
+
+`go test -race ./agent/...` **fails, reproducibly, today**:
+
+```
+--- FAIL: TestEnrolMode_TailnetAuthKeyNeverLeaks
+    testing.go:1712: race detected during execution of test
+```
+
+Nothing runs it. `Makefile:74` is `go test ./agent/... ...` with no
+`-race`. `ci/main.go:41-42` drops it deliberately — *"alpine's musl
+lacks the C toolchain CGO needs; race detection runs locally via
+`go test -race`"* — and it does not run locally either, so the failure
+has simply been sitting there.
+
+## Why this is more than a flaky test
+
+The race is **in the tests that certify our three secrets never leak.**
+
+`enrolmode_test.go:1391` declares `var logBuf bytes.Buffer`, hands it to
+`slog.NewTextHandler` *and* `slog.SetDefault`, then reads
+`logBuf.String()` at `:1449` while pipeline goroutines are still writing
+to it. The assertion *"the boot log must not contain the tailnet auth
+key"* is therefore checked against a **torn, partially-written
+snapshot** — a leak logged a millisecond later is silently missed.
+
+Same pattern in the other two: `:501`/`:594` (the per-scope secret) and
+`:887`/`:993` (the device interop key). Those two pass only because
+their `waitLoop` happens to quiesce the pipeline first. That is luck,
+not synchronisation. All three read the buffer *before* their deferred
+`cancel()` + `p.Wait()`.
+
+So the three tests standing between us and a leaked credential cannot
+reliably see one.
+
+**The correct pattern already exists, unused, in the same package:**
+`syncBuffer` at `headless_test.go:21-36`.
+
+## What to build
+
+### 1. Fix the three races
+
+Use `syncBuffer` (or an equivalent mutex-guarded writer) for all three,
+and read the buffer **after** the pipeline has stopped — deferred
+`cancel()` and `Wait()` must happen before the assertion, not after.
+
+Do not weaken the assertions to make the race go away. The tests must
+still walk the whole buffer tree, the config file, and the rendered TUI
+frames.
+
+Check for the same pattern anywhere else a test shares a buffer with a
+running goroutine.
+
+### 2. Put `-race` in the gate
+
+- A `make` target that runs the Go suite with `-race`, and `make test`
+  must reach it locally. Say in PR.md whether you made it the default or
+  a separate target, and why.
+- **CI: add a `-race` leg rather than dropping the check.** The current
+  reason is real — musl lacks the CGO toolchain — so the fix is a
+  glibc-based job (a `golang:` image rather than alpine), not disabling
+  race detection. If the existing runner genuinely cannot host that, say
+  so explicitly in PR.md with what you tried; do not quietly leave the
+  gate as it is.
+- Add `-count=1` where it matters: `make test` can currently serve
+  entirely cached results.
+
+### 3. Correct the comments that are now false
+
+`ci/main.go:41-42` claims race detection "runs locally via `go test
+-race`". It does not, and that sentence is why nobody checked. Whatever
+you end up with, the comment must describe what actually happens.
+
+## Tests
+
+- [ ] `go test -race ./agent/...` passes.
+- [ ] The three leak tests still fail if a secret *is* leaked — prove
+  it. Temporarily log the secret in a scratch build, confirm each test
+  catches it, then remove that. Describe the exercise in PR.md. A leak
+  test that cannot fail is worse than no leak test, and that is exactly
+  what we have had.
+- [ ] `-race` is reachable from the documented gate command.
+
+## Warts / traps
+
+- Do not touch `gateway/`, `operator/` or the catalog — a sibling
+  effort covers Postgres in CI and will collide.
+- Do not change production code to silence a test race. If a race is in
+  production code, that is a finding: report it in PR.md prominently
+  rather than papering over it.
+- `docs/MATURITY.md` and `docs/dev/testing.md` describe the gate's blind
+  spots. If you change what the gate covers, they must change too —
+  `MATURITY.md:37` is already wrong about the skip count.
+
+Finish: `/workspace/PR.md` with the race fixed and `-race` output
+attached, the proof each leak test can still fail, what you did about
+CI, and every comment you corrected.

--- a/loops/specs/gateway-identity-enforcement/SPEC.md
+++ b/loops/specs/gateway-identity-enforcement/SPEC.md
@@ -1,0 +1,148 @@
+# SPEC — gateway-identity-enforcement: stop letting any agent claim any scope
+
+Repo: `loop-bot/tycho`. Gate: `make build test lint`.
+
+Implements **ADR 0008 (scope identity) section 2**. Unlike the previous
+loop, the ADR **is** in your clone: read
+`docs/adr/0008-scope-identity.md` before writing anything. If your
+implementation must diverge from it, say so in PR.md — do not edit the
+ADR to match your code.
+
+## The hole
+
+`RegisterSource` (`gateway/internal/catalog/postgres.go`) is an upsert
+behind a **single shared bearer token held by every agent in the
+fleet**:
+
+```sql
+INSERT INTO source (id, model, agent_version, registered_at, make, serial, ...)
+VALUES (...)
+ON CONFLICT (id) DO UPDATE SET
+    model = COALESCE(EXCLUDED.model, source.model),
+    serial = COALESCE(EXCLUDED.serial, source.serial),
+    ...
+```
+
+An agent that registers under a source id another owner already uses
+does not collide, does not error, and does not alert. It takes the row,
+and its frames land under the other owner's scope, attributed to them,
+pooled into their masters. A typo in `SOURCE_ID` does this. So does
+copy-pasting a config between two scopes — which is the *likely* way it
+happens, not the adversarial one.
+
+Until last night nothing could tell two devices apart, so the upsert was
+the only behaviour available. That changed:
+
+```
+id               | seestar-1
+model            | Seestar S30 Pro
+make             | ZWO
+serial           | 5741d34d
+hardware_id      | de079cbf89464ff2
+firmware_version | 8.46
+attested_at      | 2026-08-01 02:08:58+00
+```
+
+The live scope now attests. A fingerprint exists to enforce against.
+
+## The decision to implement
+
+**A registration whose fingerprint contradicts the recorded one is
+refused.** Not upserted, not warned about, not last-write-wins.
+
+The transitions, all four of which must be handled deliberately:
+
+| recorded | incoming | behaviour |
+|---|---|---|
+| no attestation | attests | **bind** — trust on first use, record it |
+| attested | same fingerprint | update firmware/agent version as today |
+| attested | no attestation (device unreachable) | **allowed**, existing attestation untouched — this already works via `COALESCE`, do not regress it |
+| attested | *different* fingerprint | **refuse**, loudly |
+
+Decide and state in PR.md: what counts as "different" when `serial`
+matches and `hardware_id` does not, or only one of the two is present?
+They are independent values (`device.sn` and `device.cpuId`) and a
+device can legitimately report one and not the other. Pick a rule,
+justify it, and make it a named function with its own tests rather than
+an inline `&&` — this is the predicate the whole decision rests on.
+
+## The rebind path is part of this loop, not a follow-up
+
+ADR 0008's consequences say it outright: without a rebind path, **the
+first legitimate hardware swap becomes a support incident.** An owner
+who genuinely replaces a scope and keeps the id must have a way through
+that is explicit and deliberate.
+
+- It must **not** be a flag on the normal registration path that an
+  agent can set for itself. If an agent can rebind itself, nothing was
+  enforced.
+- It must be an operator action against the gateway, or a documented
+  catalog operation — your call, argue for it in PR.md.
+- Whatever it is, **document it where the person hitting the error will
+  look.** The refusal message itself should point at the remedy. An
+  error that says "fingerprint mismatch" and nothing else sends someone
+  to the source code at 2am.
+
+## Do not turn a refusal into a hot loop
+
+The agent registers on startup and the uploader re-registers over its
+lifetime. If the gateway starts refusing, the agent must **back off and
+stay loud** — not retry every few seconds forever, and not silently
+give up either. A refused agent whose logs scroll one line per second is
+a refused agent nobody reads.
+
+Check what the current retry behaviour actually does before changing it,
+and say in PR.md what a refused agent does over its first ten minutes.
+
+## Tests
+
+The one that matters most is that **the running fleet keeps working**:
+
+- [ ] A source recorded exactly as `seestar-1` is above, re-registering
+  with that same fingerprint, succeeds. If this test fails you have
+  broken the only real scope in the fleet.
+- [ ] The same source re-registering with no attestation at all (device
+  was off) succeeds and leaves the recorded fingerprint intact.
+- [ ] A *different* fingerprint under the same id is refused, and the
+  recorded row is unchanged afterwards — assert the row, not just the
+  error. A refusal that still wrote is worse than no refusal, because
+  the error implies nothing happened.
+- [ ] An unattested source that attests for the first time binds.
+- [ ] The refusal is distinguishable by callers from an ordinary
+  failure — a typed error, not a string match on a message.
+- [ ] Whatever rebind path you build has a test that it works, and a
+  test that an ordinary agent registration **cannot** trigger it.
+
+## What this loop does not do
+
+**ADR 0008 §4 (`TELESCOP` demoted to audit) is not in this loop.**
+Comparing the header serial against the attested serial on ingest is the
+right thing and it belongs in its own loop: it changes the highest-
+throughput path in the system, and a wrong predicate there rejects
+every frame from a live scope instead of refusing one registration.
+Registration is a once-per-startup event and is where the hole is. Do
+not add header checking here.
+
+## Warts / traps
+
+- The gateway is the enforcement point. Do not put the check in the
+  agent — an agent enforcing a rule about itself is not enforcement.
+- Attestation is **self-reported, not cryptographic**. This refuses
+  accidents, collisions and copy-pasted configs. It does not stop a
+  modified firmware from claiming any serial, and the shared fleet
+  token is still the weak link. Do not write a comment, field name or
+  PR.md line calling this "secure" or "verified".
+- Do not change `DescribeDevice`, the keys allowlist, or anything in
+  `agent/internal/zwo` — that shipped last night and works against real
+  hardware.
+- `isNew` from `RegisterSource` drives `tycho.source.registered`'s
+  emitted-once semantics. Do not break it, and decide whether a refusal
+  should emit anything on the bus at all.
+- Migration numbering: next after the highest in
+  `gateway/internal/catalog/migrations/` (0006 is taken as of last
+  night).
+
+Finish: `/workspace/PR.md` with your fingerprint-comparison rule and why,
+the four transitions and what each does, the rebind path and how an
+owner discovers it, what a refused agent does over ten minutes, and
+proof that a `seestar-1`-shaped row still registers cleanly.

--- a/loops/specs/gateway-reenrol-state/SPEC.md
+++ b/loops/specs/gateway-reenrol-state/SPEC.md
@@ -1,0 +1,106 @@
+# SPEC — gateway-reenrol-state: re-enrolment leaves stale identity behind
+
+Repo: `loop-bot/tycho`. Gate: `make build test lint`.
+
+## The failure
+
+The founder hit Re-enrol on a scope, and the setup screen jumped
+straight to "✓ Found your scope — is this right? [Yes] [No]" without
+ever showing the new setup code. Yes and No both returned him to the
+same screen. A loop, with no way through.
+
+The site's mode resolution is correct given what we tell it:
+
+```ts
+if (!scope.enrolled)   return "need-code";
+if (!scope.attestedAt) return "waiting-attestation";
+return "found-it";
+```
+
+`seestar-1` was already `enrolled` (a credential from an earlier
+enrolment) and already `attestedAt` (from the device that enrolled
+then). Minting a new code changes **neither**, so every downstream
+consumer keeps reading the previous enrolment's identity as though it
+described the current one.
+
+The screen is not wrong about what it sees. It is answering *"has this
+scope ever attested?"* when the question is *"has it attested for
+**this** enrolment?"*
+
+A sibling loop (`webapp-reenrol-state`) is fixing the site half against
+the contract below, **right now**.
+
+## THE CONTRACT (identical in both specs — do not improvise)
+
+`GET /v1/scopes` gains one field per scope:
+
+```json
+{ "scope_id": "...", "enrolled": true, "attested_at": "...",
+  "pending_code": true }
+```
+
+- `pending_code` is a **boolean**. True when an enrolment code exists
+  for that scope which is neither redeemed nor expired.
+- All existing fields keep their current names and types.
+
+## What to build
+
+### 1. Report whether a code is outstanding
+
+`pending_code` on the scope read. It is the only fact that
+distinguishes "this scope is set up" from "someone is in the middle of
+setting it up again", and nothing currently exposes it.
+
+### 2. Redemption clears the previous identity
+
+When a code is redeemed for a scope that **already has** an
+attestation, that attestation describes a device from a previous
+enrolment and is no longer evidence about the current one. Clear it —
+`attested_at`, `model`, `make`, `serial`, `firmware_version` — as part
+of the same transaction that installs the new credential.
+
+The freshly-enrolled client re-attests within seconds, so the blank
+window is brief and honest. The alternative is what shipped: a serial
+on the screen that may belong to hardware the member no longer owns.
+
+Do **not** clear it when the code is merely *issued*. ADR 0009 §5 is
+explicit that the previous credential is invalidated on **redemption**,
+not on generating a code — otherwise generating a code by accident
+kills a working scope. Same reasoning applies here.
+
+### 3. Do not break the working path
+
+Re-registration by an already-enrolled, already-attested scope with a
+matching credential is untouched: no code involved, nothing cleared.
+This only fires on redemption.
+
+## Tests
+
+- [ ] A scope with an unredeemed, unexpired code reports
+  `pending_code: true`; one with no code, a redeemed code, or an expired
+  code reports `false`. Four cases, not one.
+- [ ] Redeeming a code for an attested scope clears `attested_at`,
+  `model`, `make`, `serial`, `firmware_version` — asserted from the
+  database, not the response.
+- [ ] The scope's **sessions, subs and results are untouched** by that
+  clearing. This is the test that matters most: `seestar-1` carries 8
+  sessions, 798 subs and the M13 masters, and re-enrolment must never
+  put a member's history at risk.
+- [ ] A normal register/heartbeat by an enrolled scope clears nothing.
+- [ ] Postgres-backed tests are **skip-gated** without
+  `TYCHO_TEST_DATABASE_URL`, so a green gate does not mean they ran.
+  Write them anyway and say so in PR.md.
+
+## Warts / traps
+
+- Do not change enrolment code generation, the upload path, the device
+  key endpoint, `DescribeDevice` or the keys allowlist — all shipped and
+  verified against real hardware.
+- `owner_member_id` and `label` are not identity and are never cleared.
+- Migration numbering: next after the highest in
+  `gateway/internal/catalog/migrations/`.
+- `docs/adr/**` is a record, not a scratchpad.
+
+Finish: `/workspace/PR.md` with the four `pending_code` cases, proof the
+history survives a re-enrolment, and the exact column list cleared on
+redemption.

--- a/loops/specs/gateway-scope-credentials/SPEC.md
+++ b/loops/specs/gateway-scope-credentials/SPEC.md
@@ -1,0 +1,191 @@
+# SPEC — gateway-scope-credentials: the gateway owns scope identity
+
+Repo: `loop-bot/tycho`. Gate: `make build test lint`.
+
+Implements **ADR 0009** (`docs/adr/0009-scope-credentials.md` — read it
+first) on the gateway side. Two sibling loops are building the client
+(`scopetui-enrolment`) and the web UI (`webapp-scope-management`)
+against the same contract **at the same time as you**. The contract
+below is law.
+
+**Stay out of `agent/` and `scopetui`.** The sibling loop owns that
+tree and you will collide.
+
+---
+
+## THE WIRE CONTRACT (identical in all three specs — do not improvise)
+
+### Identity
+
+Scope ids are **server-issued**, opaque: `scp_` + 8 lowercase hex, e.g.
+`scp_7f3a91c4`. Owners never type or choose one. The human label is a
+separate, editable, purely cosmetic field.
+
+### Catalog (Postgres, gateway-owned)
+
+`source` gains: `owner_member_id TEXT`, `label TEXT`,
+`credential_hash TEXT`, `credential_issued_at TIMESTAMPTZ`,
+`revoked_at TIMESTAMPTZ`.
+
+New table `enrolment_code`: `code_hash TEXT PRIMARY KEY`,
+`scope_id TEXT NOT NULL REFERENCES source(id)`, `created_at`,
+`expires_at`, `redeemed_at`.
+
+Codes and secrets are stored **SHA-256 hashed, hex**, never plaintext.
+
+### Codes and secrets
+
+- **Setup code:** 12 chars from `23456789ABCDEFGHJKMNPQRSTUVWXYZ`
+  (no `0/O/1/I/L`), formatted `XXXX-XXXX-XXXX`. TTL **30 minutes**.
+  Single use.
+- **Scope secret:** 32 random bytes, base64url, unpadded. Returned
+  exactly once, at redemption, and never retrievable again.
+
+### Gateway HTTP API
+
+Site → gateway, `Authorization: Bearer $SITE_API_TOKEN`:
+
+```
+POST   /v1/scopes                            {owner_member_id, label}
+                                             -> 201 {scope_id}
+GET    /v1/scopes?owner_member_id=...
+       -> 200 {scopes:[{scope_id, label, model, make, serial,
+                        firmware_version, attested_at,
+                        last_heartbeat_at, revoked_at, enrolled}]}
+PATCH  /v1/scopes/{scope_id}                 {label}   -> 204
+DELETE /v1/scopes/{scope_id}                           -> 204
+POST   /v1/scopes/{scope_id}/enrolment-code
+       -> 201 {code, expires_at}
+```
+
+Agent → gateway, **unauthenticated** (the code *is* the credential):
+
+```
+POST /v1/enrol   {code}   -> 200 {scope_id, secret}
+                          -> 410 expired / already redeemed / unknown
+```
+
+Agent → gateway, `Authorization: Bearer <scope secret>`:
+
+```
+POST /v1/sources/{scope_id}/register     (existing shape + attestation)
+POST /v1/sources/{scope_id}/heartbeat
+PUT  /v1/uploads/...                     (existing upload path)
+```
+
+`SOURCE_AUTH_TOKEN` is retired.
+
+---
+
+## What to build
+
+### 1. Close the upload path — this is the point of the whole ADR
+
+`upload.Service`'s own doc comment says it: *"this endpoint currently
+has no notion of caller identity beyond 'an agent' (authmw isn't wired
+onto the upload path)"*. Frames can be written under any source id, by
+anyone who can reach the gateway, with no token at all.
+
+- Every authenticated request carries a scope secret. Resolve it to a
+  scope id by hash.
+- **Reject 403 if the credential's scope id is not the `{scope_id}` in
+  the path**, and reject 403 if an upload's object key prefix is not
+  `tycho-source-<scope_id>/`.
+- A revoked credential (`revoked_at` non-null) is refused everywhere.
+
+Do not skip the object-key check because the path check exists. The
+object key is what decides where bytes land and whose attribution they
+join; it is the one that matters.
+
+### 2. Enrolment
+
+- `POST /v1/enrol` is the only unauthenticated write endpoint in the
+  gateway. Treat it accordingly: constant-time code comparison, and a
+  redemption that is **atomic** — two simultaneous redemptions of one
+  code must not both succeed. You have a pattern for this already:
+  `RegisterSource` on the parked `loop/enforce` branch used
+  `SELECT ... FOR UPDATE` in a transaction. Same shape.
+- Redemption returns the secret **once**. It is hashed on write and
+  there is no endpoint that reads it back. Say in PR.md what happens if
+  the agent loses the response (answer: the owner issues a new code).
+- Issuing a new code for a scope **invalidates any unredeemed code** for
+  that scope. Otherwise "generate again because the first didn't arrive"
+  quietly leaves two live codes.
+- An expired, unknown, or already-redeemed code all return **410 with
+  the same body**. Do not tell an unauthenticated caller which of the
+  three it was.
+
+### 3. Scope CRUD for the site
+
+`DELETE` **revokes the credential and soft-deletes the scope. It never
+deletes frames.** Someone removing a scope from their deck is saying
+"this device is no longer mine", not "erase three months of my data" —
+and `session.source_id` has a foreign key onto `source` anyway. Say in
+PR.md what a removed scope's existing frames and masters look like
+afterwards.
+
+`PATCH` changes only the label. A label is not identity and carries no
+authority; two scopes may share one.
+
+`GET` drives the deck. `enrolled` is true once a credential exists.
+Distinguish, in the response, a scope that has **never enrolled**, one
+enrolled but **never attested** (device was off), and one **attested** —
+the three states ADR 0008 called for. The web loop renders exactly
+these; if you collapse them it cannot.
+
+### 4. Migrate the live deployment
+
+`seestar-1` exists now, attested, with real frames and a foreign key
+from `session`. It must keep working.
+
+- Its id stays `seestar-1` — do not rewrite ids that other tables
+  reference. Server-issued ids apply to scopes created from here on.
+- Give it a path to a credential without a web UI: document it, and
+  provide whatever one-shot command or SQL the operator runs. Its
+  existing attestation carries across; it does not re-attest from
+  scratch.
+- Say in PR.md, precisely, the steps to migrate the running deployment,
+  in order, including what breaks if they are done out of order.
+
+### 5. `SITE_API_TOKEN`
+
+A new required env var, distinct from every other. Follow the precedent
+the parked branch set: **fail to start if it is missing, and fail to
+start if it equals any other configured token.** A documented invariant
+nobody checks is how this project keeps getting hurt.
+
+## Tests
+
+- [ ] An upload whose object key prefix does not match its credential's
+  scope is refused, and **nothing is written to Garage** — assert the
+  storage call did not happen, not just the status code.
+- [ ] A request authenticated as scope A against scope B's path is 403.
+- [ ] Redeeming a code twice: exactly one caller gets a secret.
+  Concurrent, not sequential.
+- [ ] An expired code and an unknown code are indistinguishable to the
+  caller.
+- [ ] A revoked scope cannot register, heartbeat, or upload.
+- [ ] `seestar-1` with its current row shape survives the migration and
+  can still register — this is the test that stops you breaking the only
+  real scope in the fleet.
+- [ ] Postgres-backed tests: note that they **skip** unless
+  `TYCHO_TEST_DATABASE_URL` is set, so a green gate does not mean they
+  ran. Write them anyway, and say in PR.md that they are skip-gated.
+
+## Warts / traps
+
+- Secrets and codes never appear in a log line, an error message, an
+  event payload, or a FITS header. Check your error wrapping.
+- Do not touch `agent/`, `agent/cmd/scopetui`, or
+  `agent/internal/uploader` — the sibling loop owns them and is
+  editing them right now.
+- Do not change `DescribeDevice`, the keys allowlist, or
+  `agent/internal/zwo`: shipped and working against real hardware.
+- Migration numbering: next after the highest in
+  `gateway/internal/catalog/migrations/` (0006 is taken).
+- `docs/adr/**` is a record, not a scratchpad.
+
+Finish: `/workspace/PR.md` with the migration runbook for `seestar-1`,
+what a removed scope's frames look like, the three enrolment states and
+how the site tells them apart, and proof the upload path now refuses a
+mismatched key.

--- a/loops/specs/operator-session-namespacing/SPEC.md
+++ b/loops/specs/operator-session-namespacing/SPEC.md
@@ -1,0 +1,133 @@
+# SPEC — operator-session-namespacing: one CR name for two telescopes
+
+Repo: `loop-bot/tycho`. Gate: `make build test lint`.
+
+Scope: **`operator/` only.** A sibling loop
+(`catalog-session-namespacing`) is doing the schema half in parallel —
+stay out of `gateway/` and `agent/`.
+
+## The failure
+
+A session id is `slugify(target)-YYYY-MM-DD` — `m-13-2026-07-27` — with
+**no scope in it**. The operator uses that string, alone, for two
+identities:
+
+**1. The `ImagingSession` CR name.** `sessionclose.go:171` calls
+`sessionCRName(sessionID)` (`:360`), which takes only the session id.
+Two scopes shooting the same target on the same night produce **one CR**,
+and the second scope's close silently updates the first's object.
+
+**2. The quiescence tracker key.** `activity.go:39-47`:
+
+```go
+s, ok := t.sessions[sessionID]
+if !ok {
+    s = &trackedSession{SourceID: sourceID, SessionID: sessionID}
+    t.sessions[sessionID] = s
+}
+```
+
+Keyed by `sessionID` alone — while *storing* `SourceID` in the struct.
+So the second scope's activity updates the first scope's entry, sub
+counts from both telescopes are summed under one, and `SourceID` stays
+whichever arrived first. The struct field records an ownership the map
+key does not enforce.
+
+## The good news
+
+**The operator already has the source id everywhere it needs it.** It
+validates its presence (`sessionclose.go:115-116`, *"missing source_id"*
+is a hard error), passes it to `closeSession` (`:133`), hands it to
+`RecordActivity` (`:135`), and puts it on the CR spec (`:197`). This is
+threading an argument you already hold into two naming decisions — not
+new plumbing.
+
+**And the pattern already exists in this repo.** `TargetMaster` names
+itself `master-seestar-1-m-13` — source, then target. Live proof:
+
+```
+NAME                    SOURCE      TARGET
+master-seestar-1-m-13   seestar-1   m-13
+```
+
+`targetMasterCRName` (`master_trigger.go:29`) is the convention to
+follow. Do not invent a second one.
+
+## What to build
+
+### 1. `sessionCRName` includes the source
+
+Same DNS-label-safe treatment, same 253-char clamp, same `unknown`
+fallback — with the source id in the name. Match `targetMasterCRName`'s
+shape so the two read alike.
+
+Mind the clamp: truncating must not make two different
+`(source, session)` pairs collide. Say in PR.md what you did about long
+names, and test it.
+
+### 2. The tracker keys on both
+
+`t.sessions` becomes keyed by the pair. Every method that reads or
+writes it follows. Keep `SourceID` on the struct — but it must now agree
+with the key by construction rather than by hope.
+
+### 3. Existing CRs: decide deliberately and say so
+
+There are **8 live `ImagingSession` CRs**, all owned by `seestar-1`, all
+named by the old scheme — including `m-13-2026-07-18/27/29`, whose
+frames are in the M13 masters on the public site:
+
+```
+68-herculis-2026-07-15   m-13-2026-07-18   m-13-2026-07-27
+m-13-2026-07-29   nu-coronae-borealis-2026-07-27
+pi-herculis-2026-07-17   rho-herculis-2026-07-15   rho-herculis-2026-07-17
+```
+
+Renaming means the operator stops recognising them and creates new
+objects alongside — orphaning eight records of real observing history,
+five of them `Done` with completed stacks.
+
+Decide and justify in PR.md. Options, not exhaustive:
+- accept the orphans and document what an operator should do with them
+- look up by a label or spec field rather than by name, so existing CRs
+  are still found
+- provide a one-shot migration the operator runs by hand
+
+**Do not silently orphan them.** Whatever you choose, say what happens
+to those eight objects and what a human has to do about it.
+
+### 4. Do not change what the operator does, only how it names
+
+Reconcile logic, phases, combine triggering, event payloads and the
+`TargetMaster` path are all unchanged. This loop changes identity, not
+behaviour.
+
+## Tests
+
+- [ ] Two sources with the **same session id on the same night** produce
+  two distinct CR names and two distinct tracker entries, each with the
+  right sub counts. This is the whole point.
+- [ ] The tracker's `SourceID` field can no longer disagree with its
+  key — assert it rather than trusting it.
+- [ ] Quiescence still fires correctly for a single source (the existing
+  behaviour must be untouched).
+- [ ] Long source/session combinations still yield valid, distinct,
+  DNS-safe names.
+- [ ] `operator/fullloop_test.go` — note that it constructs
+  `CombineJobReconciler` **without `Scheme`**, which trips an early
+  `return nil` and silently disables the master and fleet-master spawn
+  paths. If your change touches anything those paths reach, that test
+  will not tell you. Say in PR.md whether you fixed it or worked around
+  it; do not assume it covers you.
+
+## Warts / traps
+
+- Do not touch `gateway/` or `agent/` — the sibling loop owns the
+  schema, and the agent's `SessionID` is deliberately unchanged.
+- The operator does not read Postgres; it is event- and CRD-driven. You
+  do not need the schema change to land first.
+- `docs/adr/**` is a record, not a scratchpad.
+
+Finish: `/workspace/PR.md` with the new naming scheme beside
+`targetMasterCRName` for comparison, your decision on the eight existing
+CRs and what a human must do, and the two-scopes-one-night test.

--- a/loops/specs/rename-tycho-client/SPEC.md
+++ b/loops/specs/rename-tycho-client/SPEC.md
@@ -1,0 +1,95 @@
+# SPEC — rename-tycho-client: one name for the thing users run
+
+Repo: `loop-bot/tycho`. Gate: `make build test lint`.
+
+## Why
+
+The binary a user downloads and runs is called `scopetui`. It is the
+**client** — the thing that connects a scope to Tycho. The TUI is how
+it happens to present itself, not what it is for, and naming it after
+its rendering layer is why every doc has to explain what it does.
+
+Decision (the founder's, taken today): it is **`tycho-client`**.
+
+```
+$ tycho-client -conf tycho.yaml
+```
+
+This matters now rather than later because the enrolment flow shipped
+today puts that command in front of every new user, on a setup screen,
+as the one thing they must type. Renaming it after people have it in
+their shell history is a worse day than renaming it this afternoon.
+
+## What to rename
+
+- `agent/cmd/scopetui/` → `agent/cmd/tycho-client/`, and the binary it
+  produces.
+- Every reference: `README.md`, `docs/**` (except `docs/adr/**`, see
+  traps), Makefile targets, CI workflow, package docs, comments, test
+  names, log lines, help text, and the TUI's own header.
+- Anything user-visible that says "scopeTUI" in prose becomes "the
+  Tycho client" or `tycho-client` as the sentence needs.
+
+## Audit the rest of the names, and mostly leave them alone
+
+The founder's ask was broader than one binary: *"we're getting to the
+point that we might need to unite the naming"*. So audit — but change
+only what is actually inconsistent, and say why in PR.md for each.
+
+Current state, for reference:
+
+| name | what it is |
+|---|---|
+| `tycho-agent`, `tycho-gateway`, `tycho-operator`, `tycho-combine`, `tycho-scorer` | services — already consistent |
+| `scopetui` | the client — **renaming** |
+| `scopectl` | one-shot ZWO debug CLI |
+| `fleetview` | fleet-wide ingest view over JetStream |
+| `dummyscope`, `simfleet` | simulators (`docs/dev/simulation.md`) |
+
+Guidance, not orders:
+
+- The **services** are already `tycho-*`. Do not touch them: their names
+  are in Kubernetes manifests, image tags and gitops in another repo
+  that this loop cannot see, and renaming them breaks a live deployment
+  for zero user benefit.
+- `scopectl` and `fleetview` ship to operators, so consistency has some
+  value. Weigh it against the same breakage risk and argue your call.
+- `dummyscope`/`simfleet` are dev-only. Renaming them is churn.
+- README already frames these as "supporting binaries, deliberately not
+  part of 'one client'". That distinction is deliberate — preserve it or
+  explain why it should go.
+
+**Do not rename anything whose name appears in a Kubernetes manifest,
+an image tag, or a gitops repo.** You cannot see those, and a green
+gate here will not tell you it broke.
+
+## Traps
+
+- `docs/adr/**` is a historical record. ADRs 0008 and 0009 were written
+  today and mention the client. **Do not rewrite them.** An ADR records
+  what was decided when it was decided; the rename is later context.
+  If a reference genuinely misleads, the fix is a note, not an edit.
+- The `tycho.yaml` config filename does **not** change.
+- The `-conf`/`-scope`/`-agent`/`-key` flags do **not** change. This is a
+  rename, not a CLI redesign, and the setup screen live on the site
+  right now tells users to type `-conf tycho.yaml`.
+- Do not touch the enrolment code, the keys allowlist, `DescribeDevice`,
+  or the credential handling — all shipped today and verified against
+  real hardware and a live gateway. This loop moves names, nothing else.
+- Release asset filenames are produced by a build script in a different
+  repo. Do not try to fix them here; note in PR.md what the new binary
+  name means for them.
+
+## Tests
+
+- [ ] `make build test lint` green, which is table stakes.
+- [ ] No occurrence of `scopetui` or `scopeTUI` survives outside
+  `docs/adr/**` and any CHANGELOG-style history — grep for both spellings,
+  case-insensitively, and put the grep output in PR.md.
+- [ ] The existing client tests still pass under the new package path,
+  unchanged in substance. If you find yourself editing what a test
+  asserts, you are no longer doing a rename.
+
+Finish: `/workspace/PR.md` with the grep proving the old name is gone,
+your decision and reasoning for each other binary, and anything you
+deliberately left alone because it reaches outside this repo.

--- a/loops/specs/scopetui-enrolment/SPEC.md
+++ b/loops/specs/scopetui-enrolment/SPEC.md
@@ -1,0 +1,187 @@
+# SPEC — scopetui-enrolment: download it, run it, find the scope, done
+
+Repo: `loop-bot/tycho`. Gate: `make build test lint`.
+
+Implements **ADR 0009** (`docs/adr/0009-scope-credentials.md` — read it
+first) on the client side. Two sibling loops are building the gateway
+(`gateway-scope-credentials`) and the web UI
+(`webapp-scope-management`) against the same contract **right now**.
+The contract below is law.
+
+**Stay out of `gateway/`.** The sibling loop owns that tree.
+
+---
+
+## THE WIRE CONTRACT (identical in all three specs — do not improvise)
+
+Scope ids are **server-issued**, opaque: `scp_` + 8 lowercase hex.
+Owners never type one.
+
+Setup code: 12 chars from `23456789ABCDEFGHJKMNPQRSTUVWXYZ` (no
+`0/O/1/I/L`), formatted `XXXX-XXXX-XXXX`, TTL 30 minutes, single use.
+
+Scope secret: 32 random bytes, base64url, unpadded — issued once at
+redemption.
+
+```
+POST /v1/enrol   {code}   -> 200 {scope_id, secret}
+                          -> 410 expired / already redeemed / unknown
+```
+
+Then everything else carries `Authorization: Bearer <scope secret>`:
+
+```
+POST /v1/sources/{scope_id}/register     (existing shape + attestation)
+POST /v1/sources/{scope_id}/heartbeat
+PUT  /v1/uploads/...
+```
+
+Downloaded `tycho.yaml`:
+
+```yaml
+endpoints:
+  - url: https://gateway.tychofleet.com
+    setup_code: KX7M-2QN4-8PLD
+    label: Backyard S30
+```
+
+After redemption scopeTUI **rewrites the file in place**, replacing
+`setup_code` with the issued identity:
+
+```yaml
+endpoints:
+  - url: https://gateway.tychofleet.com
+    scope_id: scp_7f3a91c4
+    secret: <base64url>
+    label: Backyard S30
+```
+
+File mode **0600**. The secret is never logged, never rendered in the
+TUI, never in an event or a FITS header.
+
+`SOURCE_ID` and `SOURCE_AUTH_TOKEN` are retired as client config.
+
+---
+
+## The user this is for
+
+Someone who has never used Tycho, has a Seestar on their home WiFi, and
+has just downloaded a binary and a config file from a website. They do
+not know their scope's IP address. They may not know what an IP address
+is. They are standing outside in the dark.
+
+Everything below follows from that.
+
+## What to build
+
+### 1. `scopetui -conf tycho.yaml` handles the whole first run
+
+Today `-conf` is field mode and expects a fully-formed config with a
+static `SCOPE_HOST`. Now it must:
+
+1. Read `tycho.yaml`. If the endpoint has a `setup_code`, redeem it.
+2. Persist the issued `scope_id` + `secret` back into the file, 0600.
+3. Find the scope on the local network (section 2).
+4. Attest it (`DescribeDevice` already exists — do not modify it).
+5. Register, heartbeat, and stream, authenticated with the secret.
+
+A second run finds `scope_id`/`secret` already present and skips
+straight to step 3. **Re-running must never re-redeem** — the code is
+gone, and a stale `setup_code` left in the file after a successful
+redemption is a bug that will strand people.
+
+If redemption returns 410, say so in words a beginner can act on: the
+code has expired or already been used, generate a new one from the
+website. Do not print the status code alone.
+
+### 2. Find the scope — no IP address typed by a human
+
+This is the worst step in the flow today and it is the reason this loop
+exists. `agent/internal/discovery` is static-IP only (`agent/main.go:56`
+says so). Build discovery:
+
+- Probe the local subnet(s) for a reachable ZWO control socket on TCP
+  **4700**, concurrently and with a short per-host timeout. Bound it —
+  scanning a /16 sequentially is not acceptable.
+- A host that accepts on 4700 **is not proof** it is a Seestar. Confirm
+  by completing the handshake and asking the device what it is
+  (`DescribeDevice`) before offering it.
+- More than one found: list them with make/model/serial and let the
+  person pick. Do not silently take the first.
+- None found: fall back to prompting for an address, with a message
+  that says what to check — scope powered on, on the same WiFi as this
+  computer, not still in its own hotspot mode.
+- An explicit address in the config or on the flag skips discovery
+  entirely.
+
+Say in PR.md how long a scan takes on a /24 and what it does on a
+machine with several interfaces (VPN, docker bridges, tailscale).
+
+### 3. Show state a person can act on
+
+The TUI should make these distinguishable at a glance, because they
+have completely different remedies:
+
+| state | what the person does |
+|---|---|
+| endpoint unreachable | check internet |
+| code rejected | get a new code from the site |
+| no scope found | check the scope is on and on this WiFi |
+| scope found, not answering identity | probably fine, keep going |
+| running | nothing |
+
+Note that "no device" currently masquerades as a parse error — with the
+scope off, the agent logs `zwo: decoding get_verify_str result:
+unexpected end of JSON input`, a decode failure for a connectivity
+problem. Do not surface that string to a human. Classify it.
+
+### 4. Failure handling that does not strand anyone
+
+- Losing the endpoint mid-session must not lose frames: the buffer and
+  retry behaviour that exists today keeps working, unchanged.
+- A **revoked** credential (the owner removed the scope from their deck)
+  gets 401/403 from the gateway. Stop cleanly, say why in one plain
+  sentence, do not hot-loop, do not delete the buffer.
+- A corrupt or partially-written `tycho.yaml` must not brick the next
+  run. Write it atomically (temp file + rename), not in place.
+- Never print the secret, even at debug level, even in a "here's your
+  config" summary.
+
+## Tests
+
+- [ ] Redemption happens exactly once: a second run with a persisted
+  credential makes no `/v1/enrol` call.
+- [ ] After redemption the file contains `scope_id` + `secret` and **no
+  `setup_code`**, at mode 0600.
+- [ ] A 410 from `/v1/enrol` produces an actionable message, not a
+  status code.
+- [ ] Discovery finds a simulated scope on a loopback listener,
+  rejects a port-4700 listener that is not a scope, and terminates
+  within its bound when nothing is there.
+- [ ] The secret appears in no log line and no rendered TUI frame —
+  assert against captured output, the way the attestation loop asserted
+  against a serialised message.
+- [ ] A 403 from a revoked credential stops cleanly without a retry
+  storm.
+
+`dummyscope` exists (`docs/dev/simulation.md`) — use it rather than
+inventing a second fake.
+
+## Warts / traps
+
+- Do not touch `gateway/` — the sibling loop is editing it now.
+- Do not modify `DescribeDevice`, the keys allowlist, or
+  `agent/internal/zwo`'s attestation path: shipped and working against
+  real hardware last night.
+- The scope's ZWO RSA key (`see_start_pem`, `KEY_PATH`) is unrelated to
+  any of this and unchanged — it authenticates to the *device*, not to
+  Tycho. Do not conflate them.
+- Windows is a supported target (`loops/bin/release-build.sh` cross-
+  builds it). File modes and network scanning both behave differently
+  there — say in PR.md what you did about it.
+- `docs/adr/**` is a record, not a scratchpad.
+
+Finish: `/workspace/PR.md` with a transcript of a full first run
+(discovery through streaming), the file before and after redemption
+with the secret redacted, scan timings, and what each of the five
+states above looks like on screen.

--- a/loops/specs/tycho-client-tailnet/SPEC.md
+++ b/loops/specs/tycho-client-tailnet/SPEC.md
@@ -1,0 +1,146 @@
+# SPEC — tycho-client-tailnet: join the tailnet, then dial
+
+Repo: `loop-bot/tycho`. Gate: `make build test lint`.
+
+## Why
+
+The gateway is published **only** on the Tycho fleet tailnet:
+`https://tycho-gateway.tail92d9b0.ts.net`. Not on the public internet,
+not on any LAN. A client that dials it as an ordinary HTTPS endpoint
+resolves nothing — which is exactly what a real member hit:
+
+```
+$ ./tycho-client -conf tycho.yaml
+tycho-client: couldn't reach http://tycho-gateway.tycho.svc.cluster.local
+              — check this computer's internet connection
+```
+
+The tailnet path already exists in this repo and enrolment was built
+without it. `agent/internal/tailnet` brings the binary up as an
+**embedded tsnet node** — no tailscaled, no root — and everything
+northbound goes through its dialer. `agent/internal/fieldconf` already
+carries an `authkey`. Enrol mode invented a second config format and a
+second, non-tailnet path.
+
+**This loop puts enrolment back on the tailnet.** A sibling loop is
+building the site half right now against the contract below.
+
+## THE CONTRACT (identical in both specs — do not improvise)
+
+The downloaded `tycho.yaml` gains one field:
+
+```yaml
+endpoints:
+  - url: https://tycho-gateway.tail92d9b0.ts.net
+    setup_code: KX7M-2QN4-8PLD
+    tailscale_auth_key: tskey-auth-xxxxxxxxxxxx
+    label: Backyard S30
+```
+
+All four are **strings**. (A contract that named a field and not its
+type is how two green loops shipped a broken flow this week.)
+
+After a successful first run the file is rewritten with the issued
+identity and **without** either single-use secret:
+
+```yaml
+endpoints:
+  - url: https://tycho-gateway.tail92d9b0.ts.net
+    scope_id: scp_7f3a91c4
+    secret: <base64url>
+    label: Backyard S30
+```
+
+Mode 0600, written atomically (temp file + rename).
+
+## What to build
+
+### 1. Join the tailnet before anything else
+
+Order matters and is not negotiable: **tsnet up → redeem → device key →
+attest → register → stream.** Every one of those needs the gateway, and
+the gateway is only reachable through the tailnet.
+
+- Bring the node up from `tailscale_auth_key` using
+  `agent/internal/tailnet` — the package that already exists. **Do not
+  write a second tailnet implementation.** The whole reason this loop
+  exists is that enrolment grew a parallel path.
+- tsnet state persists under the buffer directory
+  (`fieldboot.TailnetStateDirName` is already the convention), so a
+  second run rejoins without a key.
+- The auth key is **single-use**. Once the node has joined, remove it
+  from `tycho.yaml`. A stale key left in the file is a dead credential
+  that will confuse the next run and the next reader.
+- Every northbound dial — redeem, device-key, register, heartbeat,
+  upload — goes through the tsnet dialer. Assert this; a call that
+  accidentally uses the default transport will work on your machine and
+  fail on a member's.
+
+### 2. Keep the existing modes working
+
+- **Field mode** (`tycho.conf`, `-scope`, `-key`) is unchanged. The
+  headless `tycho-agent` StatefulSet depends on it and is running in
+  production right now.
+- The two config formats may stay separate **only if** they share one
+  tailnet bring-up path. If you can converge them cleanly, do — and if
+  you cannot, say precisely why in PR.md. Two formats is tolerable; two
+  implementations of joining a tailnet is what caused this.
+- `-key` still overrides the served device key. Unrelated to the
+  tailnet key — do not conflate them. One authenticates to the *scope*
+  over the local network; the other joins *Tycho's* network.
+
+### 3. States a person can act on
+
+Four failures, four different remedies. Do not collapse them:
+
+| state | what the person must do |
+|---|---|
+| tailnet key rejected/expired | get a new config from the website |
+| joined, but gateway unreachable | check internet; the tailnet is up |
+| setup code rejected (410) | get a new code |
+| credential revoked (403) | the scope was removed from their deck |
+
+"Couldn't reach the service" for a rejected request shipped this week
+and had to be fixed. Do not reintroduce it here.
+
+### 4. Secret handling
+
+Neither the tailnet auth key nor the scope secret nor the device interop
+key may appear in a log line, an error, a rendered TUI frame, an event,
+or a FITS header. `TestEnrolMode_DeviceKeyNeverLeaks` is the pattern —
+extend it to cover the tailnet key.
+
+## Tests
+
+- [ ] `tycho-client -conf tycho.yaml` with **no other flags** joins the
+  tailnet and proceeds. This is the command the setup screen prints.
+- [ ] A second run makes no `/v1/enrol` call and needs no auth key —
+  tsnet state is reused.
+- [ ] After a successful first run the file has `scope_id` + `secret`
+  and **neither** `setup_code` nor `tailscale_auth_key`, at 0600.
+- [ ] Northbound requests go through the tsnet dialer, asserted — not
+  the process default transport.
+- [ ] Each of the four states above produces its own distinct,
+  actionable message.
+- [ ] No secret in captured output.
+
+`agent/internal/tailnet`'s tests run fully offline (tsnet only dials
+lazily). Keep that property — the gate has no network.
+
+## Warts / traps
+
+- Do not modify `DescribeDevice`, the keys allowlist, `agent/internal/
+  zwo`, the enrolment protocol, or the device-key endpoint — all shipped
+  and verified against real hardware and a live gateway today.
+- Do not hardcode the tailnet hostname. It comes from the config.
+- Discovery of the scope on the local network is unchanged and stays
+  local — the telescope is on the member's LAN, not the tailnet.
+- The fleet ACL confines `tag:scope` to the gateway alone. If you find
+  yourself needing to reach anything else on the tailnet, stop: that is
+  a design change, not an implementation detail.
+- `docs/adr/**` is a record, not a scratchpad.
+
+Finish: `/workspace/PR.md` with a transcript of a full first run from
+tailnet join through streaming, the config file before and after with
+secrets redacted, proof the dialer is tsnet's, and what each of the four
+failure states looks like on screen.

--- a/loops/specs/webapp-client-downloads/SPEC.md
+++ b/loops/specs/webapp-client-downloads/SPEC.md
@@ -1,0 +1,104 @@
+# SPEC — webapp-client-downloads: the client has to be downloadable
+
+Repo: `loop-bot/tychofleet`. Gate: `make build test lint`.
+
+## The failure
+
+Setup screen 3 (`/scopes/{id}/setup`, shipped in PR #44) says
+"Download scopeTUI" and links at Forgejo release assets. `loop-bot/tycho`
+is a **private repo**, so a signed-out browser gets:
+
+```
+GET .../releases/download/scopetui-v0.3.0/...windows-amd64.zip
+  HTTP 404
+```
+
+Not the listing — the **binary itself**. A real user cannot obtain the
+client at all, which means step 1 of onboarding is a dead end and every
+screen after it is unreachable.
+
+`src/lib/gateway/releases.ts` currently calls Forgejo's API. It already
+degrades honestly (`unreachable` / `not-available`, never a broken
+link), which is why the page doesn't lie today. That module is what
+this loop replaces.
+
+## The fix: serve the client from Garage, through the site
+
+Release assets are published into the Garage bucket the site already
+reads, under a `clients/` prefix:
+
+```
+clients/<tag>/<asset-filename>
+e.g. clients/scopetui-v0.3.0/tycho-...-windows-amd64.zip
+```
+
+**No new credential.** The site already holds
+`GARAGE_ACCESS_KEY_ID`/`GARAGE_SECRET_ACCESS_KEY` and already streams
+Garage objects for master previews — reuse that path.
+
+- A **signed-in member** can download. Signed-out gets the same
+  treatment as any other member surface (redirect to login), not a 403
+  blob and not a silent empty page.
+- Reuse `/fleet/[slug]/master-preview.jpg`'s safety property exactly:
+  **never stream an arbitrary key taken from a URL.** The route accepts
+  a platform (and optionally a version), resolves it to a key against
+  what actually exists, and streams only that. A caller must not be able
+  to name a key and have it served.
+- Stream it; do not buffer a 20 MB archive in memory to hand it back.
+
+## Discovering what exists
+
+The site must not hardcode filenames — they carry a version string that
+changes every release, and today's are ugly for reasons unrelated to
+this loop (`tycho-list-25-gdffbc71-windows-amd64.zip`; a stale git tag
+pollutes `git describe`). Resolve by **listing the `clients/` prefix**
+and matching on platform substring, the way `releases.ts` already does:
+
+```
+macos   -> "macos", "darwin"
+linux   -> "linux"
+windows -> "windows", ".exe"
+```
+
+Pick the newest tag present. Say in PR.md how you decide "newest" and
+what happens when two assets match one platform (there are two macOS
+builds — `darwin-amd64` and `darwin-arm64` — and a member on Apple
+silicon must not be handed the Intel one; decide deliberately, and if
+you offer both, label them in words a person understands rather than
+`amd64`/`arm64` alone).
+
+## The states, all of which must read honestly
+
+| state | what the page says |
+|---|---|
+| asset found | a real download link |
+| Garage reachable, no asset for this platform | plainly: no build for this platform yet |
+| Garage unreachable | "couldn't check right now" — never a dead link |
+
+A blank panel or a link that 404s is worse than an honest "not
+available". This repo has shipped plausible-looking emptiness before;
+do not add another.
+
+## Tests
+
+- [ ] A signed-out request to the download route does not stream bytes.
+- [ ] A member downloading gets the asset for the platform they asked
+  for, and **cannot** obtain a different object by manipulating the URL
+  — assert an attempt to name an arbitrary key is refused.
+- [ ] Each of the three states above renders its own distinct text.
+- [ ] Listing finds the newest tag when several are present.
+- [ ] No Forgejo call remains on the setup path — grep for it.
+
+## Warts / traps
+
+- Do not add a Forgejo token to this repo. The whole point is that the
+  client is obtainable without one.
+- Do not change the enrolment flow, the setup code, or the scope API —
+  they work and were verified against the live gateway today.
+- The 88 MB FITS download rule still stands elsewhere: streamed, never
+  buffered. Same discipline here.
+- `docs/design/**` is read-only law.
+
+Finish: `/workspace/PR.md` with the resolved key for each platform, the
+arm64-vs-amd64 decision, an ASCII render of screen 3 in all three
+states, and proof that a URL naming an arbitrary object is refused.

--- a/loops/specs/webapp-connecting-state/SPEC.md
+++ b/loops/specs/webapp-connecting-state/SPEC.md
@@ -1,0 +1,99 @@
+# SPEC — webapp-connecting-state: "offline" is hiding a third state
+
+Repo: `loop-bot/tychofleet`. Gate: `make build test lint`.
+
+## The failure
+
+The founder finished setup, watched his deck, and saw his brand-new
+scope reported as **offline** — while the client was running fine and
+the gateway was recording heartbeats seconds later. He asked, exactly:
+
+> is that offline like my scope is off, or just not broadcasting
+> anything?
+
+That is the question the card should already have answered. A minute
+later it flipped to online on its own.
+
+Nothing is broken. `resolveScopeCardState` (`src/lib/scope-deck.ts`) is
+behaving as written: with `lastHeartbeatAt` null it returns
+`{kind: "offline", lastSeenText: null}`. The bug is that **two very
+different situations render as the same word**:
+
+| reality | today | what it means |
+|---|---|---|
+| never heard a heartbeat | `offline` | it is still coming up |
+| heard one, but not recently | `offline · last seen 4h ago` | it really is down |
+
+The first happens exactly once per scope — in the minute after setup,
+while the member is staring at the screen deciding whether any of this
+worked. Telling them "offline" then is the worst possible moment to be
+imprecise.
+
+## The fix
+
+A distinct state for **enrolled and attested, but no heartbeat ever
+received**. Call it `connecting` unless the design language suggests
+better.
+
+- It reads as work in progress, not failure: something like
+  `◌ connecting… waiting for the first check-in`. Do not use the word
+  offline, and do not use a red/error treatment.
+- Once any heartbeat has ever arrived, the existing two states apply
+  unchanged: recent → `● online`; stale → `● offline · last seen …`.
+- A scope that goes quiet after having been seen is **offline**, never
+  back to connecting. `connecting` means "never yet", not "not right
+  now" — otherwise it becomes another word for offline and we are back
+  where we started.
+
+`HEARTBEAT_STALE_AFTER_MS` (2 minutes) stays as is. Its comment notes
+the client's real heartbeat interval was unknown when it was written —
+it is **500ms in tests and the production default is set by
+`uploader.WithHeartbeatInterval`**; if you can confirm the real interval
+from the tycho repo's defaults, say so in PR.md and adjust the constant
+only if 2 minutes is clearly wrong. Do not guess.
+
+## Does it need to be reassuring for long?
+
+Consider, and decide deliberately: a scope that has said `connecting…`
+for a very long time is not connecting, it is broken. Either leave it
+connecting forever (simple, honest about what we know: we have never
+heard from it) or degrade to something firmer after a while. If you
+degrade, say what the threshold is and why, and make sure the message
+still tells the member what to *do* — the setup screen is where they
+would go.
+
+State your choice in PR.md either way. Silently picking one is how the
+current ambiguity got in.
+
+## Tests
+
+- [ ] Enrolled + attested + `lastHeartbeatAt` null renders `connecting`,
+  and specifically **does not** contain the word "offline".
+- [ ] A heartbeat within the window renders `online`.
+- [ ] A heartbeat older than the window renders `offline` **with** a
+  last-seen time.
+- [ ] A scope that was online and goes stale renders `offline`, not
+  `connecting` — assert this explicitly; it is the regression that
+  would make the new state meaningless.
+- [ ] The existing `setup-not-finished` and `awaiting-attestation`
+  states are unchanged.
+
+Five states now, each with its own test. `src/tests/pages/
+scope-deck-cards.test.ts` already has the shape.
+
+## Warts / traps
+
+- This is a **rendering** change. Do not touch the gateway, the scope
+  API, enrolment, key minting, or the heartbeat itself.
+- The deck polls; do not add a refresh mechanism to make `connecting`
+  resolve faster. It resolves on its own within a heartbeat.
+- A degraded gateway read must still render `--`, never `0h 00m`, and
+  never a fabricated state. If we cannot reach the gateway we do not
+  know whether the scope is connecting or offline, and must not claim
+  either.
+- `docs/design/**` is read-only law.
+
+Finish: `/workspace/PR.md` with an ASCII render of all five card states
+as built, your decision on whether `connecting` ever degrades and why,
+and whether you were able to confirm the client's real heartbeat
+interval.

--- a/loops/specs/webapp-fail-closed/SPEC.md
+++ b/loops/specs/webapp-fail-closed/SPEC.md
@@ -1,0 +1,99 @@
+# SPEC — webapp-fail-closed: a fake that looks real, and a timeout that lies
+
+Repo: `loop-bot/tychofleet`. Gate: `make build test lint`.
+
+Two defects found by a senior review, both confirmed. They are unrelated
+in code and identical in shape: **something reports success while doing
+the wrong thing, and a comment says it is fine.**
+
+## 1. Production mints fake Tailscale keys
+
+`src/lib/provision/index.ts:10`
+
+```ts
+const kind = process.env.PROVISIONER ?? "fake";
+```
+
+`PROVISIONER` is **unset in the live deployment** (verified in the
+running pod) and appears in no gitops manifest. So `getProvisioner()`
+returns `FakeProvisioner`, whose `mintAuthKey` returns
+`tskey-fake-000001` (`src/lib/provision/fake.ts:19`).
+
+The admin approve flow then stores it (`api/admin/approve.ts:82`),
+emails a working-looking invite (`:109`), and the member downloads a
+`tycho.conf` containing it (`src/lib/tycho-conf-delivery.ts:34`).
+Every screen reports success. The member's agent silently never joins
+the tailnet. `src/lib/remint.ts:22` has the same exposure.
+
+This contradicts the codebase's own posture everywhere else: the
+gateway, tsmint, garage and catalog clients all fail **closed** to an
+honest `not-wired`. This one fails **open**, to a fake that looks real.
+
+**Fix:** no default. An unset `PROVISIONER` in a non-test environment is
+a configuration error and must fail loudly — at startup if you can
+reach it, otherwise on first use, with a message naming the variable.
+Selecting the fake must be explicit and impossible to do by omission.
+
+Keep the fake available for tests, and give it a failure mode: it
+currently never throws (`fake.ts:16-24`), so every caller's error path
+— including `approve.ts:54-56` — has never been exercised.
+
+## 2. The 3-second abort truncates every large download
+
+`src/lib/garage/client.ts:83,150,244` pass
+`AbortSignal.timeout(CONNECT_TIMEOUT_MS)` with `CONNECT_TIMEOUT_MS =
+3000`. The comment at `:77-83` asserts:
+
+> *"the response is piped through, never buffered, so this timeout only
+> guards 'Garage never answered at all'."*
+
+**That is false**, and was demonstrated empirically on this project's
+Node version: the signal stays attached to the response body, and
+firing it after headers arrive destroys the stream mid-transfer.
+
+Because `fleet/[slug]/master-download.fit.ts:57` and
+`api/tycho-client/[platform].ts:50` pipe the stream straight to the
+client, client backpressure propagates upstream. An 88 MB FITS on a
+10 Mbps link needs ~70 s; the signal fires at 3. `content-length` has
+already been sent, so the browser reports a failed download.
+
+**Anyone not on a very fast link cannot complete either download
+today** — including the `tycho-client` binary a new member must have to
+set up at all.
+
+**Fix:** the timeout must bound *establishing* the response, not
+consuming it. Once headers are in hand, the body must stream without a
+deadline it cannot meet. Delete the comment that says otherwise — it is
+what stopped this being noticed.
+
+Say in PR.md how you bounded a connection that stalls *after* headers,
+if you did; "no timeout at all on the body" is an acceptable answer for
+now if you say so explicitly rather than leaving it implied.
+
+## Tests
+
+- [ ] An unset `PROVISIONER` fails loudly outside tests. Assert the
+  error names the variable — someone hitting this at 2am needs to know
+  what to set.
+- [ ] Explicitly selecting the fake still works, and the fake can be
+  made to fail so `approve.ts`'s error path is exercised at least once.
+- [ ] A body that takes **longer than the connect timeout to stream**
+  completes intact. This is the regression, and it needs a test that
+  names it: serve a slow body from a local server, read it fully,
+  assert the bytes are complete rather than truncated.
+- [ ] A genuinely unreachable Garage still fails fast, so the fix does
+  not simply remove the protection.
+
+## Warts / traps
+
+- Do not change the enrolment flow, scope API, session gate or
+  authorization — all shipped and verified.
+- Do not "fix" the download by buffering. The 88 MB FITS and the 20 MB
+  client must stay streamed.
+- `tsmint` (the new enrolment path) does **not** use the provisioner and
+  is unaffected — do not refactor it into this.
+- `docs/design/**` is read-only law.
+
+Finish: `/workspace/PR.md` with the startup failure a missing
+`PROVISIONER` now produces, proof a slow large body streams intact, and
+what still bounds a connection that stalls after headers.

--- a/loops/specs/webapp-lint-astro/SPEC.md
+++ b/loops/specs/webapp-lint-astro/SPEC.md
@@ -1,0 +1,87 @@
+# SPEC — webapp-lint-astro: the linter cannot see half the codebase
+
+Repo: `loop-bot/tychofleet`. Gate: `make build test lint`.
+
+## The failure
+
+`biome.json:11` excludes every `.astro` file:
+
+```json
+"includes": [..., "!**/*.astro"]
+```
+
+`pnpm lint` reports *"Checked 233 files."* Run it against
+`src/pages/scopes/index.astro` and it reports **"Checked 0 files."**
+
+That is ~50 pages, components and layouts — including **every
+client-side `<script>` block** — never linted. And `pnpm lint` runs
+`tsc --noEmit` but **not** `astro check`, so `.astro` template types are
+only ever checked inside `make build`.
+
+Real consequences already in the tree, none reachable by the linter:
+
+- `ScopeDeckCards.astro` — a `card.querySelector("span.font-sans")` DOM
+  coupling that breaks on any class change
+- the same file's rename handler: `catch {}` swallowing a 400 and a 503
+  identically, silently reverting with no message
+- `setup.astro` — a `setInterval` poll that is never cleared, has no
+  backoff or cap, and does not stop on 401
+
+## What to build
+
+### 1. Lint `.astro`
+
+Remove the exclusion. Biome supports `.astro` — confirm what it does and
+does not check there (it lints the frontmatter and script blocks; it is
+not a full template linter) and **say so plainly in PR.md**, so nobody
+later assumes more coverage than exists.
+
+### 2. `astro check` in the lint gate
+
+Add it to `make lint`, so template types are checked by the gate rather
+than only as a side effect of building.
+
+### 3. Fix what this uncovers — but scope it
+
+Turning the linter on ~50 unlinted files will surface a lot. **Do not
+sprawl.** Rules:
+
+- Fix everything that is a genuine defect or a real correctness risk.
+- For stylistic noise, prefer configuring the rule over rewriting fifty
+  files. Say what you disabled and why.
+- **If the volume is large, fix the defects and land the config with the
+  noisy rules off, listing them in PR.md as follow-up.** A lint gate that
+  is on for real code beats a perfect one that never lands.
+
+Report the count: how many diagnostics appeared, how many were real,
+how many you fixed, how many you deferred.
+
+### 4. The three named above
+
+Whatever else you defer, these three are real and should be fixed:
+the brittle DOM selector, the error-swallowing `catch {}` (a rejected
+request and an unreachable service must read differently — that
+distinction is load-bearing in this codebase and was a production bug),
+and the uncleared interval that never stops on 401.
+
+## Tests
+
+- [ ] `pnpm lint` reports a file count that includes `.astro` files —
+  assert the number is not 233.
+- [ ] `make lint` fails on a deliberately broken `.astro` file. Add one
+  temporarily, confirm the gate catches it, remove it, describe it in
+  PR.md. A gate that cannot fail is the thing we are fixing.
+- [ ] The existing 863 tests still pass.
+
+## Warts / traps
+
+- Do not change behaviour while fixing lint, except for the three named
+  defects. A rename that silently alters rendering is worse than a lint
+  warning.
+- Do not touch enrolment, key minting, the scope API, the download route
+  or authorization — all shipped and verified against the live gateway.
+- `docs/design/**` is read-only law.
+
+Finish: `/workspace/PR.md` with the before/after file counts, the
+diagnostic tally, exactly which rules you disabled and why, proof the
+gate now fails on a broken `.astro`, and the three named fixes.

--- a/loops/specs/webapp-reenrol-state/SPEC.md
+++ b/loops/specs/webapp-reenrol-state/SPEC.md
@@ -1,0 +1,100 @@
+# SPEC — webapp-reenrol-state: the setup screen answers the wrong question
+
+Repo: `loop-bot/tychofleet`. Gate: `make build test lint`.
+
+## The failure
+
+The founder hit **Re-enrol** on a scope with existing history. The
+setup screen went straight to *"✓ Found your scope — is this right?
+[Yes] [No]"*, never showing the new setup code. Yes and No both landed
+him back on the same screen. He could not get through, and had to be
+handed a hand-minted config out of band.
+
+`resolveSetupMode` (`src/lib/scope-deck.ts`) is correct given its
+inputs:
+
+```ts
+if (!scope.enrolled)   return "need-code";
+if (!scope.attestedAt) return "waiting-attestation";
+return "found-it";
+```
+
+The scope was still `enrolled` and still `attestedAt` from its
+**previous** enrolment. So the screen is answering *"has this scope ever
+attested?"* when the question is *"has it attested for **this**
+enrolment?"* — the same shape as every other bug this week: a plausible
+value, computed from the wrong generation of data.
+
+A sibling loop (`gateway-reenrol-state`) is adding the missing fact
+**right now**.
+
+## THE CONTRACT (identical in both specs — do not improvise)
+
+`GET /v1/scopes` gains one field per scope:
+
+```json
+{ "scope_id": "...", "enrolled": true, "attested_at": "...",
+  "pending_code": true }
+```
+
+`pending_code` is a **boolean** — true when a code exists that is
+neither redeemed nor expired. Existing fields keep their names and
+types. The gateway will also clear the stale attestation when a code is
+redeemed, so `attested_at` goes null for the window between redemption
+and the new device attesting.
+
+## What to build
+
+### 1. A pending code outranks historical attestation
+
+Setup mode resolves `pending_code` **first**. If a code is outstanding,
+the member is mid-setup and must see the code screen — whatever the
+scope attested in a previous life.
+
+Order becomes: pending code → not enrolled → not attested → found it.
+
+Say in PR.md what each of the four resolves to, and make sure the
+re-enrol path walks screen 3 → 4 exactly as first-time setup does.
+
+### 2. The deck must not claim a re-enrolling scope is fine
+
+A scope with an outstanding code is not simply `online`. Someone is
+part-way through replacing its credential, and the card should say so
+and link to setup — the same way `setup-not-finished` does today. A
+green `● online` on a scope whose owner is mid-re-enrolment is exactly
+the reassuring-but-wrong state this project keeps shipping.
+
+Decide whether that is a new card state or a reuse of
+`setup-not-finished`, and justify it in PR.md.
+
+### 3. Do not let the confirm screen loop
+
+Screen 4's **No** revokes and reissues. With this fix that returns the
+member to a code screen, as intended. Verify it — a No that lands back
+on screen 4 is the bug we are fixing.
+
+## Tests
+
+- [ ] `pending_code: true` on an enrolled, attested scope resolves to
+  the **code** screen, not `found-it`. This is the regression, and it
+  needs a test that names it.
+- [ ] The four resolution cases each have their own test.
+- [ ] Screen 4's **No** leads to a code screen, not back to screen 4.
+- [ ] The deck card for a scope with a pending code does not read
+  `● online`.
+- [ ] First-time setup is unchanged — assert it, since this touches the
+  shared path.
+
+## Warts / traps
+
+- Do not change enrolment, key minting, the download route or the
+  session gate — all shipped and verified.
+- The gateway field does not exist yet; build against a typed stub. The
+  sibling loop is adding it now.
+- A degraded gateway read still renders `--` and an honest error, never
+  a fabricated state.
+- `docs/design/**` is read-only law.
+
+Finish: `/workspace/PR.md` with an ASCII render of the re-enrol path
+screen by screen, the four resolution cases, and your decision on the
+deck card state.

--- a/loops/specs/webapp-scope-create-400/SPEC.md
+++ b/loops/specs/webapp-scope-create-400/SPEC.md
@@ -1,0 +1,96 @@
+# SPEC — webapp-scope-create-400: adding a scope fails, and lies about why
+
+Repo: `loop-bot/tychofleet`. Gate: `make build test lint`.
+
+Two bugs, live in production right now. The founder hit them within a
+minute of trying the flow.
+
+## 1. Adding a scope is broken: a type mismatch on the wire
+
+`POST /v1/scopes` sends the member id as a **JSON number**, because the
+site's member ids are SQLite integers:
+
+```ts
+expect(JSON.parse(init.body)).toEqual({ owner_member_id: 7, label: "Backyard S30" });
+//                                                       ^ number
+```
+
+The gateway declares that field as a **string**
+(`OwnerMemberID string \`json:"owner_member_id"\``), so it rejects the
+request outright. Reproduced against the live gateway:
+
+```
+{"owner_member_id":7,...}    -> 400  invalid JSON body: json: cannot unmarshal
+                                     number into Go struct field
+                                     .owner_member_id of type string
+{"owner_member_id":"7",...}  -> 201  {"scope_id":"scp_0b0e9ffa"}
+```
+
+**Fix it on this side: send a string.** The gateway stores
+`owner_member_id` as `TEXT` and treats it as an opaque owner handle, so
+a string is the correct representation and the gateway is not wrong
+here. Do not ask for a gateway change.
+
+Audit **every** field this repo sends to or reads from the gateway for
+the same class of mismatch — not just this one call. `GET
+/v1/scopes?owner_member_id=…` already stringifies via the query string
+and works, which is exactly why this went unnoticed: one call site
+converted implicitly and the other did not.
+
+## 2. The error message blamed the network for a rejected request
+
+The site rendered:
+
+> Couldn't reach the scope service — try again shortly.
+
+It reached the scope service perfectly. The service replied 400. Its
+own log line even had it right — `gateway: POST /v1/scopes returned
+400, expected 201` — while the user-facing text sent someone off to
+check DNS and firewalls for a request-shape bug.
+
+**"Unreachable" and "rejected" are different facts and must read
+differently.** This is the same failure this project keeps repeating:
+one state wearing another state's clothes.
+
+- A transport failure (DNS, refused, timeout, network policy) is the
+  only thing allowed to say the service could not be reached.
+- A response that arrives and is not what we wanted says so: the
+  request was rejected, and — for a 4xx that indicates our own bug —
+  says plainly that something is wrong on our side rather than
+  suggesting the user retry. Retrying a 400 never helps.
+- A 5xx may reasonably suggest trying again.
+
+Audit every gateway call site in the repo for this conflation, not only
+scope creation. Put the list in PR.md: call site, what it said before,
+what it says now.
+
+## Tests
+
+- [ ] The create-scope request body carries `owner_member_id` as a
+  **string**, asserted on the serialised body.
+- [ ] A test that would have caught this: feed the client a gateway stub
+  that validates types the way the real gateway does (reject a number),
+  and assert the call succeeds. A stub that accepts anything is how a
+  green suite shipped a broken flow.
+- [ ] A 400 from the gateway renders as a rejection, not as
+  unreachable, and does not tell the user to try again shortly.
+- [ ] A genuine transport failure still renders as unreachable.
+- [ ] Every other gateway field is exercised with the type the gateway
+  actually declares.
+
+## Warts / traps
+
+- Do not change the gateway, its API shape, or anything in the tycho
+  repo. This is a client-side fix.
+- Do not weaken the gateway stub to make tests pass. The stub being too
+  permissive is the root cause of this reaching production.
+- The enrolment flow, download route, session gate and scope UI all
+  shipped today and are verified working — this loop touches the
+  request body and the error text, nothing else.
+- Leftover test scopes exist in the catalog from debugging
+  (`Numeric Test`, `String Test`, owner `7`, plus `flowtest-member`).
+  Ignore them; do not write cleanup code.
+
+Finish: `/workspace/PR.md` with the corrected request body, the full
+audit table of gateway call sites and their old/new error text, and the
+test that fails against the old code.

--- a/loops/specs/webapp-scope-management/SPEC.md
+++ b/loops/specs/webapp-scope-management/SPEC.md
@@ -1,0 +1,227 @@
+# SPEC — webapp-scope-management: add a scope, manage it, remove it
+
+Repo: `loop-bot/tychofleet`. Gate: `make build test lint`.
+
+The site has **no scope surface at all** today. A member can join
+fleets and see attribution, but there is nowhere to add the thing that
+produces the data. This loop builds it.
+
+Two sibling loops are building the gateway
+(`gateway-scope-credentials`) and the client (`scopetui-enrolment`)
+against the same contract **right now**. The contract is law: build to
+it even though the endpoints will not exist while you work. Stub the
+client, test against the stub.
+
+---
+
+## THE WIRE CONTRACT (identical in all three specs — do not improvise)
+
+The site never touches scope credentials or the catalog's scope tables
+directly. It calls the gateway, authenticated with a service token
+`TYCHO_GATEWAY_URL` + `SITE_API_TOKEN` (new env, add to the ExternalSecret
+pattern this repo already uses):
+
+```
+POST   /v1/scopes                            {owner_member_id, label}
+                                             -> 201 {scope_id}
+GET    /v1/scopes?owner_member_id=...
+       -> 200 {scopes:[{scope_id, label, model, make, serial,
+                        firmware_version, attested_at,
+                        last_heartbeat_at, revoked_at, enrolled}]}
+PATCH  /v1/scopes/{scope_id}                 {label}   -> 204
+DELETE /v1/scopes/{scope_id}                           -> 204
+POST   /v1/scopes/{scope_id}/enrolment-code
+       -> 201 {code, expires_at}
+```
+
+Setup code format: `XXXX-XXXX-XXXX`, TTL 30 minutes, single use.
+Scope ids are server-issued (`scp_7f3a91c4`) — **never let a user type
+one**, never show it as something they chose.
+
+The generated `tycho.yaml` the user downloads:
+
+```yaml
+endpoints:
+  - url: https://gateway.tychofleet.com
+    setup_code: KX7M-2QN4-8PLD
+    label: Backyard S30
+```
+
+---
+
+## The screens
+
+These wireframes are the spec. Build them; deviate only where you can
+say why in PR.md.
+
+### 1 · Deck, no scopes
+
+```
+┌──────────────────────────────────────────────┐
+│  YOUR DECK                                   │
+│                                              │
+│   You haven't added a scope yet.             │
+│   Tycho needs one to start collecting.       │
+│                                              │
+│            [ Add a scope ]                   │
+└──────────────────────────────────────────────┘
+```
+
+### 2 · Add a scope
+
+One field. **Do not ask for make, model, or serial** — the scope
+reports those itself and typing them is how identity got brittle in the
+first place.
+
+```
+┌──────────────────────────────────────────────┐
+│  ADD A SCOPE                          [ × ]  │
+│                                              │
+│  What do you want to call it?                │
+│  ┌────────────────────────────────────────┐  │
+│  │ Backyard S30                           │  │
+│  └────────────────────────────────────────┘  │
+│  Just a label for you. You can change it.    │
+│                                              │
+│  Your computer:  ( ) macOS  ( ) Linux        │
+│                  ( ) Windows                 │
+│                                              │
+│               [ Continue ]                   │
+└──────────────────────────────────────────────┘
+```
+
+### 3 · Setup, live
+
+Code shown as text so it can be typed if the download fails. Countdown
+is real. Page polls `GET /v1/scopes` and advances by itself.
+
+```
+┌──────────────────────────────────────────────┐
+│  SET UP "BACKYARD S30"                       │
+│                                              │
+│  1  Download scopeTUI                        │
+│         [ scopetui-macos-arm64.tar.gz ]      │
+│                                              │
+│  2  Download your config                     │
+│         [ tycho.yaml ]                       │
+│     Setup code: KX7M-2QN4-8PLD               │
+│     Expires in 29:41. One use only.          │
+│                                              │
+│  3  Run it next to your scope                │
+│     ┌────────────────────────────────────┐   │
+│     │ ./scopetui -conf tycho.yaml        │   │
+│     └────────────────────────────────────┘   │
+│                                              │
+│  ◌ Waiting for your scope to check in…       │
+│                          [ Generate new code ]│
+└──────────────────────────────────────────────┘
+```
+
+The download link points at the real release asset for the chosen
+platform. If the release for a platform does not exist, say so plainly
+rather than serving a 404 — check what
+`code.phillips-homelab.net/loop-bot/tycho/releases` actually has.
+
+### 4 · Found it
+
+Everything here comes from the device. Nothing is typed.
+
+```
+┌──────────────────────────────────────────────┐
+│  ✓ FOUND YOUR SCOPE                          │
+│                                              │
+│     Seestar S30 Pro                          │
+│     Firmware 8.46 · Serial 5741d34d          │
+│     Two optical trains                       │
+│                                              │
+│     Is this right?                           │
+│         [ Yes, that's mine ]  [ No ]         │
+└──────────────────────────────────────────────┘
+```
+
+**No** revokes that credential and issues a fresh code — someone else's
+device redeemed it, and leaving it enrolled is the whole problem this
+design exists to prevent.
+
+### 5 · Deck, populated
+
+```
+┌──────────────────────────────────────────────┐
+│  BACKYARD S30            ● online     [···]  │
+│  Seestar S30 Pro · fw 8.46 · verified        │
+│  Last seen 12s ago                           │
+│                                              │
+│  Fleets     Fleet Zero, Messier Marathon     │
+│  Collected  3h 47m over 3 nights             │
+└──────────────────────────────────────────────┘
+```
+
+`[···]` → **Rename**, **Re-enrol**, **Remove**.
+
+## The states you must render distinctly
+
+The gateway distinguishes these; so must you. Guessing or collapsing
+them is how a member ends up staring at a card that says nothing useful:
+
+| state | card reads |
+|---|---|
+| created, never enrolled | `setup not finished` + a link back to screen 3 |
+| enrolled, never attested | `enrolled — we haven't heard from the device yet` |
+| attested, heartbeat recent | `● online`, model and firmware |
+| attested, heartbeat stale | `● offline · last seen 4h ago` |
+| revoked / removed | not on the deck at all |
+
+A degraded read of the integration figures renders `--`, never `0h 00m`
+— this repo has shipped that bug twice and the campaign page already
+does it correctly. Match it.
+
+## Rename, re-enrol, remove — build all three properly
+
+- **Rename** is inline, optimistic, `PATCH`. A label is cosmetic and
+  carries no authority. Two scopes may share a label.
+- **Re-enrol** issues a fresh code and returns to screen 3. This is the
+  hardware-swap and reinstall path, and it is the *owner's* action —
+  there is no operator involved. Warn plainly: the scope stops
+  collecting until the new code is redeemed.
+- **Remove** needs a confirmation that says what actually happens:
+  the device stops being able to upload, and **the frames it already
+  contributed stay** — in the archive, in the fleets, in the masters.
+  Do not imply data is deleted. Do not use the word "delete".
+
+## Privacy
+
+A scope's serial, model and firmware belong to its owner's deck. Decide
+deliberately what, if anything, appears on public surfaces, and say why
+in PR.md. This repo leaked a member's email onto a public page this
+month via a plausible fallback nobody audited — do not add a second
+one. **Never render an email anywhere a signed-out visitor can reach.**
+
+## Tests
+
+- [ ] A member with no scopes sees screen 1, not an empty table.
+- [ ] Each of the five card states above renders its own distinct text —
+  a test per state, not one happy-path render.
+- [ ] The setup code is never rendered for a scope that is already
+  enrolled.
+- [ ] Remove asks for confirmation and, on confirm, the scope leaves the
+  deck while the member's contributed integration total is **unchanged**.
+- [ ] A member cannot see, rename, re-enrol or remove another member's
+  scope — assert on the authorization, not just the UI.
+- [ ] Gateway unreachable renders a stated error, not a blank panel and
+  not zeros.
+
+## Warts / traps
+
+- The gateway endpoints **do not exist yet**. Build against a typed
+  client with a stub; the sibling loop is implementing them now.
+- PR #35's schema fixture test and PR #36's typed array helper still
+  apply to any catalog query you touch.
+- `docs/design/**` is read-only law. If a screen there governs the deck,
+  it wins over the wireframes above — say so in PR.md.
+- Migration numbering: next after the highest in `drizzle/`.
+
+Finish: `/workspace/PR.md` with an **ASCII render of every screen and
+every card state as actually built** (not copied from this spec), the
+privacy decision, and what a member sees when the gateway is down.
+Renders in `/workspace/renders/*.png` if you can produce them — a green
+gate cannot see pixels.

--- a/loops/specs/webapp-setup-in-progress/SPEC.md
+++ b/loops/specs/webapp-setup-in-progress/SPEC.md
@@ -1,0 +1,106 @@
+# SPEC — webapp-setup-in-progress: one predicate, not four opinions
+
+Repo: `loop-bot/tychofleet`. Gate: `make build test lint`.
+
+## The failure
+
+The founder re-enrolled a scope, reached the setup screen (which
+correctly offered a fresh code), clicked download, and got **410 Gone**.
+
+`src/pages/api/scopes/[scopeId]/tycho-yaml.ts:34`:
+
+```ts
+if (lookup.scope.enrolled) return new Response(null, { status: 410 });
+```
+
+`seestar-1` has been `enrolled` since an earlier code was redeemed, so
+the download refuses. Its comment explains that a redeemed code must
+never be handed out again — correct for first-time setup, wrong for
+re-enrolment, which is *precisely* the case where a scope is enrolled
+**and** a new code is live.
+
+## Why this is the third time
+
+An earlier loop fixed `resolveSetupMode` (`scope-deck.ts:158`) to
+consult `pendingCode` before `enrolled`. That fix was correct and its
+reasoning is written out well. But **"is this scope mid-setup?" is
+decided independently in four places**, and only one was taught the new
+fact:
+
+| site | reads | state today |
+|---|---|---|
+| `scope-deck.ts:158` `resolveSetupMode` | `pendingCode` → `enrolled` → `attestedAt` | **fixed** |
+| `scope-deck.ts:58` `resolveScopeCardState` | `enrolled` only | a re-enrolling scope still reads `● online` |
+| `tycho-yaml.ts:34` | `enrolled` only | **the 410** |
+| `status.ts:27` | returns all three to the client | fine, but the client re-decides |
+
+This is the same shape as two other bugs shipped in the last 24 hours —
+a fact that exists in one place and is re-derived, differently,
+somewhere else. Fixing the fourth site individually would leave a fifth.
+
+## What to build
+
+### 1. One predicate, exported, used everywhere
+
+A single function — `setupInProgress(scope)` or similar — that answers
+"is this scope part-way through enrolment right now?" Every consumer
+calls it. No route, page or component may re-derive this from
+`enrolled`/`attestedAt`/`pendingCode` on its own.
+
+Say in PR.md what it returns for each of the four combinations of
+`enrolled` × `pendingCode`, and why.
+
+### 2. The download route serves during re-enrolment
+
+`tycho-yaml.ts` must serve a config when a code is genuinely live.
+`410` is correct **only** when there is no pending code *and* the scope
+is already enrolled — i.e. someone is fishing for a spent code.
+
+Do not weaken anything else about that route: it stays session-gated,
+stays owner-checked via `findOwnedScope`, and still must never serve a
+config missing its gateway URL or tailnet key.
+
+### 3. The deck must not call a re-enrolling scope online
+
+`resolveScopeCardState` should report a scope with a live code as
+in-setup, linking to the setup screen — not `● online` because a stale
+credential and a stale attestation both still exist. Reuse
+`setup-not-finished` or add a state; justify the choice.
+
+### 4. Audit, and make the audit the deliverable
+
+Enumerate **every** place in the repo that reads `enrolled`,
+`attestedAt` or `pendingCode` outside the new predicate — including
+`.astro` templates and client-side `<script>` blocks, which the linter
+does not currently cover. For each: what it decides, and what it reads
+after this loop. Put that table in PR.md.
+
+`profile/index.astro`'s `row.enrolled` is **campaign enrolment**, an
+unrelated concept with the same word. Note it in the table and leave it
+alone — that collision is itself worth recording.
+
+## Tests
+
+- [ ] A scope that is `enrolled` **and** has a live code serves its
+  config. This is the founder's 410 and it needs a test that names it.
+- [ ] A scope that is `enrolled` with **no** pending code still gets
+  410 — the anti-fishing property must not regress.
+- [ ] A scope with a live code does not render `● online` on the deck.
+- [ ] First-time setup is unchanged, asserted, since this touches the
+  shared path.
+- [ ] The predicate has its own table-driven test over all four
+  `enrolled` × `pendingCode` combinations.
+
+## Warts / traps
+
+- Do not change the gateway. `pending_code` is already reported and
+  correct.
+- Do not change enrolment, key minting, the session gate, or ownership
+  checks — all shipped and verified against the live gateway.
+- Keep the good reasoning already written at `scope-deck.ts:150-157`;
+  move it to the new predicate rather than deleting or duplicating it.
+- `docs/design/**` is read-only law.
+
+Finish: `/workspace/PR.md` with the predicate's truth table, the full
+audit of every reader, and an ASCII render of the deck card for a scope
+mid-re-enrolment.

--- a/loops/specs/webapp-tailscale-minting/SPEC.md
+++ b/loops/specs/webapp-tailscale-minting/SPEC.md
@@ -1,0 +1,140 @@
+# SPEC — webapp-tailscale-minting: hand each scope a key to the fleet tailnet
+
+Repo: `loop-bot/tychofleet`. Gate: `make build test lint`.
+
+## Why
+
+A member's telescope reaches the gateway **over the fleet tailnet** —
+that is the whole transport. The gateway is published there and nowhere
+else: `https://tycho-gateway.tail92d9b0.ts.net`, unreachable from the
+public internet or any LAN.
+
+So the client needs a way onto that tailnet, and it must arrive with the
+config the member downloads. A sibling loop (`tycho-client-tailnet`) is
+building the client half **right now** against the contract below.
+
+## THE CONTRACT (identical in both specs — do not improvise)
+
+The downloaded `tycho.yaml` gains one field:
+
+```yaml
+endpoints:
+  - url: https://tycho-gateway.tail92d9b0.ts.net
+    setup_code: KX7M-2QN4-8PLD
+    tailscale_auth_key: tskey-auth-xxxxxxxxxxxx
+    label: Backyard S30
+```
+
+- `tailscale_auth_key` is a **string**, always the raw key.
+- All four fields are strings. (A field named without its type is how a
+  green site and a green gateway shipped a broken flow this week —
+  `owner_member_id` went out as a JSON number against a Go `string`.)
+- The client consumes the key on first join and rewrites the file
+  without it. Nothing reads it back.
+
+## Note on the base you cloned
+
+An earlier version of this loop was respawned because it had cloned a
+`main` that predated the `TYCHO_GATEWAY_PUBLIC_URL` split (tychofleet
+#48). That work is now on `main`: the member-facing gateway address
+comes from `TYCHO_GATEWAY_PUBLIC_URL`, distinct from the in-cluster
+`TYCHO_GATEWAY_URL` the site uses server-side, and a missing public URL
+means **no config is served at all** rather than a broken one.
+
+Build on that rather than around it — `src/lib/gateway/client.ts` and
+`src/pages/api/scopes/[scopeId]/tycho-yaml.ts` already have the shape.
+The auth key follows the same rule: no key, no config.
+
+## What to build
+
+### 1. Mint a key when the setup code is minted
+
+The existing enrolment-code call already happens when a member reaches
+the setup screen. Mint the tailnet key in the same step, so the
+downloaded config is complete or is not offered at all.
+
+Key properties, all required:
+
+- **Pre-authorized** — a member must not need an admin to approve their
+  scope.
+- **Ephemeral: no.** The node persists; the key is single-use.
+- **Reusable: no.** One key, one scope.
+- **Tagged `tag:scope`** — this is what the fleet ACL confines to the
+  gateway and nothing else. A key minted without the tag lands a
+  telescope on the tailnet with no restrictions.
+- **Expiry ~7 days.** It is a setup key, not a credential.
+
+Credentials: a Tailscale **OAuth client scoped to `auth_keys` only**,
+carrying `tag:scope-minter`. New env, wired from 1Password like every
+other secret in this repo:
+
+```
+TS_MINTER_CLIENT_ID
+TS_MINTER_CLIENT_SECRET
+TS_TAILNET          # "-" resolves to the OAuth client's own tailnet
+```
+
+The client is deliberately **not** permitted to touch devices. Do not
+add scopes, and do not reuse the operator's client.
+
+### 2. Throttle, and handle 429 properly
+
+Minting is a write against someone else's API on a member-triggered
+path.
+
+- Per-member rate limit using the repo's existing rate-limit helper.
+  Say in PR.md what limit you chose and why.
+- A 429 from Tailscale is retried with backoff, and if it persists the
+  member sees an honest "try again in a moment", not a broken config.
+- Every other failure is **rejected**, not "unreachable" — that
+  distinction shipped this week and must not regress.
+
+### 3. Never serve a config that cannot work
+
+If minting fails, **do not fall back to a `tycho.yaml` without a key**.
+A member who receives one will get a client that cannot reach anything,
+and will have no way to tell why. The screen says setup is temporarily
+unavailable and the server logs the reason.
+
+Same rule already applies to `TYCHO_GATEWAY_PUBLIC_URL` — no key, no
+config; no public URL, no config.
+
+### 4. Secret handling
+
+The key is a credential. It appears in the downloaded file and nowhere
+else: not in a log line, not in an error, not in the session, not in the
+site's database. Assert this the way the client asserted the device key
+never reaches disk.
+
+Regenerating a setup code mints a **fresh** key. Say in PR.md whether
+you can revoke the previous one through the API and, if not, why the
+7-day expiry is an acceptable bound.
+
+## Tests
+
+- [ ] A generated `tycho.yaml` contains a `tailscale_auth_key` string,
+  asserted against the file's contents.
+- [ ] The mint request asks for tag `tag:scope`, pre-authorized,
+  non-reusable, non-ephemeral — assert on the request body sent to
+  Tailscale, not on a mock's return value. A stub that accepts anything
+  is how the last contract bug reached production.
+- [ ] Minting failure serves **no** config and an honest message.
+- [ ] A 429 is retried and then surfaces as retryable, distinct from a
+  rejection.
+- [ ] The key appears in no log line and no rendered page.
+- [ ] Regenerating a code mints a new key rather than reusing one.
+
+## Warts / traps
+
+- Do not change the enrolment protocol, scope API, download route or
+  session gate — all shipped and verified against the live gateway.
+- `TYCHO_GATEWAY_PUBLIC_URL` is set by the deployment; do not hardcode
+  the tailnet hostname anywhere in this repo.
+- The gateway is **not** reachable from the site's pod over the tailnet
+  and does not need to be — the site talks to it in-cluster over
+  `TYCHO_GATEWAY_URL`. Only the member's client uses the tailnet.
+- `docs/design/**` is read-only law.
+
+Finish: `/workspace/PR.md` with a generated `tycho.yaml` (key redacted),
+the exact request body sent to Tailscale, your rate limit and why, what
+a member sees when minting fails, and the revoke-vs-expiry answer.

--- a/loops/specs/webapp-tech-docs/SPEC.md
+++ b/loops/specs/webapp-tech-docs/SPEC.md
@@ -1,0 +1,100 @@
+# SPEC — webapp-tech-docs: explain the machine to someone who might join it
+
+Repo: `loop-bot/tychofleet`. Gate: `make build test lint`.
+
+## Why
+
+Tycho now does something worth explaining: a telescope in a back garden
+attests its own identity, joins a private tailnet in-process, streams
+frames to a gateway that authenticates every request per-scope, and its
+photons get pooled with strangers' into a shared master with honest
+per-source attribution.
+
+None of that is written down anywhere a visitor can read. `docs/`
+exists on the site but predates all of it.
+
+The audience is **an amateur astronomer with a Seestar who is deciding
+whether to trust this with their nights** — technically literate,
+not a distributed-systems engineer. Second audience: someone
+considering contributing.
+
+## What to build
+
+Technical documentation under the site's existing `docs/` section.
+Suggested shape, argue for a different one if it's better:
+
+1. **How Tycho works** — the whole pipeline in one page. Scope → client
+   → gateway → object storage + catalog → combine → pooled master →
+   attribution. A diagram if you can make one that survives dark mode.
+2. **What runs on your machine** — the client. What it does, what it
+   talks to, what it stores. Explicitly: it needs a computer beside the
+   scope that stays awake.
+3. **Identity and trust** — how a scope proves what it is, what a
+   per-scope credential is, what the fleet tailnet does and does not
+   give other people access to. This is the section that earns trust or
+   loses it.
+4. **Attribution** — how seconds are counted, why it's `SUM` over
+   sessions of `MAX(totalexp_s)` rather than a flat sum, and why nobody
+   gets a byline.
+
+## The rules that matter
+
+**Every claim must be true today.** Not aspirational, not "will soon".
+If something is designed but unbuilt, either omit it or say plainly
+that it isn't built. This project has just spent two days finding
+comments that asserted properties the code didn't have; documentation
+that does the same to *members* is worse.
+
+**Be specific where specificity builds trust.** "Your scope can reach
+the gateway and nothing else on the network" is worth more than "we
+take security seriously" — and it's checkable.
+
+**Do not overclaim on security.** Device attestation is
+**self-reported, not cryptographic**: a modified firmware can report
+any serial. Say so. The per-scope credential is real authentication;
+the attestation is a consistency signal. Anyone who reads the ADRs and
+then the docs must not find the docs flattering.
+
+**Source of truth:** `docs/adr/0008-scope-identity.md` and
+`0009-scope-credentials.md` in the **tycho** repo, plus what is actually
+deployed. Where an ADR and reality disagree, reality wins and the ADR
+gets an issue, not a quiet paper-over.
+
+## Design
+
+The existing `docs/` pages are the largest surviving pre-redesign
+surface — `text-slate-*` throughout, while newer pages use the bespoke
+tokens. **Do not deepen that split.** Use the current design tokens for
+anything new. If that makes new pages clash with old ones, say so in
+PR.md rather than compromising toward the old style; unifying is
+tracked separately.
+
+Accessibility, since these are read-heavy pages: real headings in
+order, `<h1>` per page, no reliance on `--color-text-faint` for
+anything load-bearing (it fails WCAG AA — tracked separately), and
+tables with `scope="col"` if you use any.
+
+## Tests
+
+- [ ] Every new page renders and is reachable from the docs index and
+  from the nav — this repo has shipped links to routes nobody built.
+- [ ] The existing link-integrity crawl covers them. Note that
+  `crawl.test.ts` currently generates its cases from `dist/` and, with
+  everything SSR, produces **one** test — if that's still true, say so
+  in PR.md rather than assuming coverage.
+- [ ] No page claims a capability that does not exist. List in PR.md
+  every factual claim you made about identity, security or attribution,
+  with the file that backs it.
+
+## Warts / traps
+
+- Do not change enrolment, the scope API, the download route, key
+  minting or authorization — all shipped and verified against the live
+  gateway.
+- Do not document `PROGRESS.md`, `SPEC.md` or loop-rig internals.
+  Members do not care and those files are not public.
+- `docs/design/**` is read-only law.
+
+Finish: `/workspace/PR.md` with an ASCII render of each page, the table
+of claims and their backing files, and anything you deliberately left
+out because it isn't built yet.


### PR DESCRIPTION
63 spec files, written as each loop was spawned, pushed to `spec/*` branches and never merged.

This is a prerequisite for tycho#132 (comment integrity). ~130 comments in the tycho repo cite `SPEC` as the authority behind wire contracts and schema choices; a spec living on an unmerged branch is unverifiable to anyone reading that code.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added specifications for secure scope enrollment, gateway authentication, device-key provisioning, identity enforcement, and re-enrollment workflows.
  * Documented session namespacing and source attribution safeguards.
  * Defined client connectivity, downloads, setup states, scope management, and webapp error-handling improvements.
  * Added specifications for renaming the client, tailnet support, Tailscale key delivery, and technical documentation.
  * Expanded quality requirements for PostgreSQL CI coverage, race detection, Astro linting, and regression testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->