### PR TITLE
feat(tycho): combine scratch on NVMe — storage class, 32Gi, homelab-04 pin

### DIFF
--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -130,10 +130,24 @@ spec:
                   key: uri
             - name: COMBINE_S3_SECRET_NAME
               value: "tycho-combine-s3" # hand-minted from tycho-config values — see README
-            # COMBINE_SCRATCH_SIZE is optional (default 10Gi): the
-            # emptyDir size limit for the combine Job's scratch volume.
+            # COMBINE_SCRATCH_SIZE is optional (default 10Gi): the size
+            # of the combine Job's scratch volume. 32Gi covers the
+            # deepest observed session (19.5 GiB at N=631 half-res)
+            # with headroom — see loops/specs/combinescratch/SPEC.md.
             - name: COMBINE_SCRATCH_SIZE
-              value: "10Gi"
+              value: "32Gi"
+            # Scratch on the homelab-04 NVMe via a generic ephemeral
+            # volume instead of emptyDir. Unset storage class = legacy
+            # emptyDir. The node pin is load-bearing, not an
+            # optimization: local-path-config's nodePathMap lists ONLY
+            # homelab-04, and with WaitForFirstConsumer a combine Job
+            # scheduled anywhere else would sit Pending forever. Widen
+            # nodePathMap before relaxing this. Inert until the
+            # operator image carries loop/combinescratch.
+            - name: COMBINE_SCRATCH_STORAGE_CLASS
+              value: "nvme-scratch"
+            - name: COMBINE_SCRATCH_NODE_SELECTOR
+              value: "kubernetes.io/hostname=homelab-04"
             # NTFY_URL is optional: a full ntfy topic URL for
             # best-effort session-close/combine-result notifications.
             # Unset (the default — no value here) disables


### PR DESCRIPTION
COMBINE_SCRATCH_STORAGE_CLASS=nvme-scratch and
COMBINE_SCRATCH_NODE_SELECTOR=kubernetes.io/hostname=homelab-04 (names
settled with the combinescratch loop; value format matches its parser
tests). SIZE 10Gi -> 32Gi for the N=631 half-res worst case.

Safe to merge ahead of the operator image bump: the running d8ae6fa
operator reads only COMBINE_SCRATCH_SIZE (emptyDir limit); the two new
envs are inert until the loop's image lands. Concurrency cap env is
deliberately absent -- not yet named.

Pinning chosen over widening nodePathMap per Casey: 32Gi against the
836GiB NVMe leaves room even with concurrent combines once the cap
exists; widen only if combines start queueing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated scratch storage to 32 GiB using the `nvme-scratch` storage class.
  * Configured workloads to target the `homelab-04` node.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->