### PR TITLE
deploy(tychofleet): 0c7bbc5 — accessibility

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:1f01739
+          image: zot.phillips-homelab.net/tychofleet:0c7bbc5
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Ships tychofleet #63, closing the accessibility findings from the senior review.

I recomputed every ratio independently rather than trusting the PR:

| token | before | after | floor | |
|---|---|---|---|---|
| `--color-text-faint` | 2.92:1 | **4.69:1** | 4.5 | 178 usages — last-seen times, setup countdown, helper text |
| `--color-border` | 2.38:1 | **3.89:1** | 3.0 | the only thing marking a field as a field |
| `--color-text-strong` | dimmer than base | **17.99:1** | 4.5 | inversion fixed |

Also: a real `:focus-visible` that survives the global `box-shadow: none !important`, labels for admin's 35 previously-unlabelled inputs, an `<h1>` per page, `aria-live` on the setup page's polling status, and `overflow-x-auto` on the two public tables that lacked what the admin ones had.

`global.contrast.test.ts` computes the ratios, so a future token tweak that breaks WCAG fails the gate rather than shipping silently. 931 tests, up from 881.

Deliberately **not** included: the two-visual-eras problem (issue #59) — `text-slate-*` in 100 places, a type scale defined and used zero times, a button hand-rolled 20 times. That is a separate change and bundling it here would have made this unreviewable.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt