### PR TITLE
tycho: deploy cb49452 (real build identity in recorded provenance)

### DIFF
--- a/gitops/tools/apps/tycho/agent/kustomization.yaml
+++ b/gitops/tools/apps/tycho/agent/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-agent
-    newTag: "f2fa8f6"
+    newTag: "cb49452"

--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-gateway
-    newTag: "f2fa8f6"
+    newTag: "cb49452"

--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -107,7 +107,7 @@ spec:
               # feature was live everywhere except the container that
               # reads it (tycho #154). Bump this whenever combine/
               # changes, and check it moved after ArgoCD syncs.
-              value: "zot.phillips-homelab.net/tycho-combine:f2fa8f6"
+              value: "zot.phillips-homelab.net/tycho-combine:cb49452"
             - name: COMBINE_S3_SECRET_NAME
               value: "tycho-combine-s3" # hand-minted from tycho-config values — see README
             # COMBINE_SCRATCH_SIZE is optional (default 10Gi): the

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -12,4 +12,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "f2fa8f6"
+    newTag: "cb49452"


### PR DESCRIPTION
All four pins → `cb49452`, `COMBINE_IMAGE` included.

Closes the gap in [tycho #156](https://code.phillips-homelab.net/loop-bot/tycho/issues/156): `engine_digest` was `sha256` of the dependency versions only, and `tycho-combine` has been `0.1.0` for the project's whole life — so the two M13 masters that differ by **20% in integrated star flux and 9.9% in colour** hashed identically.

The combine image now bakes its build commit in. Verified in the pushed image:

```
$ docker run --rm --entrypoint sh zot.phillips-homelab.net/tycho-combine:cb49452 \
    -c 'echo $COMBINE_BUILD_COMMIT'
cb49452
```

And the digest separates the exact pair that collided:

```
f2fa8f6 -> sha256:c823f49dfa33527514d...
31451df -> sha256:b574aa2d37456b10277...
unknown -> sha256:28eab7d9482d0991428...
```

An unknown build hashes differently from any known build rather than silently degrading to the old dependency-only value — that silent degradation is how the original bug survived.

**Provenance only.** 0 of 1,328,400 pixels differ against `origin/main` on the real M13 fixtures. No master changes as a result of this deploy; masters only change when re-reduced.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Tycho agent, gateway, and operator components to a newer container image version.
  * Ensures all Tycho components use the same updated release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->