### PR TITLE
tycho: deploy gateway 280c581 (part-upload timeout + slot saturation)

### DIFF
--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-gateway
-    newTag: "c8578e3"
+    newTag: "280c581"


### PR DESCRIPTION
Bumps the gateway image pin from `c8578e3` to `280c581`.

Ships tycho PR #185 (`failloud` 1.1-1.3): `Storage.UploadPart` is now
bounded by a configurable deadline (`UPLOAD_PART_TIMEOUT_SECONDS`,
default 9m, `0` = unbounded), so a hung storage backend produces a
retryable error instead of permanently holding a `PartSemaphore` slot.

## Why

On 2026-08-04 all 8 part slots wedged on hung storage calls. Every
upload in the fleet stalled for ~40 minutes — no error, no log, no
metric, no self-recovery. Only `rollout restart` cleared it.

Garage was healthy the whole time (29.7 GB free, serving other
clients), so "is the backend up?" would have cleared the gateway
falsely. What was wedged was its pooled connection.

## Also in this image

- WARN when slot occupancy is ≥75% sustained for 30s — the leading
  indicator, previously unobservable
- ERROR naming object key + part number when the deadline fires

## Verification after merge

- deployed pod reports image tag `280c581` (not just the env — see #431)
- uploads continue draining
- no `PartTimeout` ERRORs under normal load

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Tycho gateway container image to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->