### PR TITLE
tycho: deploy b06bf2f (unsalvageable + parallel passes)

### DIFF
--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -107,7 +107,7 @@ spec:
               # feature was live everywhere except the container that
               # reads it (tycho #154). Bump this whenever combine/
               # changes, and check it moved after ArgoCD syncs.
-              value: "zot.phillips-homelab.net/tycho-combine:4c971e8"
+              value: "zot.phillips-homelab.net/tycho-combine:b06bf2f"
             # ADR 0010 outbound delivery. Both are REQUIRED: the
             # operator fails closed at startup without them, so this
             # block must land in the same commit as the image bump.

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -14,4 +14,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "4c971e8"
+    newTag: "b06bf2f"


### PR DESCRIPTION
Both images pushed to zot at `b06bf2f`:

- **tycho #191 (unsalvageable):** deterministic 'no combinable inputs' refusals now land a terminal `Unsalvageable` phase via the pod termination-message verdict; the attempts-reset leak is fixed; TargetMaster/FleetMaster combine around dead sessions. After sync, the two hand-parked sessions (`nu-coronae-borealis-2026-07-27`, `pi-herculis-2026-07-17`) can be unparked per PR #191's instructions.
- **tycho #193 (parallelpasses):** all four compute passes now worker-pooled off `COMBINE_CPU_LIMIT` (was reprojection-only) — this is the big wall-clock win for the M13 re-runs' successors.

No config changes; the throughput knobs are already live from #444.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Tycho operator deployment to use the latest container image version.
  * Aligned the configured combine image with the updated operator release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->