### PR TITLE
tycho: raise COMBINE_MEMORY_LIMIT to 12Gi for 600+ input combines

### DIFF
--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -107,7 +107,7 @@ spec:
               # feature was live everywhere except the container that
               # reads it (tycho #154). Bump this whenever combine/
               # changes, and check it moved after ArgoCD syncs.
-              value: "zot.phillips-homelab.net/tycho-combine:c8578e3"
+              value: "zot.phillips-homelab.net/tycho-combine:8eb8bfe"
             # ADR 0010 outbound delivery. Both are REQUIRED: the
             # operator fails closed at startup without them, so this
             # block must land in the same commit as the image bump.

--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -148,6 +148,20 @@ spec:
               value: "nvme-scratch"
             - name: COMBINE_SCRATCH_NODE_SELECTOR
               value: "kubernetes.io/hostname=homelab-04"
+            # COMBINE_MEMORY_LIMIT: operator/main.go's 4Gi default is
+            # sized for ADR 0003's v0 operating point (~10 inputs) and
+            # says outright that a combine growing past it should raise
+            # this rather than rely on a bigger default. Issue #45 made
+            # sessions 600+ inputs: the first real 626-input combine
+            # (m-13-2026-07-18 r3, 2026-08-04) peaked at 4006Mi against
+            # the 4096Mi limit -- 97.8%, surviving on luck. The tiled
+            # path bounds peak RAM independently of N, but sigma-clip's
+            # per-tile float64 temporaries make the real peak several
+            # times the nominal tile budget. 12Gi is ~3x the observed
+            # peak; homelab-04 has 62Gi allocatable at 18% use, so the
+            # old ceiling was arbitrary, not a capacity constraint.
+            - name: COMBINE_MEMORY_LIMIT
+              value: "12Gi"
             # NTFY_URL is optional: a full ntfy topic URL for
             # best-effort session-close/combine-result notifications.
             # Unset (the default — no value here) disables

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -14,4 +14,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "c8578e3"
+    newTag: "8eb8bfe"


### PR DESCRIPTION
The first real post-#45 combine peaked at **4006Mi against the 4096Mi
default — 97.8%**. It survived, but on margin, and every M13 session is
now this size.

| | |
|---|---|
| session | m-13-2026-07-18 r3 |
| inputs kept | **626 of 631** (was 3 pre-#45) |
| peak RSS | 4006Mi / 4096Mi limit |
| restarts | 0 |

`operator/main.go` anticipates exactly this — the 4Gi default is sized
for ADR 0003's v0 point (~10 inputs) and says a combine growing past it
"is expected to raise `COMBINE_MEMORY_LIMIT`, not rely on a default
large enough to never OOM."

The tiled path does bound peak RAM independently of N; sigma-clip's
per-tile float64 temporaries just make the real peak several times the
nominal tile budget. 12Gi is ~3x observed peak. homelab-04 has 62Gi
allocatable at 18% use.

`COMBINE_MAX_CONCURRENT` stays at 1 on purpose — a completion time for a
626-input combine isn't known yet, and that's what should drive it.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the Tycho operator and Combine images to newer versions.
  * Increased the available Combine memory limit to 12 GiB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->