### PR TITLE
tycho: install the Delivery CRDs and grant the operator RBAC

### DIFF
--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -5,6 +5,8 @@ resources:
   - fleet.tycho.dev_imagingsessions.yaml
   - fleet.tycho.dev_targetmasters.yaml
   - fleet.tycho.dev_fleetmasters.yaml
+  - fleet.tycho.dev_deliveries.yaml
+  - fleet.tycho.dev_deliverytargets.yaml
   - rbac.yaml
   - deployment.yaml
 images:

--- a/gitops/tools/apps/tycho/operator/rbac.yaml
+++ b/gitops/tools/apps/tycho/operator/rbac.yaml
@@ -38,10 +38,10 @@ rules:
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["fleet.tycho.dev"]
-    resources: ["imagingsessions", "seestars", "targetmasters", "fleetmasters"]
+    resources: ["imagingsessions", "seestars", "targetmasters", "fleetmasters", "deliverytargets", "deliveries"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["fleet.tycho.dev"]
-    resources: ["imagingsessions/status", "seestars/status", "targetmasters/status", "fleetmasters/status"]
+    resources: ["imagingsessions/status", "seestars/status", "targetmasters/status", "fleetmasters/status", "deliverytargets/status", "deliveries/status"]
     verbs: ["get", "patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
The `c8578e3` deploy rolled the delivery controllers **without their CRDs**.

Not an outage — the operator is Running with 0 restarts and `targetmaster`/`imagingsession` started normally — but it logs this every 10 seconds and the delivery controllers never start:

```
ERROR  if kind is a CRD, it should be installed before calling Start
       no matches for kind "Delivery" in version "fleet.tycho.dev/v1alpha1"
```

Both the CRD YAMLs and the RBAC lines already existed in the tycho repo's `deploy/operator/` — they were just never copied into gitops. My omission in #430.

**Installing the CRDs alone would only have moved the error from "no matches for kind" to "forbidden"**, since the gitops `rbac.yaml` was missing `deliverytargets`/`deliveries` in both the resource and status rules. So both land in one commit. `rbac.yaml` is now byte-identical to the repo's — it differed in exactly those two lines.

All three files pass `kubectl apply --dry-run=server`.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing deliveries and delivery targets through the Tycho operator.
  * Enabled the operator to access and update delivery resource statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->