### PR TITLE
spec(loops): S3 in CI, and the enrolment lock-order deadlock

### DIFF
--- a/loops/specs/gate-s3-ci/SPEC.md
+++ b/loops/specs/gate-s3-ci/SPEC.md
@@ -1,0 +1,95 @@
+# SPEC — gate-s3-ci: the storage that runs in production is untested
+
+Repo: `loop-bot/tycho`. Gate: `make build test lint`.
+
+Closes issue **#135**. Scope: `ci/`, the `Makefile`, `docs/dev/`, and
+whatever `gateway/internal/storage` needs to be reachable. A sibling
+loop is in `gateway/internal/catalog` — stay out of it.
+
+## The failure
+
+PR #134 added `gateway/internal/storage/contract_test.go`, which runs
+the same behavioural assertions against `Mem` and `S3Storage` so a
+divergence between the fake and production fails in CI. It is a good
+test and it closed three real divergences.
+
+**Its S3 half never runs.** It skips unless `TYCHO_TEST_S3_ENDPOINT` is
+set, and nothing sets it:
+
+- not the `Makefile`, which has a loud warning block for
+  `TYCHO_TEST_DATABASE_URL` and nothing for S3
+- not `ci/main.go`, which now runs a Postgres service — so the pattern
+  exists and was simply not applied
+- not `docs/dev/testing.md`, the document whose entire job is
+  enumerating the gate's blind spots
+
+So the half of the contract test covering **the implementation that
+actually runs in production** never executes anywhere, and
+`storage/s3.go` stays at 0% coverage.
+
+This is the same shape as the eight Postgres tests that skipped
+silently for months, fixed this morning in #124 — reintroduced on the
+very next PR. Not the loop's fault: it copied the
+`TYCHO_TEST_DATABASE_URL` convention faithfully, and that convention
+was silent until today. **Conventions propagate faster than fixes**,
+which is why this one needs closing rather than noting.
+
+## What to build
+
+### 1. An S3-compatible service in CI
+
+Same shape as the Postgres service in `ci/main.go`. MinIO or Garage —
+pick one and say why. Set `TYCHO_TEST_S3_ENDPOINT` (and whatever
+region/bucket/credentials the test needs) alongside
+`TYCHO_TEST_DATABASE_URL`.
+
+The bucket must be **disposable and created by the test setup**, not
+assumed to exist.
+
+### 2. A loud skip when it is absent
+
+Match the Postgres banner in the `Makefile` exactly — same shape, same
+`STRICT=1` hard failure. A developer running `make test` without a
+bucket must be told, in the same words, that a real part of the gate
+did not run.
+
+### 3. Correct the blind-spot docs
+
+`docs/dev/testing.md` must list S3 alongside Postgres. If
+`docs/MATURITY.md` states coverage or skip counts, they change too.
+
+Be exact. That file was wrong about the Postgres skip count for weeks
+("three Go tests skip" when it was eight across six files), which is
+part of why this class of gap survived.
+
+### 4. Verify the contract test actually finds something
+
+With the S3 leg running, confirm `Mem` and `S3Storage` genuinely agree
+on the assertions in that file. If a divergence surfaces, **that is the
+finding** — report it prominently in PR.md rather than adjusting the
+test to pass. The three already closed (short-read handling, minimum
+part size, `StatObject`'s missing error path) suggest there may be
+more.
+
+## Tests
+
+- [ ] `TYCHO_TEST_S3_ENDPOINT` set → the S3 leg of `contract_test.go`
+  runs and passes. Paste the output in PR.md — `--- PASS` lines naming
+  the S3 subtests, not a summary.
+- [ ] Unset → a loud banner, and a hard failure under `STRICT=1`.
+- [ ] `storage/s3.go` coverage is no longer 0%. State the number.
+
+## Warts / traps
+
+- Do not weaken any assertion in `contract_test.go` to make the S3 leg
+  pass. If production behaves differently from the fake, production is
+  the fact and the fake is wrong — unless the fake encodes what we
+  *want*, in which case that is a bug in `s3.go` and a separate issue.
+- Do not touch `gateway/internal/catalog` — a sibling loop is there.
+- The gate runs `-race -count=1` by default. Keep it.
+- CI is offline apart from services it starts itself. A test that
+  reaches the public internet will not run.
+
+Finish: `/workspace/PR.md` with the S3 subtests passing, the coverage
+number for `s3.go`, the loud-skip banner, the corrected blind-spot
+docs, and any divergence the newly-running leg exposed.

--- a/loops/specs/gateway-enrolment-deadlock/SPEC.md
+++ b/loops/specs/gateway-enrolment-deadlock/SPEC.md
@@ -1,0 +1,96 @@
+# SPEC — gateway-enrolment-deadlock: two paths, two locks, opposite order
+
+Repo: `loop-bot/tycho`. Gate: `make build test lint`.
+
+Closes issue **#130**. Scope: `gateway/internal/catalog/postgres.go`
+and its tests. A sibling loop is in `ci/` and
+`gateway/internal/storage` — stay out of both.
+
+## The failure
+
+Two code paths take the same two row locks in opposite order:
+
+- **`IssueEnrolmentCode`** (`postgres.go:159-196`) locks `source` first
+  (`:167` `SELECT revoked_at FROM source WHERE id = $1 FOR UPDATE`),
+  then takes row locks on `enrolment_code` via `:183`
+  `DELETE FROM enrolment_code WHERE scope_id = $1 AND redeemed_at IS NULL`.
+- **`RedeemEnrolmentCode`** (`postgres.go:205-249`) locks
+  `enrolment_code` first (`:216` `... WHERE code_hash = $1 FOR UPDATE`),
+  then `source` (`:229`).
+
+For one scope X with one live unredeemed code C:
+
+| | T1 = Redeem(C) | T2 = Issue(new code for X) |
+|---|---|---|
+| 1 | `BEGIN`; locks `enrolment_code` **C** | |
+| 2 | | `BEGIN`; locks `source` **X** |
+| 3 | wants `source` X → **blocks on T2** | |
+| 4 | | must lock code **C** → **blocks on T1** |
+
+Postgres aborts one transaction with SQLSTATE 40P01 after
+`deadlock_timeout`. Neither path retries, so it surfaces as a **500**
+through `scope/http.go:172-175`'s default branch.
+
+**It happens with a single site instance** — it needs two concurrent
+*requests*, not two replicas. Realistic trigger: an owner clicks
+"regenerate code" on their deck at the same moment their agent redeems
+the previous one. Agents retry, so an in-flight redemption is normal.
+
+Severity is moderate, not urgent: the window is milliseconds, the
+outcome is a 500 rather than corruption, and both operations are safely
+retryable. It is worth fixing because it is cheap and because a 500 on
+enrolment is a support ticket nobody can diagnose.
+
+## What to build
+
+Make both paths acquire the locks in the same order.
+
+The suggested fix is a **two-line reorder**: in `IssueEnrolmentCode`,
+move the `DELETE` (`:183`) above the `SELECT ... FOR UPDATE` on
+`source` (`:167`), so both paths take `enrolment_code` before `source`.
+The revoked check stays correct — it is still inside the same
+transaction, so a revoked scope rolls back and undoes the DELETE.
+
+If you would rather not reason about lock order at all,
+`SELECT pg_advisory_xact_lock(hashtext($scope_id))` as the first
+statement in both functions is equally cheap and obviously correct.
+Either is acceptable; **say which you chose and why**.
+
+Whatever you choose, leave a comment at both sites stating the ordering
+invariant and what breaks if a future edit reverses it. That comment
+earns its place under the project's own rule: it names a constraint the
+type system cannot hold, and the failure it prevents.
+
+## Tests
+
+This is the hard part, and it is the point of the loop.
+
+- [ ] A **Postgres-backed** test that drives the two paths concurrently
+  against the same scope and asserts neither returns a deadlock error.
+  Postgres is now available in CI (#124), so this can be a real test
+  rather than a thought experiment.
+- [ ] Both operations still behave correctly under contention: exactly
+  one redemption succeeds, the issued code is the live one afterwards,
+  and a revoked scope is still refused.
+- [ ] Say in PR.md whether your test **fails against the current
+  ordering**. A concurrency test that passes before and after the fix
+  proves nothing — demonstrate it catches the bug, the way the leak
+  tests were made to prove they could fail.
+
+**Note this is invisible to the in-memory fake by construction:**
+`MemCatalog` takes one global mutex per method body (`mem.go:181`), so
+no fake can express lock ordering. Delete `FOR UPDATE` from both
+queries and every existing test still passes. Do not add a fake-level
+test and call it covered.
+
+## Warts / traps
+
+- Do not change the enrolment protocol, the code format, TTLs, or
+  hashing. This is a lock-ordering fix, nothing else.
+- Do not remove `FOR UPDATE` — the row locks are load-bearing for
+  single-use redemption, which is verified working in production.
+- Do not touch `gateway/internal/storage` or `ci/` — sibling loops.
+- The gate runs `-race -count=1` by default.
+
+Finish: `/workspace/PR.md` with your chosen fix and why, the concurrent
+test, and evidence that it fails against the current ordering.


### PR DESCRIPTION
Specs for tycho#135 and #130. Disjoint trees (`ci/` + `storage/` vs `catalog/postgres.go`), running in parallel.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt