### PR TITLE
tycho: delivery rollout — deliver image, B2 creds, fleet-sync site UI

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:0c7bbc5
+          image: zot.phillips-homelab.net/tychofleet:2816c0a
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -51,6 +51,22 @@ spec:
               value: devs@lighttheham.com
             - name: SMTP_FROM
               value: admin@tychofleet.com
+            # Per-fleet backup/sync admin UI (tychofleet #65). The
+            # in-cluster k8s client reads the SA token Kubernetes
+            # projects into the pod; TYCHO_NAMESPACE is where the
+            # DeliveryTarget/Secret pairs land. Managed-storage mode's
+            # non-secret half lives here; the key pair arrives via
+            # tychofleet-config (ESO), reading the SAME tycho-item
+            # fields as the operator's tycho-delivery-b2 Secret so the
+            # two sides can never drift.
+            - name: TYCHO_NAMESPACE
+              value: "tycho"
+            - name: MANAGED_STORAGE_ENDPOINT
+              value: "https://s3.us-east-005.backblazeb2.com"
+            - name: MANAGED_STORAGE_REGION
+              value: "us-east-005"
+            - name: MANAGED_STORAGE_BUCKET
+              value: "tf-fleet-bak-01"
             - name: GARAGE_ENDPOINT
               value: "http://garage.garage.svc.cluster.local:3900"
             - name: GARAGE_BUCKET

--- a/gitops/apps/tychofleet/external-secret.yaml
+++ b/gitops/apps/tychofleet/external-secret.yaml
@@ -73,3 +73,15 @@ spec:
     remoteRef:
       key: tychofleet
       property: GARAGE_SECRET_ACCESS_KEY
+  # "TychoFleet Managed Storage" (per-fleet sync, tychofleet #65):
+  # deliberately read from the `tycho` item's B2 delivery fields — the
+  # same properties the operator-side tycho-delivery-b2 ExternalSecret
+  # reads (SITE_API_TOKEN no-drift pattern).
+  - secretKey: MANAGED_STORAGE_ACCESS_KEY_ID
+    remoteRef:
+      key: tycho
+      property: b2_delivery_key_id
+  - secretKey: MANAGED_STORAGE_SECRET_ACCESS_KEY
+    remoteRef:
+      key: tycho
+      property: b2_delivery_application_key

--- a/gitops/tools/apps/tycho/externalsecret-delivery.yaml
+++ b/gitops/tools/apps/tycho/externalsecret-delivery.yaml
@@ -1,0 +1,37 @@
+# Destination credentials for outbound delivery (ADR 0010, tycho #195):
+# the B2 application key for bucket tf-fleet-bak-01, scoped to that
+# bucket at creation. One Secret shared by every DeliveryTarget that
+# points at this bucket (Conner's cross-check feed today; the
+# fleetsync targets the tychofleet site mints use their own
+# fleetsync-* Secrets instead — see the site's Role below).
+# Key names are the deliver Job's env contract: plain AWS_* pairs
+# (deploy/operator/README.md "env var contract").
+# Separate ExternalSecret rather than more tycho-config keys because
+# DeliveryTarget.credentialRef names a whole Secret — the per-target
+# Secret shape is the CRD's contract, not a style choice.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: tycho-delivery-b2
+  namespace: tycho
+  annotations:
+    # Client-side apply: SSA conflicts with ESO's field manager on spec.data
+    # and can wedge the sync (see stock-bot ExternalSecrets).
+    argocd.argoproj.io/sync-options: ServerSideApply=false
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: staging
+  target:
+    name: tycho-delivery-b2
+    creationPolicy: Owner
+  data:
+  - secretKey: AWS_ACCESS_KEY_ID
+    remoteRef:
+      key: tycho
+      property: b2_delivery_key_id
+  - secretKey: AWS_SECRET_ACCESS_KEY
+    remoteRef:
+      key: tycho
+      property: b2_delivery_application_key

--- a/gitops/tools/apps/tycho/kustomization.yaml
+++ b/gitops/tools/apps/tycho/kustomization.yaml
@@ -8,6 +8,7 @@ kind: Kustomization
 namespace: tycho
 resources:
 - externalsecret.yaml
