### PR TITLE
spec(loops): the two findings that lose photons

### DIFF
--- a/loops/specs/agent-buffer-retention/SPEC.md
+++ b/loops/specs/agent-buffer-retention/SPEC.md
@@ -1,0 +1,118 @@
+# SPEC — agent-buffer-retention: nothing ever deletes anything
+
+Repo: `loop-bot/tycho`. Gate: `make build test lint`.
+
+Closes issue **#126**. Scope: `agent/internal/uploader/` and its
+callers. Stay out of `gateway/` — a sibling loop
+(`gateway-upload-integrity`) is there now.
+
+## The failure
+
+```
+grep -rn "os.Remove\|RemoveAll\|retention\|prune\|reap" agent/internal/ agent/main.go
+```
+
+excluding tests, returns **nothing**. Files are marked `Shipped: true`
+(`uploader/state.go:22`) and left on disk permanently. Nothing prunes
+`state.Files`, `state.Previews` or `state.Sessions` either.
+
+A senior review ranked this its worst finding: *"everything else is
+recoverable; this one loses data and gets more expensive every night."*
+
+### Three compounding consequences
+
+**1. The `BufferMax*` caps do not guard this.** `pendingLocked`
+(`uploader/uploader.go:511-519`) counts only `!rec.Shipped`. So on a
+*healthy* agent — where everything ships — backpressure never engages
+and the disk fills anyway. The `*int64` nil-vs-zero plumbing behind
+those caps is the most heavily commented machinery in the client, and
+it guards the wrong number.
+
+**2. `persistLocked` is O(n) per frame, so O(n²) per season.**
+`uploader/state.go:109` `json.MarshalIndent`s the entire state map on
+every state change. At 50k tracked frames that is a multi-MB
+pretty-printed JSON rewritten once per uploaded file — onto whatever SD
+card is in the machine beside the telescope. That is write
+amplification that kills hardware, not just latency.
+
+**3. `discover()` full-walks the buffer every 60s**
+(`uploader.go:895-921`), appending every path to a slice, then doing n
+map lookups under the lock.
+
+### How it ends
+
+Disk full → `fetcher.Fetch` fails → `fieldrun.go:573` logs *"will retry
+next interval"* forever → the Seestar rotates its own storage →
+**frames are lost silently.** The member's night is gone and nothing
+said so.
+
+## What to build
+
+### 1. Retention
+
+Delete shipped files. The policy is yours to choose — delete on
+`Shipped`, keep N nights, keep until a size ceiling — but say in PR.md
+what you chose, what a member loses if the gateway later says it never
+received something, and how a member would recover.
+
+Consider that the buffer is also the **resume** story: a file deleted
+too eagerly cannot be re-uploaded if the gateway rejects it later.
+Deleting only after the gateway has confirmed acceptance is the
+conservative reading. Argue your choice.
+
+### 2. Prune the state map
+
+Entries for files no longer on disk must go, or the state file keeps
+growing after retention starts working. Prune on the same pass.
+
+### 3. Make the caps guard the real number
+
+`pendingLocked` counting only unshipped files means the caps are
+inert on a healthy agent. Either count what is actually on disk, or
+rename the fields so they stop implying a guarantee they do not give.
+Say which and why — do not leave the current gap with a comment.
+
+### 4. Do not rewrite the whole state on every frame
+
+O(n²) writes are the part that damages hardware. Options include an
+append-only journal with periodic compaction, or writing only what
+changed. Whatever you pick must survive a crash mid-write — this file
+is how the agent knows what it has already uploaded, and
+`enrol.Save`'s atomic-write helper has just been fixed to do
+`O_EXCL` + fsync + dir-fsync; reuse it rather than writing a third
+implementation.
+
+## Tests
+
+- [ ] A shipped file is removed by the retention pass, and its state
+  entry with it.
+- [ ] An **unshipped** file is never removed, however old.
+- [ ] Retention does not remove a file the gateway has not confirmed.
+- [ ] The state file does not grow without bound across many
+  ship-and-prune cycles — assert on its size or entry count, not on
+  the code path.
+- [ ] A crash mid-persist leaves a readable state file. This is the
+  test that matters most: the buffer's whole job is surviving
+  restarts.
+- [ ] The buffer caps engage on a healthy agent whose files all ship —
+  the regression this loop exists to close.
+
+## Warts / traps
+
+- Do not touch enrolment, the tailnet path, `DescribeDevice`, the keys
+  allowlist or the credential handling — all shipped and verified
+  against real hardware.
+- Do not touch `gateway/` — a sibling loop is editing it now.
+- The gate runs `-race -count=1` by default. A retention goroutine
+  racing the uploader will be caught, and should be.
+- `lost+found` on a PVC-backed ext4 fails a naive walk with EPERM —
+  `uploader.go:902-907` already knows this. Do not regress it.
+- The deployed headless agent has a PVC-backed buffer that has been
+  accumulating since July. Say in PR.md what happens on first start
+  after this change: a retention pass that deletes thousands of files
+  at once must not stall the pipeline.
+
+Finish: `/workspace/PR.md` with your retention policy and its
+justification, what a member loses in the worst case, the state-file
+growth measurement before and after, and what happens on the first
+start against an existing full buffer.

