### PR TITLE
spec(loops): publish-before-status, gateway resource limits

### DIFF
--- a/loops/specs/gateway-resource-limits/SPEC.md
+++ b/loops/specs/gateway-resource-limits/SPEC.md
@@ -1,0 +1,108 @@
+# SPEC — gateway-resource-limits: a client-declared number allocates gateway memory
+
+Repo: `loop-bot/tycho`. Gate: `make build test lint`.
+
+Closes issue **#129**. Scope: `gateway/` and `deploy/gateway/`. A
+sibling loop is in `operator/` — stay out.
+
+## The failure
+
+`storage/s3.go` reads a part with:
+
+```go
+buf, err := io.ReadAll(io.LimitReader(body, size))
+```
+
+where `size` is `r.ContentLength` (`upload/http.go:122`) — **entirely
+client-supplied**, capped nowhere. `upload.go:115-120` states plainly
+that the gateway does not enforce `partSize`.
+
+The comment above that line claims *"Bounded at one protocol part
+(8MiB)"*. It is false. A request declaring
+`Content-Length: 8000000000` makes the gateway allocate 8 GB in a
+single buffer.
+
+**And `deploy/gateway/deployment.yaml` has no `resources:` block at
+all**, so that OOMs the node rather than the pod. With `replicas: 1`,
+the node it lands on is the whole ingest path.
+
+Related, same class:
+
+- `grep MaxBytesReader gateway/ operator/` → **zero hits**. Every JSON
+  handler streams an unbounded body, including `POST /v1/enrol` — the
+  one deliberately unauthenticated write in the system.
+- `main.go:232-236` sets only `ReadHeaderTimeout`. No `WriteTimeout`,
+  no `IdleTimeout`. Part uploads legitimately run for minutes over
+  flaky links, so stalled connections accumulate with nothing to reap
+  them.
+
+This is an availability problem before it is a security one, and the
+unauthenticated enrol endpoint makes it reachable without a credential.
+
+## What to build
+
+### 1. Reject oversized parts before allocating
+
+A declared size beyond what the protocol permits is a **413**, refused
+before any allocation. `partSize * 2` is a reasonable ceiling; pick one
+and justify it — the point is that a client cannot name a number that
+becomes a buffer.
+
+Delete the comment claiming it is already bounded. It is exactly the
+kind of confident-and-wrong comment this project has been removing all
+week.
+
+### 2. Bound every request body
+
+`http.MaxBytesReader` on every handler that reads one. `POST /v1/enrol`
+matters most: unauthenticated, and a code is a fixed 14 characters, so
+its limit can be very small.
+
+### 3. Server timeouts
+
+`WriteTimeout` and `IdleTimeout` on the `http.Server`. Choose values
+that do not break a legitimate slow part upload over a bad connection —
+say what you chose and why. A too-aggressive `WriteTimeout` here would
+break exactly the members this system exists for.
+
+### 4. Container resources
+
+`requests` and `limits` in `deploy/gateway/deployment.yaml`. Base them
+on something: the part ceiling, the concurrency, and observed usage if
+you can find it. Say how you arrived at the numbers.
+
+Consider a concurrency semaphore on part uploads, so N concurrent
+uploads cannot each allocate the ceiling simultaneously. If you add
+one, its limit and the memory limit must be consistent with each other,
+and say so.
+
+## Tests
+
+- [ ] A request declaring a `Content-Length` above the ceiling is
+  refused with 413 **before** any storage call — assert the storage
+  call did not happen.
+- [ ] A legitimate part at the normal size still succeeds unchanged.
+- [ ] An oversized body to `/v1/enrol` is refused.
+- [ ] A body whose declared length exceeds what it actually sends is
+  handled without hanging — note `s3.go`'s `io.ReadAll` currently
+  returns a **short buffer with nil error** and then declares the full
+  size, which is a real divergence from `Mem`'s `io.ReadFull`.
+
+`storage/s3.go` can now be tested against a real MinIO in CI
+(`TYCHO_TEST_S3_ENDPOINT`, added in #137) — use it.
+
+## Warts / traps
+
+- Do not weaken checksum verification.
+- Do not change the upload protocol shape — resumability is the reason
+  it exists and works.
+- Do not touch `operator/` — a sibling loop is there.
+- The gateway currently runs `replicas: 1`. Do not change that here;
+  if your reading is that it should be higher, say so in PR.md as a
+  recommendation.
+- The gate runs `-race -count=1` by default.
+
+Finish: `/workspace/PR.md` with the ceiling you chose and why, the
+timeout values and their justification, the container numbers and how
+you derived them, and proof that an oversized declaration never reaches
+storage.

--- a/loops/specs/operator-publish-before-status/SPEC.md
+++ b/loops/specs/operator-publish-before-status/SPEC.md
@@ -1,0 +1,112 @@
+# SPEC — operator-publish-before-status: the requeue can never republish
+
+Repo: `loop-bot/tycho`. Gate: `make build test lint`.
+
+Closes issue **#127**. Scope: `operator/` only. A sibling loop is in
+`gateway/internal/storage` and `gateway/internal/upload` — stay out.
+
+## The failure
+
+Every terminal-state reconciler commits the phase transition and *then*
+publishes:
+
+```
+Status().Update(...)   // phase := Done
+publish(...)           // fails
+return err             // requeue
+```
+
+The requeued Reconcile hits a guard at the top that returns `nil`
+unless the phase is `Combining` — sees the phase it just wrote — and
+no-ops. **The event is lost permanently and nothing retries.**
+
+Six sites:
+
+| controller | update → publish | guard |
+|---|---|---|
+| `combine_controller.go` | `:195→220`, `:265→286` | `:90` |
+| `master_controller.go` | `:137→184`, `:196→218` | `:83` |
+| `fleetmaster_controller.go` | `:138→180`, `:231→253` | `:100` |
+
+`master_controller.go:184` is the costly one — `tycho.job.master.succeeded`
+carries `input_keys`, the **only** source of `combine_input` provenance.
+Lose it and a master exists with no record of which sessions built it.
+
+Same shape in `sessionclose.go:328-333`: `created=false` on redelivery
+skips `publishJobStarted` forever.
+
+`combine_controller.go:226-239` describes this exact hazard for
+`ensureMasterCombine` and correctly downgrades it to log-and-continue —
+then leaves `:220` returning the error. The reasoning was right and was
+applied in one place out of seven.
+
+## Why it was never caught
+
+`eventbus/mem.go` declares a `PublishErr` fault-injection hook in
+**both** gateway and operator.
+
+```
+grep -rn "PublishErr" --include='*_test.go'   →   nothing
+```
+
+The hook exists. Someone built it. Nobody wired it up. So every
+publish-failure branch in the operator is dead code under test. Four of
+seven fault hooks in the gateway fakes are similarly dead.
+
+## What to build
+
+### 1. Publish before the status update
+
+The consumer is already idempotent — `RecordResult`'s revision guard
+(`postgres.go:479`) makes a redelivered event safe. So publishing
+first, then committing the phase, means a publish failure requeues into
+a Reconcile that still sees `Combining` and retries properly.
+
+If you find a site where publishing first is genuinely wrong — an event
+that must not be emitted unless the transition committed — **say so in
+PR.md and use `Status.PublishedRevision`** (or an equivalent) to gate
+the guard instead. Do not silently leave one of the seven unfixed; that
+is how this survived.
+
+### 2. Fix `sessionclose.go`'s redelivery case
+
+`created=false` must not mean "never publish". Decide what redelivery
+should do and say why.
+
+### 3. Wire up `PublishErr`
+
+Use the hook that already exists. Every one of the seven sites needs a
+test where the publish fails and the event is **still delivered after a
+requeue**. That is the whole point — not that an error is returned, but
+that the event eventually arrives.
+
+## Tests
+
+- [ ] For each of the six controller sites: publish fails once, the
+  reconcile requeues, and on retry the event **is published**. Assert
+  on the event reaching the bus, not on the error.
+- [ ] `sessionclose.go`'s redelivery path publishes.
+- [ ] The idempotency the fix relies on holds: a duplicate
+  `master.succeeded` does not corrupt `combine_input`.
+- [ ] Existing behaviour is unchanged when publishing succeeds first
+  time — assert it, since this reorders the happy path.
+
+**Note `operator/fullloop_test.go:170,302` construct
+`CombineJobReconciler` without `Scheme`**, which trips an early
+`return nil` at `master_trigger.go:92-94` and
+`fleetmaster_trigger.go:123-125` — silently disabling the master and
+fleet-master spawn paths inside the test that claims to cover the full
+loop. If your change touches those paths, that test will not tell you.
+Say in PR.md whether you fixed it or worked around it.
+
+## Warts / traps
+
+- Do not touch `gateway/` — a sibling loop is there now.
+- Do not change event payloads or subjects; consumers depend on them.
+- `RequeueAfter` appears exactly once in the whole operator
+  (`seestar_controller.go:75`). Related to issue #51 but **not this
+  loop** — do not fix it here, and do not make it harder to fix later.
+- The gate runs `-race -count=1` by default.
+
+Finish: `/workspace/PR.md` with the seven sites and what each does now,
+the `PublishErr` tests, and your answer on `fullloop_test.go`.


### PR DESCRIPTION
tycho#127 and #129. Disjoint trees (operator vs gateway), running in parallel.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt