### PR TITLE
tycho: deploy f2fa8f6 (rejection floor) + unstick COMBINE_IMAGE

### DIFF
--- a/gitops/tools/apps/tycho/agent/kustomization.yaml
+++ b/gitops/tools/apps/tycho/agent/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-agent
-    newTag: "e2508d7"
+    newTag: "f2fa8f6"

--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-gateway
-    newTag: "e2508d7"
+    newTag: "f2fa8f6"

--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -102,7 +102,12 @@ spec:
             # operator fails closed at startup without them. See the
             # placeholder-image note above.
             - name: COMBINE_IMAGE
-              value: "zot.phillips-homelab.net/tycho-combine:31451df" # PRs #96/#97: partition before load, and combinability is RGB-and-solved
+              # Bumped by hand, and it has drifted before: it sat 70
+              # commits stale through the #148 deploy, so the recipe
+              # feature was live everywhere except the container that
+              # reads it (tycho #154). Bump this whenever combine/
+              # changes, and check it moved after ArgoCD syncs.
+              value: "zot.phillips-homelab.net/tycho-combine:f2fa8f6"
             - name: COMBINE_S3_SECRET_NAME
               value: "tycho-combine-s3" # hand-minted from tycho-config values — see README
             # COMBINE_SCRATCH_SIZE is optional (default 10Gi): the

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -12,4 +12,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "e2508d7"
+    newTag: "f2fa8f6"


### PR DESCRIPTION
Bumps gateway/operator/agent `e2508d7` → `f2fa8f6`, **and `COMBINE_IMAGE` `31451df` → `f2fa8f6`**.

### The COMBINE_IMAGE part matters

`COMBINE_IMAGE` had drifted **70 commits** ([tycho #154](https://code.phillips-homelab.net/loop-bot/tycho/issues/154)). It predated the recipe work in #148 — so that feature has been live in the gateway, operator, catalog and event schemas, while the container that actually reads `TYCHO_RECIPE_JSON` was old code ignoring it. No symptom: combine kept doing exactly what it always did.

So this deploy lands two things in combine at once: the recipe reader (#148) and the rejection floor (#151).

### What #151 does

Raises `MIN_INPUTS_FOR_CLIP` 3 → 8, which turns pixel rejection off for every target in the archive. Measured on three real M13 nights at N=3:

| | old | new |
|---|---|---|
| integrated star flux | 2,496,341 | 1,678,921 — **−32.7%** |
| pixels changed | — | **72.3%** |
| local noise, star-free patch | 89.6 | **21.6** |

**Existing masters are untouched by this deploy.** They only change when re-reduced, which is a separate, deliberate step — M13 first.

Also replaced the trailing comment on `COMBINE_IMAGE`, which credited PRs #96/#97 and no longer explained anything true about the pin.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Tycho agent, gateway, and operator components to a newer container image version.
  * Added deployment guidance for manually updating images and verifying configuration consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->