### PR TITLE
tycho: deploy operator+combine 8eb8bfe (raw-sub combine + NVMe scratch)

### DIFF
--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -107,7 +107,7 @@ spec:
               # feature was live everywhere except the container that
               # reads it (tycho #154). Bump this whenever combine/
               # changes, and check it moved after ArgoCD syncs.
-              value: "zot.phillips-homelab.net/tycho-combine:c8578e3"
+              value: "zot.phillips-homelab.net/tycho-combine:8eb8bfe"
             # ADR 0010 outbound delivery. Both are REQUIRED: the
             # operator fails closed at startup without them, so this
             # block must land in the same commit as the image bump.

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -14,4 +14,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "c8578e3"
+    newTag: "8eb8bfe"


### PR DESCRIPTION
Activates the config #438 already landed. Only the two image tags move.

**Both images move together on purpose.** The combine image alone would
try to stage a 631-input session into the old 10 GiB emptyDir and be
evicted mid-run; the operator image is what reads
`COMBINE_SCRATCH_STORAGE_CLASS` / `COMBINE_SCRATCH_NODE_SELECTOR` /
`COMBINE_MAX_CONCURRENT`.

## What goes live

**tycho #186 (issue #45)** — raw mono subs become combinable: superpixel
debayer, then anchored registration against the session's plate-solved
device stack (only 1 of 900 subs carries its own WCS).

Measured before-state, tonight:

| session | staged | kept |
|---|---|---|
| m-13-2026-07-18 | 631 | **3** |
| m-13-2026-07-27 | 272 | **2** |
| rho-herculis-2026-07-17 | 78 | **1** |

Every one is below `MIN_INPUTS_FOR_CLIP=8`, so outlier rejection has
never engaged on real data.

**tycho #187** — scratch moves to a `nvme-scratch` ephemeral volume,
the output grid stops upsampling to the anchor's resolution (**19.5 GiB
at N=631, was 78 GiB**), and combine Jobs are capped at 1 concurrent so
scratch can't starve the loop rig sharing that NVMe.

## Verification after merge

`COMBINE_IMAGE` has drifted before — #154 had it 70 commits stale while
the feature was live everywhere else — so:

- operator pod image tag is `8eb8bfe`
- **the next combine Job's container image**, not just the manifest
- a session combine keeps hundreds of inputs instead of 3
- the Job gets a PVC, lands on homelab-04, and is not evicted

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated the Tycho operator deployment to a newer image version.
  * Kept deployment configuration aligned across related components for more consistent operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->