### PR TITLE
tycho: deploy gateway d587aca (source object listing for fetch ledger)

### DIFF
--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-gateway
-    newTag: "280c581"
+    newTag: "d587aca"


### PR DESCRIPTION
Bumps the gateway image `280c581` → `d587aca`.

Ships tycho #189's gateway half: **`GET /v1/sources/{sourceID}/objects`**,
reporting every sub already accepted for a source.

## Why

The client keeps no durable record of which files it has handled —
shipped files are deleted from the buffer and their records pruned at
state compaction. So on restart it cannot tell "never fetched" from
"fetched, uploaded, cleaned up" and **re-downloads the scope's entire
album (~29 GB)**. Measured 2026-08-04: 5 of 6 sampled re-fetched frames
were byte-identical to what the catalog already held.

The new endpoint lets a client with no ledger seed from what the
catalog actually holds, so the fix itself doesn't cost one final full
re-download on upgrade.

## Scope

Additive route only, guarded like the neighbouring source routes. No
existing behaviour changes. Safe to deploy ahead of the client — an
unused endpoint until a v0.9.3 client calls it.

The client half (`v0.9.3`) is a hand-installed binary, not part of this
deploy.

https://claude.ai/code/session_01TgzNdjFSoSG48v2PdjuZQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Tycho Gateway deployment to use a newer container image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->