### PR TITLE
tycho: deploy 0ae9196 (coverage threshold fix)

### DIFF
--- a/gitops/tools/apps/tycho/agent/kustomization.yaml
+++ b/gitops/tools/apps/tycho/agent/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-agent
-    newTag: "f21e72b"
+    newTag: "0ae9196"

--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-gateway
-    newTag: "f21e72b"
+    newTag: "0ae9196"

--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -107,7 +107,7 @@ spec:
               # feature was live everywhere except the container that
               # reads it (tycho #154). Bump this whenever combine/
               # changes, and check it moved after ArgoCD syncs.
-              value: "zot.phillips-homelab.net/tycho-combine:f21e72b"
+              value: "zot.phillips-homelab.net/tycho-combine:0ae9196"
             - name: COMBINE_S3_SECRET_NAME
               value: "tycho-combine-s3" # hand-minted from tycho-config values — see README
             # COMBINE_SCRATCH_SIZE is optional (default 10Gi): the

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -12,4 +12,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "f21e72b"
+    newTag: "0ae9196"


### PR DESCRIPTION
All four pins → `0ae9196`, `COMBINE_IMAGE` included. Commit verified baked into the pushed image.

Fixes [tycho #162](https://code.phillips-homelab.net/loop-bot/tycho/issues/162), a regression from #159 currently live in the M13 master.

`common_coverage_mask` tested `footprints > 0`, which silently depended on `reproject_interp` returning binary footprints. Switching to `reproject_exact` made them fractional, so a pixel covered by one part in a thousand counted as covered — and at the real 112.8° inter-night rotation that blew the crop bounding box out by **1,251 rows**, readmitting the partial-coverage sliver the crop exists to remove.

Now thresholds at `COMMON_COVERAGE_THRESHOLD = 0.5`. Verified independently as the unique value reproducing `interp`'s mask exactly:

```
0.25 → 382 differing pixels
0.50 →   0
0.55 →  78
```

A clean minimum in both directions, and it coincides with the principled definition — a pixel is covered when more than half of it is.

M13 gets re-reduced to r8 after this rolls out.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated Tycho agent, gateway, operator, and Combine components to a newer container image version.
  * Ensures all Tycho services use the same updated release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->