+- externalsecret-delivery.yaml
 - operator
 - gateway
 - scorer

--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -112,13 +112,13 @@ spec:
             # operator fails closed at startup without them, so this
             # block must land in the same commit as the image bump.
             #
-            # DELIVERY_JOB_IMAGE is a placeholder -- no delivery Job
-            # image is built yet. Nothing pulls it: DeliveryTargets
-            # default disabled and none exist, so no Delivery is ever
-            # admitted. It exists so the gap is a visible startup
-            # requirement rather than a silent ImagePullBackOff later.
+            # DELIVERY_JOB_IMAGE: the real delivery Job image as of
+            # tycho #195 (ADR 0010's first adapter, kind: s3). Bump
+            # alongside the operator tag whenever operator/cmd/deliverjob
+            # or the adapter changes — same drift hazard as
+            # COMBINE_IMAGE above.
             - name: DELIVERY_JOB_IMAGE
-              value: "zot.phillips-homelab.net/tycho-deliver:none-yet"
+              value: "zot.phillips-homelab.net/tycho-deliver:b1f1a18"
             # Read-only in intent: DeliveryReconciler's admission needs
             # a session's frame count and accepted-byte total before
             # any Job exists. Uses the same Secret the gateway writes

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -14,4 +14,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "b06bf2f"
+    newTag: "b1f1a18"


### PR DESCRIPTION
The full ADR 0010 rollout in one PR. All three images pushed to zot with verified digests.

**Included:**
- operator → `b1f1a18` (tycho #195: `tycho-deliver` Job image + `kind: s3` adapter; #194 masterdebounce rides along) and `DELIVERY_JOB_IMAGE` off the `none-yet` placeholder
- `tycho-delivery-b2` ExternalSecret: the B2 key for `tf-fleet-bak-01` (us-east-005), read from the `tycho` 1P item's `b2_delivery_key_id`/`b2_delivery_application_key`
- tychofleet → `2816c0a` (site #65: per-fleet backup/sync admin UI, site-admin only) with managed-storage env; its ESO keys read the **same** tycho-item B2 fields (SITE_API_TOKEN no-drift pattern)

**Deliberately NOT included — needs your own reviewed commit (permissions grant):** the site's fleetsync ServiceAccount + Role/RoleBinding. Until it lands, the storage UI saves settings and shows "not materialized," which is its designed degrade state. Add this as a follow-up commit (note: the RUNBOOK brief asked for resourceNames *prefix* scoping, which k8s RBAC can't express — this pins mutating verbs to exact names instead, extend the list per fleet):

```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: tychofleet-fleetsync
  namespace: tychofleet
---
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: tychofleet-fleetsync
  namespace: tycho
rules:
- apiGroups: ["fleet.tycho.dev"]
  resources: ["deliverytargets"]
  verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
- apiGroups: ["fleet.tycho.dev"]
  resources: ["deliveries"]
  verbs: ["get", "list", "watch"]
- apiGroups: [""]
  resources: ["secrets"]
  verbs: ["create"]
- apiGroups: [""]
  resources: ["secrets"]
  resourceNames: ["fleetsync-fleet-zero"]
  verbs: ["get", "update", "patch", "delete"]
---
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: tychofleet-fleetsync
  namespace: tycho
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: tychofleet-fleetsync
subjects:
- kind: ServiceAccount
  name: tychofleet-fleetsync
  namespace: tychofleet
```

…plus `serviceAccountName: tychofleet-fleetsync` in the site deployment's pod spec (left out here so the pod doesn't reference a nonexistent SA).

**After merge+sync, next steps (Claude handles):** apply Conner's `DeliveryTarget` (raws+stacks+masters, backfill ~35 GB) referencing `tycho-delivery-b2`, verify the backfill flows, then set up fleet-zero sync through the site UI once the SA lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added managed-storage configuration and credential synchronization for Tycho’s fleet backup and sync experience.
  * Added support for delivering data through the S3-compatible storage adapter.
* **Bug Fixes**
  * Updated Tycho services to use published images, replacing an unbuilt delivery image.
* **Chores**
  * Updated deployed application image versions and enabled automatic delivery credential management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->