--- a/loops/specs/gateway-upload-integrity/SPEC.md
+++ b/loops/specs/gateway-upload-integrity/SPEC.md
@@ -1,0 +1,122 @@
+# SPEC — gateway-upload-integrity: the one path that destroys photons
+
+Repo: `loop-bot/tycho`. Gate: `make build test lint`.
+
+Closes issue **#125**. Scope: `gateway/internal/storage/` and
+`gateway/internal/upload/`.
+
+## The failure
+
+`storage/s3.go` takes the upload token and throws it away — the
+parameter is literally `_`:
+
+```go
+func (s *S3Storage) UploadPart(ctx context.Context, key, _ string, partNumber int32, body io.Reader, size int64) (string, error)
+func (s *S3Storage) ListParts(ctx context.Context, key, _ string) ([]PartInfo, error)
+```
+
+The file says so itself (`:42-46`): *"ErrTokenConflict is therefore
+never returned by this implementation; it exists for Mem-backed tests,
+which document the intended protocol semantics precisely."*
+
+So the tests exercise a protocol the production storage does not
+implement. Two uploads to the same object key share one multipart
+upload, parts overwrite by number, and `CompleteUpload` assembles an
+interleaved object.
+
+**The checksum catches the corruption — after `assembleObject`
+(`upload.go:377`) has already overwritten whatever was at that key.**
+`InsertSub` then returns `ErrDuplicateSub` (`postgres.go:316`), so the
+response reads as a benign duplicate.
+
+This is the only path in the system that destroys data and reports
+something success-adjacent. A night of photons cannot be recaptured.
+
+## Two more defects in the same file
+
+- **`StartUpload` (`s3.go:95-111`) is check-then-create.** Concurrent
+  starts create two upload ids, and `resolveUploadID` picks
+  non-deterministically.
+- **Abandoned multiparts are never reaped.** A week-old partial upload
+  is silently *resumed* on the next attempt for that key, producing an
+  object built from two different capture attempts.
+
+## What to build
+
+### 1. Never overwrite an object that already has a catalog row
+
+Before assembling, check whether the destination already exists **and**
+whether the catalog holds a row for it with a different checksum. If so,
+refuse — do not assemble, do not overwrite.
+
+Say in PR.md what the caller sees, and make sure it is distinguishable
+from the benign duplicate case. "Already uploaded, identical" and
+"already uploaded, different bytes" are completely different facts and
+must not share a response.
+
+### 2. Honour the upload token, or delete the concept
+
+Decide deliberately and say why in PR.md:
+
+- **Implement it** — persist the token (object metadata, or a catalog
+  column) and return `ErrTokenConflict` when a second writer appears.
+- **Or delete it** — remove `ErrTokenConflict` and the dead 409 branch,
+  and stop the `Mem` fake asserting a protocol that does not exist.
+
+What is not acceptable is leaving a fake that documents a guarantee the
+real implementation does not provide. That exact shape — a test double
+enforcing more than production — is how the unauthenticated upload path
+survived a full day of green builds last week.
+
+### 3. Make `StartUpload` not race
+
+Concurrent starts for one key must converge on one upload id, or fail
+cleanly. Non-deterministic selection is not acceptable.
+
+### 4. Reap abandoned multiparts
+
+An incomplete multipart older than some age must not be silently
+resumed. An S3 lifecycle rule is one answer, an age check at resume is
+another; either is fine if you say which and why. Note the lifecycle
+rule is infrastructure, not code — if that is your answer, state
+exactly what an operator must configure.
+
+## Tests
+
+- [ ] Two uploads to the same key with **different content** do not
+  produce an interleaved object, and the second is refused rather than
+  silently assembled over the first.
+- [ ] A genuine retry of the **same** content still succeeds — the
+  resume path is the reason this protocol exists and must not regress.
+- [ ] Concurrent `StartUpload` for one key converges deterministically.
+- [ ] A stale abandoned multipart is not resumed.
+- [ ] **`Mem` and `S3Storage` agree.** Add a shared contract test run
+  against both, in the shape of
+  `operator/internal/combinejob/envcontract_test.go` — which reads the
+  Python source as text and asserts set-equality across a
+  cross-language boundary, and is the best test in this repo. The
+  reviewers found three divergences beyond the token:
+  `Mem` uses `io.ReadFull` and errors on a short body while `s3.go:124`
+  uses `io.ReadAll` (short read, nil error, then declares the full
+  size); `Mem.StatObject` has **no error path at all**, so
+  `upload.go:635-637`'s recovery branch is unreachable under test; and
+  `Mem` accepts any part size while S3 requires ≥5 MiB for non-final
+  parts.
+
+`storage/s3.go` has **no test file at all** (226 lines, 0% coverage).
+Postgres is now available in CI — use it.
+
+## Warts / traps
+
+- Do not change the agent or the client upload path.
+- Do not weaken the checksum verification; it is the last line and it
+  works.
+- `Mem.CallCount()` returns `len(uploads) + len(objects)` — it counts
+  **state, not calls** — while being asserted under the words *"assert
+  the storage call did not happen"*. If you touch it, make it count
+  calls or stop claiming it does.
+- `docs/adr/**` is a record; `docs/specs/**` likewise.
+
+Finish: `/workspace/PR.md` with your token decision and why, what a
+caller sees for each of the three collision cases, the shared
+`Mem`/`S3Storage` contract test, and what an operator must configure.


### PR DESCRIPTION
Specs for tycho#125 and #126 — the two review findings that can destroy irreplaceable data.

Both are in the tycho repo but disjoint trees (`gateway/internal/storage` vs `agent/internal/uploader`), so they run in parallel with an explicit stay-out note in each.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt