### PR TITLE
deploy(tychofleet): 1f01739 — published technical docs

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:ee2076f
+          image: zot.phillips-homelab.net/tychofleet:1f01739
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Ships tychofleet #60. Four pages under `/docs`: how Tycho works, what runs on your machine, identity and trust, attribution.

### Why I am comfortable putting this in front of members

I checked every security claim against the code, because this is prose that asks people to trust us with irreplaceable data. It declines to overclaim in both places where overclaiming would have been easy and invisible:

**On attestation** — *"Modified firmware could report any serial it likes, and nothing here would catch that on its own. Treat this as a consistency check — does this scope keep saying the same thing about itself over time — not as proof of ownership."*

**On the tailnet** — *"Whether anything else on that tailnet is reachable at all is a policy decision made in Tailscale's own control plane, not something this codebase can prove to you by itself — a deployment-time configuration claim, stated here honestly rather than glossed over as a guarantee this code enforces."*

That second one is the sharpest thing in the PR. The ACL confining `tag:scope` to the gateway is real and I verified it live — but it lives in Tailscale's control plane, not this repo, and the page says so rather than taking credit for it.

It also carries an "honest summary" table separating what each mechanism **actually proves**: attestation is *"a consistency signal, not unforgeable"*; the per-scope credential is *"real authentication"*; tailnet membership is *"a private transport, not a promise about what else lives on it."*

Claims verified against code and against production behaviour: the credential is checked on every request including uploads (true as of #120), a mismatched or revoked credential is refused (verified live: 401/403), removal revokes immediately (verified live), the setup key is single-use and ~7 days (`reusable: false`, `expirySeconds: 604800`), and the attribution rule is SUM over sessions of MAX — matching `attribution.ts`.

Zero `text-slate-*` in the new pages, so the design split is not deepened; one `<h1>` per page; reachable from the docs nav and index, with a reachability test. 869 tests passing.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt