### PR TITLE
tycho: deploy f21e72b (flux-conserving reprojection)

### DIFF
--- a/gitops/tools/apps/tycho/agent/kustomization.yaml
+++ b/gitops/tools/apps/tycho/agent/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-agent
-    newTag: "cb49452"
+    newTag: "f21e72b"

--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-gateway
-    newTag: "cb49452"
+    newTag: "f21e72b"

--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -107,7 +107,7 @@ spec:
               # feature was live everywhere except the container that
               # reads it (tycho #154). Bump this whenever combine/
               # changes, and check it moved after ArgoCD syncs.
-              value: "zot.phillips-homelab.net/tycho-combine:cb49452"
+              value: "zot.phillips-homelab.net/tycho-combine:f21e72b"
             - name: COMBINE_S3_SECRET_NAME
               value: "tycho-combine-s3" # hand-minted from tycho-config values — see README
             # COMBINE_SCRATCH_SIZE is optional (default 10Gi): the

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -12,4 +12,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "cb49452"
+    newTag: "f21e72b"


### PR DESCRIPTION
All four pins → `f21e72b`, `COMBINE_IMAGE` included. Commit verified baked into the pushed image (`COMBINE_BUILD_COMMIT=f21e72b`).

Closes [tycho #152](https://code.phillips-homelab.net/loop-bot/tycho/issues/152).

**Total flux was never the risk** — every method conserves it to under 0.05% at every angle out to 180°. The error lives in how flux redistributes between a star and its background, and it grows with rotation:

| pair | rotation | `interp` vs `exact`, max single-star |
|---|---|---|
| M13 07-27 → 07-29 | 1.26° | 0.012% |
| Rho pair | 8.9° | 0.404% |
| **M13 07-18 → 07-29** | **112.8°** | **5.213%** |

That 112.8° is real — an alt-az scope reframing between sessions — and it's in the M13 master on the site today. 5.2% is past this repo's own 5% photometry tolerance.

Default is now `reproject_exact`. `reproject_adaptive(conserve_flux=True)` was tried as a cheaper middle ground and **rejected**: its gaussian kernel smears single-pixel outliers below rejection's clip threshold, quietly degrading the guarantee rejection exists to provide.

Cost ~5× per input, ~6 min for a 20-night master on an async batch Job with no latency SLA.

**Existing masters unchanged** until re-reduced.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Tycho agent, gateway, and operator components to a newer container image version.
  - Applied the updated image version to the operator’s combined image configuration for consistent deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->