### PR TITLE
tycho: deploy e2508d7 (comment integrity + declarative recipes)

### DIFF
--- a/gitops/tools/apps/tycho/agent/kustomization.yaml
+++ b/gitops/tools/apps/tycho/agent/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-agent
-    newTag: "ef2c847"
+    newTag: "e2508d7"

--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-gateway
-    newTag: "ef2c847"
+    newTag: "e2508d7"

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -12,4 +12,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "ef2c847"
+    newTag: "e2508d7"


### PR DESCRIPTION
Bumps gateway/operator/agent from `ef2c847` to `e2508d7`.

Two merges land, both runtime no-ops:

- **#144** `loop/comments` — comment integrity pass + `commentlint` wired into the gate. No behaviour change.
- **#148** `loop/recipe` — combine's hardcoded stage order becomes a declarative recipe document, recorded with the result (FITS header + `result.recipe` jsonb). **The default path is byte-identical**, verified against the real M13 masters pulled from Garage: 0 of 13,303,320 pixels differ, header delta is the single new `RECIPE` card.

`tycho-agent` is scaled to 0 (the agent runs on the operator's own machine), so only gateway and operator actually roll.

Verified before merge: full gate green with the Python and Postgres legs live — migration `0009_result_recipe.sql` applies against a real PG16, `ok tycho.dev/gateway/internal/catalog`, zero skips.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated the Tycho agent, gateway, and operator components to newer container image versions.
  * Includes the latest available updates and improvements for these components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->