### PR TITLE
tycho: actually bump the image tags to c8578e3

### DIFF
--- a/gitops/tools/apps/tycho/agent/kustomization.yaml
+++ b/gitops/tools/apps/tycho/agent/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-agent
-    newTag: "0ae9196"
+    newTag: "c8578e3"

--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-gateway
-    newTag: "0ae9196"
+    newTag: "c8578e3"

--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -107,7 +107,7 @@ spec:
               # feature was live everywhere except the container that
               # reads it (tycho #154). Bump this whenever combine/
               # changes, and check it moved after ArgoCD syncs.
-              value: "zot.phillips-homelab.net/tycho-combine:0ae9196"
+              value: "zot.phillips-homelab.net/tycho-combine:c8578e3"
             # ADR 0010 outbound delivery. Both are REQUIRED: the
             # operator fails closed at startup without them, so this
             # block must land in the same commit as the image bump.

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -12,4 +12,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "0ae9196"
+    newTag: "c8578e3"


### PR DESCRIPTION
Follow-up to #430, which added the required `DELIVERY_*` env but **did not move the image tags**.

My sed matched `f21e72b`, which the previous deploy had already replaced with `0ae9196` — so the tag substitution was a silent no-op while the env block landed fine. The operator has been running `0ae9196` with two env vars it ignores.

No harm: old code doesn't read them, and nothing crash-looped. But the delivery framework isn't actually deployed.

All four pins verified moved this time rather than assumed:



This is the merge that actually rolls the new operator, so #171's startup-Postgres dependency becomes live with it.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Tycho agent, gateway, operator, and combined service images to the latest pinned release.
  * Ensured all Tycho components use the same updated image version for consistent deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->