### PR TITLE
tycho: sync ImagingSession/TargetMaster/FleetMaster CRDs from the repo

### DIFF
--- a/gitops/tools/apps/tycho/operator/fleet.tycho.dev_fleetmasters.yaml
+++ b/gitops/tools/apps/tycho/operator/fleet.tycho.dev_fleetmasters.yaml
@@ -32,6 +32,9 @@ spec:
     - jsonPath: .status.masterJobRef.name
       name: Job
       type: string
+    - jsonPath: .status.attempts
+      name: Attempts
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -100,10 +103,19 @@ spec:
             description: |-
               FleetMasterStatus tracks the latest cross-source combine Job's
               progress, which sessions it covers, and which sources contributed —
-              deliberately the same shape as TargetMasterStatus (SPEC: "do NOT
-              overbuild"), plus ContributingSources for honest per-source
-              provenance.
+              deliberately the same shape as TargetMasterStatus, plus
+              ContributingSources for honest per-source provenance.
             properties:
+              attempts:
+                description: |-
+                  Attempts counts consecutive fleet-combine failures since this
+                  target's last successful fleet combine, mirroring
+                  TargetMasterStatus.Attempts: incremented on Failed, reset to 0
+                  on Done or whenever a retry is spawned for a grown combinable-
+                  session set. Bounds ensureCombine's Failed-phase retry
+                  the same way as the TargetMaster path.
+                format: int32
+                type: integer
               actualCombinedSessionIDs:
                 description: |-
                   ActualCombinedSessionIDs is the oldest-first SessionID list the
@@ -128,7 +140,7 @@ spec:
                   CombinedSessionIDs' same spawn-time session set, each paired with
                   the ImagingSessionStatus.Revision it was at when this Revision
                   was spawned to combine it. This is what ensureCombine's dedupe
-                  compares (SPEC tycho-master-staleness) -- see
+                  compares -- see
                   TargetMasterStatus.CombinedSessions's doc comment for the
                   unknown-is-stale handling of pre-existing FleetMasters.
                 items:
@@ -162,9 +174,9 @@ spec:
               contributingSources:
                 description: |-
                   ContributingSources is the spawn-time per-source breakdown of
-                  CombinedSessionIDs (SPEC: "honest provenance" -- contributing
+                  CombinedSessionIDs -- contributing
                   sources + per-source frame counts must be visible here, not
-                  collapsed into a single total), oldest-contributing-source-first
+                  collapsed into a single total -- oldest-contributing-source-first
                   by SourceID.
                 items:
                   description: |-

--- a/gitops/tools/apps/tycho/operator/fleet.tycho.dev_imagingsessions.yaml
+++ b/gitops/tools/apps/tycho/operator/fleet.tycho.dev_imagingsessions.yaml
@@ -35,6 +35,9 @@ spec:
     - jsonPath: .status.combineJobRef.name
       name: Job
       type: string
+    - jsonPath: .status.attempts
+      name: Attempts
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -93,8 +96,8 @@ spec:
                   component used in a target master's location
                   (masters/{target-slug}/, schemas/object-layout.md) and CR names.
                   Session grouping and matching itself is decided by sky position,
-                  not by this string (docs/ATTRIBUTION.md, "Target identity is
-                  matched by name, not by sky position") -- see
+                  not by this string (docs/ATTRIBUTION.md, "sky position decides
+                  grouping, names stay for humans") -- see
                   internal/targetmaster.CombinableSessions and .ResolveTargetSlug,
                   which choose Target deterministically from TargetRADeg/
                   TargetDecDeg when available, falling back to a name-derived slug
@@ -109,15 +112,15 @@ spec:
                   event's optional target_ra_deg/target_dec_deg fields
                   (schemas/tycho.session.closed.schema.json) at session-close
                   time -- the operator has no S3 access to read manifest.json
-                  directly (SPEC guardrail), so the closing event is the only
+                  directly, so the closing event is the only
                   route a position can reach it by. Both are nil together for a
                   session whose close event didn't carry one: a quiescence-timeout
                   close never reads a manifest at all, and an older or malformed
                   manifest may lack a usable target block.
                   internal/targetmaster falls back to Target-slug matching for
                   such a session rather than dropping it from its target's
-                  grouping (docs/ATTRIBUTION.md's "fall back to name grouping"
-                  guardrail).
+                  grouping -- a session must never vanish from grouping for lack of
+                  coordinates (docs/ATTRIBUTION.md).
                 type: number
               targetRADeg:
                 description: |-
@@ -128,15 +131,15 @@ spec:
                   event's optional target_ra_deg/target_dec_deg fields
                   (schemas/tycho.session.closed.schema.json) at session-close
                   time -- the operator has no S3 access to read manifest.json
-                  directly (SPEC guardrail), so the closing event is the only
+                  directly, so the closing event is the only
                   route a position can reach it by. Both are nil together for a
                   session whose close event didn't carry one: a quiescence-timeout
                   close never reads a manifest at all, and an older or malformed
                   manifest may lack a usable target block.
                   internal/targetmaster falls back to Target-slug matching for
                   such a session rather than dropping it from its target's
-                  grouping (docs/ATTRIBUTION.md's "fall back to name grouping"
-                  guardrail).
+                  grouping -- a session must never vanish from grouping for lack of
+                  coordinates (docs/ATTRIBUTION.md).
                 type: number
             required:
             - objectPrefix
@@ -148,6 +151,24 @@ spec:
               ImagingSessionStatus tracks close detection and the resulting
               combine Job.
             properties:
+              attempts:
+                description: |-
+                  Attempts counts consecutive combine failures since this
+                  session's last successful combine (or since it was first
+                  created, if it has never succeeded): incremented each time a
+                  combine Job for this session reaches Failed, reset to 0 on
+                  Done. ensureCombineJob refuses to retry a Failed session once
+                  Attempts reaches the bounded retry limit (operator/internal/
+                  sessionclose.maxCombineAttempts) -- see Phase=Failed with
+                  Attempts at that limit as the observable "permanently failed,
+                  needs a human" terminal state: not that the combine failed,
+                  but that nothing said so and nothing tried again. A retry
+                  triggered by the session growing (more subs than the failed
+                  revision covered) resets Attempts back to 0 first, since new
+                  data deserves its own fresh retry budget rather than inheriting
+                  an unrelated prior failure streak.
+                format: int32
+                type: integer
               closeReason:
                 description: |-
                   CloseReason records how the session's close was detected, once
@@ -194,6 +215,19 @@ spec:
                   spawned to combine. Compared against a later close event's
                   sub_count to detect the session growing past what the latest
                   revision covered.
+                format: int32
+                type: integer
+              jobStartedPublishedRevision:
+                description: |-
+                  JobStartedPublishedRevision is the last Revision whose
+                  tycho.job.stack.started event was actually published
+                  successfully. Separate from Revision/CombineJobRef (set as soon
+                  as the Job is created, regardless of publish outcome) so a
+                  redelivered close signal for a Job that already exists
+                  (created=false in ensureCombineJob) can still tell whether the
+                  started event for the current revision made it out, and retry
+                  the publish alone if it didn't (issue #127: `created=false` must
+                  not mean "never publish").
                 format: int32
                 type: integer
               phase:

--- a/gitops/tools/apps/tycho/operator/fleet.tycho.dev_targetmasters.yaml
+++ b/gitops/tools/apps/tycho/operator/fleet.tycho.dev_targetmasters.yaml
@@ -38,6 +38,9 @@ spec:
     - jsonPath: .status.masterJobRef.name
       name: Job
       type: string
+    - jsonPath: .status.attempts
+      name: Attempts
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -96,12 +99,26 @@ spec:
             description: |-
               TargetMasterStatus tracks the latest master combine Job's progress
               and which sessions it covers. Deliberately as small as
-              ImagingSessionStatus's combine-tracking subset (SPEC tycho16: "do
-              NOT overbuild") — no per-sub or per-night detail beyond the
+              ImagingSessionStatus's combine-tracking subset — no per-sub or per-night detail beyond the
               contributing session id list, since that's all ensureMasterCombine
               needs to detect growth and all a consumer needs to answer "how many
               nights deep."
             properties:
+              attempts:
+                description: |-
+                  Attempts counts consecutive master-combine failures since this
+                  target's last successful master combine: incremented each time
+                  the master Job reaches Failed, reset to 0 on Done or whenever a
+                  retry is spawned for a grown combinable-session set (new data
+                  gets its own budget rather than inheriting an unrelated prior
+                  failure streak). MasterCombineReconciler's periodic
+                  re-evaluation refuses to retry a Failed
+                  TargetMaster once Attempts reaches
+                  internal/controller.maxCombineRetryAttempts -- Phase=Failed with
+                  Attempts at that limit is the observable "permanently failed"
+                  terminal state, mirroring ImagingSessionStatus.Attempts.
+                format: int32
+                type: integer
               actualCombinedSessionIDs:
                 description: |-
                   ActualCombinedSessionIDs is the oldest-first SessionID list the
@@ -111,7 +128,7 @@ spec:
                   ground-truth channel, since it has no S3 access). This is what the
                   ntfy "N nights deep" wording and the tycho.job.master.succeeded
                   event's nights/session_ids report -- CombinedSessionIDs must not
