### PR TITLE
deploy(tycho): ef2c847 — seven review fixes, and real container limits

### DIFF
--- a/gitops/tools/apps/tycho/agent/kustomization.yaml
+++ b/gitops/tools/apps/tycho/agent/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-agent
-    newTag: "2676d23"
+    newTag: "ef2c847"

--- a/gitops/tools/apps/tycho/gateway/deployment.yaml
+++ b/gitops/tools/apps/tycho/gateway/deployment.yaml
@@ -60,6 +60,19 @@ spec:
           ports:
             - name: http
               containerPort: 8080
+          # Mirrors deploy/gateway/deployment.yaml in the tycho repo,
+          # which loops can edit and this repo's manifests are not.
+          # Without a limit, the part-upload path OOMs the NODE rather
+          # than the pod — and with replicas: 1 that node is the whole
+          # ingest path. The ceiling is chosen against maxPartSize plus
+          # upload concurrency (tycho #129).
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "1000m"
           env:
             - name: LISTEN_ADDR
               value: ":8080"

--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-gateway
-    newTag: "85e8477"
+    newTag: "ef2c847"

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -12,4 +12,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "d76e721"
+    newTag: "ef2c847"


### PR DESCRIPTION
Batches everything merged since the last deploy. Verified on `main` with the Postgres **and** S3 service legs running, not just the offline gate.

| issue | what it fixes |
|---|---|
| #127 | six reconcilers lost events permanently when a publish failed — the requeue hit a guard on the phase they had just written. `PublishErr` now wired at 12 test sites, up from zero. |
| #128 | `MaxDeliver` + backoff (poison messages hot-looped forever), 7d/4GiB retention on a stream carrying full FITS headers, explicit `Terminal()` opt-in, and `WithMsgID` so exactly-once is real rather than only asserted |
| #129 | a client-declared `Content-Length` drove an unbounded allocation; refused now before any allocation, bodies bounded everywhere including unauthenticated `/v1/enrol` |
| #130 | lock-order inversion — **31 of 200 concurrent issue/redeem trials deadlocked** before the fix, zero after |
| #51 | `Failed` was terminal forever; `RequeueAfter` appeared once in the entire operator. Open since 2026-07-19, closed with the recorded incident (14 subs → fail → 169 subs → no spawn) as its test. |

### The resources block

Mirrored by hand, and worth noting why: it lives in the tycho repo's `deploy/gateway/deployment.yaml`, which loops can edit — while **this** repo's manifests are what actually run. So the limit the loop added had no effect on production. Without it the part-upload path OOMs the *node*, not the pod, and `replicas: 1` makes that node the whole ingest path.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt