### PR TITLE
deploy(tycho): 85e8477 — an accepted frame can no longer be overwritten

### DIFF
--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-gateway
-    newTag: "d76e721"
+    newTag: "85e8477"


### PR DESCRIPTION
Ships tycho #134 and #136 — the two senior-review findings that could destroy irreplaceable data.

### #125 — the gateway could overwrite an accepted frame

`storage/s3.go` discarded the upload token (`func (s *S3Storage) UploadPart(ctx, key, _ string, ...)`), and said so itself: *"ErrTokenConflict is therefore never returned by this implementation; it exists for Mem-backed tests."* So the suite exercised a protocol production did not implement.

Two uploads to one key shared a multipart upload, parts overwrote by number, and `CompleteUpload` assembled an interleaved object — with the checksum catching it only **after** `assembleObject` had overwritten what was there, and `InsertSub` then returning `ErrDuplicateSub` so it read as a benign duplicate.

Now:

```
different checksum → refused BEFORE assembly, existing object untouched
same checksum      → falls through (the resume path this protocol exists for)
```

Both covered by Postgres-backed tests, which now actually run thanks to #124.

### #136 — the agent buffer (in the release, not this deploy)

Nothing in the agent ever deleted anything. Retention now waits for **gateway-confirmed acceptance**, never upload alone; the O(n²) full-map rewrite per frame becomes an append-only journal with periodic compaction; and a shared `writeFileAtomic` does `O_EXCL` + fsync + dir-fsync, which also closes the separate finding that `enrol.Save` claimed crash-atomicity it did not provide.

This PR pins the **gateway** only. The agent-side fix reaches members through the client release, cut separately.

### Known gap, filed as #135

The new `Mem`/`S3Storage` contract test is good and closed three divergences — but its **S3 leg skips silently** unless `TYCHO_TEST_S3_ENDPOINT` is set, and nothing sets it. Same shape as the Postgres skips fixed this morning, reintroduced on the next PR because the convention it copied was silent until today.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Tycho gateway container to a newer release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->