-                  be used for those (SPEC review H3, #57). Falls back to
+                  be used for those. Falls back to
                   CombinedSessionIDs (spawn-time intent) when an older combine image
                   predating the completion report, or a GC'd Pod, leaves no report
                   to read -- best-effort, not a hard requirement, so a missing
@@ -127,8 +144,8 @@ spec:
                   to detect growth (a new night became combinable) versus a true
                   duplicate trigger (no growth -- dedupe, no new revision) --
                   spawn-time intent, not a claim about what actually landed in
-                  master.fit. See ActualCombinedSessionIDs for that (SPEC review H3,
-                  #57): a session reaching Done is no guarantee its result is
+                  master.fit. See ActualCombinedSessionIDs for that: a session
+                  reaching Done is no guarantee its result is
                   RGB-combinable (combine_controller.markDone sets Done from k8s Job
                   success alone, the operator has no S3 access to check frame kind),
                   so the master Job can silently drop one of these sessions.
@@ -139,8 +156,7 @@ spec:
                 description: |-
                   CombinedSessions is CombinedSessionIDs' same spawn-time session
                   set, each paired with the ImagingSessionStatus.Revision it was at
-                  when this Revision was spawned to combine it (SPEC
-                  tycho-master-staleness). This, not CombinedSessionIDs, is what
+                  when this Revision was spawned to combine it. This, not CombinedSessionIDs, is what
                   ensureCombine's dedupe compares: an unchanged id set does not
                   mean unchanged inputs, since a session's result is rewritten in
                   place at a stable key every time that session itself recombines.


### PR DESCRIPTION
The gitops CRD copies drifted behind `loop-bot/tycho`'s
`deploy/operator/`. `status.attempts` is defined in the operator's Go
types **and** present in the repo's CRDs — but missing from the copies
actually applied to the cluster.

Kubernetes prunes unknown fields silently, so **every write to
`status.attempts` was discarded**.

## What that broke

The combine retry budget, completely. `Attempts++` executes, the field
is stripped, the next read returns 0, and
`Attempts >= maxCombineAttempts` is never true.

`pi-herculis-2026-07-17` reached **revision 11** on a session provably
uncombinable since July — 3 Job pods per revision, forever. It only
stopped because it was manually parked. `TargetMaster` and
`FleetMaster` share the counter and the same defect.

`status.jobStartedPublishedRevision` was pruned identically — the
source of the recurring `unknown field` lines in the operator log.

## Verification

| CRD | live `status.attempts` | repo CRD |
|---|---|---|
| imagingsessions | MISSING | present |
| targetmasters | MISSING | present |
| fleetmasters | MISSING | present |

## After merge

- `attempts` persists; failing sessions go terminal at 5 instead of looping
- the three manually-parked sessions can be reset to their honest
  `Failed` state
- `unknown field` log noise stops

A drift guard so this cannot silently recur is being specced separately —
these files are hand-maintained in controller-gen's shape because the
build environment has no network to run controller-gen
(`deploy/operator/README.md:494`).

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **Attempts** status column for FleetMaster, ImagingSession, and TargetMaster resources.
  * Exposed retry-attempt counts in resource status for tracking consecutive combine failures and resets.
  * Added ImagingSession status tracking for job-started event publication by revision.

* **Documentation**
  * Clarified session deduplication, provenance, retry behavior, and target grouping.
  * Documented coordinate-based grouping with target-slug fallback when coordinates are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->