### PR TITLE
tycho: sync all six CRDs + required DELIVERY_JOB_S3_SECRET_NAME

### DIFF
--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -119,6 +119,14 @@ spec:
             # COMBINE_IMAGE above.
             - name: DELIVERY_JOB_IMAGE
               value: "zot.phillips-homelab.net/tycho-deliver:b1f1a18"
+            # Source-side S3 creds for delivery Jobs (reading the
+            # Garage archive) — the same Secret combine Jobs use.
+            # REQUIRED: the operator fails closed at startup without
+            # it (tycho #195's LoadConfig), which is exactly how its
+            # absence was discovered — a CrashLoopBackOff, not a
+            # silent delivery no-op.
+            - name: DELIVERY_JOB_S3_SECRET_NAME
+              value: "tycho-combine-s3"
             # Read-only in intent: DeliveryReconciler's admission needs
             # a session's frame count and accepted-byte total before
             # any Job exists. Uses the same Secret the gateway writes

--- a/gitops/tools/apps/tycho/operator/fleet.tycho.dev_deliveries.yaml
+++ b/gitops/tools/apps/tycho/operator/fleet.tycho.dev_deliveries.yaml
@@ -1,4 +1,11 @@
 ---
+# NOT applied directly. This file is a hand-maintained mirror of the
+# Go API types (see deploy/operator/README.md) -- the cluster reads a
+# hand-copied version of it at gitops/tools/apps/tycho/operator/ in the
+# phillips-homelab repo, not this one. A field added here is not
+# deployed until that copy is made by hand: Kubernetes silently prunes
+# any field a CRD's schema does not declare, with no error or warning
+# to the writer.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -204,6 +211,51 @@ spec:
                   CompletedAt is when this Delivery reached a terminal phase
                   (Done, Failed, Refused, or Unknown).
                 format: date-time
+                type: string
+              deliveredMasterRevision:
+                description: |-
+                  DeliveredMasterRevision is TargetMasterStatus.Revision as of this
+                  Delivery's most recent admission, meaningful only when the
+                  target selects the masters class -- the same growth-detection
+                  role DeliveredSessionRevision plays for raw_subs/stacks, but
+                  keyed on a master rebuild (internal/controller's
+                  MasterCombineReconciler.markDone hook) rather than the session's
+                  own Revision, since a master can gain a new revision long after
+                  the sessions that fed it last closed.
+                format: int32
+                type: integer
+              deliveredSessionRevision:
+                description: |-
+                  DeliveredSessionRevision is ImagingSessionStatus.Revision as of
+                  this Delivery's most recent admission -- stamped by
+                  DeliveryReconciler.admit alongside Phase=Sending. The continuous-
+                  semantics trigger (internal/controller's session-close/master-
+                  rebuild hooks, ADR 0010 "session grows and recombines -> deliver
+                  only the new/changed objects") compares a Done Delivery's own
+                  value here against the session's CURRENT Revision to decide
+                  whether growth happened since the last successful send; if so it
+                  re-arms this same object (Phase reset to "") rather than creating
+                  a second Delivery for the same (session, target) pair (ADR 0010
+                  §1: one per pair for its whole life). Idempotency (the s3
+                  adapter's HeadObject skip) is what makes a re-armed run cheap --
+                  only the delta actually transfers.
+                format: int32
+                type: integer
+              failedArtifact:
+                description: |-
+                  FailedArtifact names the ChunkKey of the artifact whose SendFile
+                  call most recently failed -- so `kubectl get delivery -o yaml`
+                  answers "what stopped this" without reading Pod logs (ADR 0010
+                  §1). Set alongside FailureReason, in the same Status().Update,
+                  immediately before deliveryjob.Run returns the error -- a
+                  partial failure is always named, never silent. Not cleared on a
+                  later successful attempt; Phase moving to Committing or Done is
+                  the stronger signal that superseded it.
+                type: string
+              failureReason:
+                description: |-
+                  FailureReason is the error message from that same failed
+                  SendFile attempt.
                 type: string
               files:
                 description: |-

--- a/gitops/tools/apps/tycho/operator/fleet.tycho.dev_deliverytargets.yaml
+++ b/gitops/tools/apps/tycho/operator/fleet.tycho.dev_deliverytargets.yaml
@@ -1,4 +1,11 @@
 ---
+# NOT applied directly. This file is a hand-maintained mirror of the
+# Go API types (see deploy/operator/README.md) -- the cluster reads a
+# hand-copied version of it at gitops/tools/apps/tycho/operator/ in the
+# phillips-homelab repo, not this one. A field added here is not
+# deployed until that copy is made by hand: Kubernetes silently prunes
+# any field a CRD's schema does not declare, with no error or warning
+# to the writer.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -23,7 +30,7 @@ spec:
     - jsonPath: .spec.adapterKind
       name: Adapter
       type: string
-    - jsonPath: .spec.artifactClass
+    - jsonPath: .spec.artifactClasses
       name: Artifact
       type: string
     - jsonPath: .spec.enabled
@@ -87,13 +94,48 @@ spec:
                   target speaks through.
                 enum:
                 - fake
+                - s3
                 type: string
-              artifactClass:
-                description: ArtifactClass selects which artifact this target receives.
-                enum:
-                - raw_subs
-                - stacks
-                type: string
+              artifactClasses:
+                description: |-
+                  ArtifactClasses selects which artifact(s) this target receives --
+                  plural because SPEC's member-selective shape needs raws delivered
+                  standing, plus optional stacks and masters, ALL on the same
+                  target. Convention, not an enforced invariant: "everything" is
+                  intended as a target's only class rather than combined with the
+                  session-scoped classes.
+                items:
+                  description: DeliveryArtifactClass selects which of a session's
+                    (or, for "everything", the whole archive's) artifacts a target
+                    receives.
+                  enum:
+                  - raw_subs
+                  - stacks
+                  - masters
+                  - everything
+                  type: string
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: set
+              backfill:
+                default: false
+                description: |-
+                  Backfill delivers every existing session this target already
+                  matches (any session already in a terminal combined state --
+                  Done or Unsalvageable, tycho#191) rather than only sessions that
+                  close from now on. The member-selective shape's real first user
+                  (a member cross-checking their own Siril pipeline against ours)
+                  wants their existing ~80 GB backfilled, not just tonight's
+                  session onward. Evaluated by DeliveryTargetReconciler whenever
+                  this target is Active: every existing matching session gets its
+                  Delivery ensured (create-if-missing, same dedupe-by-name the
+                  session-close trigger uses), so a session that closes AFTER this
+                  flag was already true is not double-delivered, and a target
+                  created with Backfill=false that flips it on later still picks
+                  up the backlog on its next reconcile. Metered like any other
+                  delivery -- a large backfill is not special-cased, only bounded
+                  by the member's own byte allowance (DeliveryQuota).
+                type: boolean
               consentRecord:
                 description: |-
                   ConsentRecord captures what the member was shown before
@@ -203,7 +245,7 @@ spec:
                 type: object
             required:
             - adapterKind
-            - artifactClass
+            - artifactClasses
             - credentialRef
             - credentialScheme
             - memberID

--- a/gitops/tools/apps/tycho/operator/fleet.tycho.dev_fleetmasters.yaml
+++ b/gitops/tools/apps/tycho/operator/fleet.tycho.dev_fleetmasters.yaml
@@ -1,4 +1,11 @@
 ---
+# NOT applied directly. This file is a hand-maintained mirror of the
+# Go API types (see deploy/operator/README.md) -- the cluster reads a
+# hand-copied version of it at gitops/tools/apps/tycho/operator/ in the
+# phillips-homelab repo, not this one. A field added here is not
+# deployed until that copy is made by hand: Kubernetes silently prunes
+# any field a CRD's schema does not declare, with no error or warning
+# to the writer.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/gitops/tools/apps/tycho/operator/fleet.tycho.dev_imagingsessions.yaml
+++ b/gitops/tools/apps/tycho/operator/fleet.tycho.dev_imagingsessions.yaml
@@ -1,4 +1,11 @@
 ---
+# NOT applied directly. This file is a hand-maintained mirror of the
+# Go API types (see deploy/operator/README.md) -- the cluster reads a
+# hand-copied version of it at gitops/tools/apps/tycho/operator/ in the
+# phillips-homelab repo, not this one. A field added here is not
+# deployed until that copy is made by hand: Kubernetes silently prunes
+# any field a CRD's schema does not declare, with no error or warning
+# to the writer.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -238,6 +245,7 @@ spec:
                 - Combining
                 - Done
                 - Failed
+                - Unsalvageable
                 type: string
               resultKeys:
                 description: |-

--- a/gitops/tools/apps/tycho/operator/fleet.tycho.dev_seestars.yaml
+++ b/gitops/tools/apps/tycho/operator/fleet.tycho.dev_seestars.yaml
@@ -1,4 +1,11 @@
 ---
+# NOT applied directly. This file is a hand-maintained mirror of the
+# Go API types (see deploy/operator/README.md) -- the cluster reads a
+# hand-copied version of it at gitops/tools/apps/tycho/operator/ in the
+# phillips-homelab repo, not this one. A field added here is not
+# deployed until that copy is made by hand: Kubernetes silently prunes
+# any field a CRD's schema does not declare, with no error or warning
+# to the writer.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/gitops/tools/apps/tycho/operator/fleet.tycho.dev_targetmasters.yaml
+++ b/gitops/tools/apps/tycho/operator/fleet.tycho.dev_targetmasters.yaml
@@ -1,4 +1,11 @@
 ---
+# NOT applied directly. This file is a hand-maintained mirror of the
+# Go API types (see deploy/operator/README.md) -- the cluster reads a
+# hand-copied version of it at gitops/tools/apps/tycho/operator/ in the
+# phillips-homelab repo, not this one. A field added here is not
+# deployed until that copy is made by hand: Kubernetes silently prunes
+# any field a CRD's schema does not declare, with no error or warning
+# to the writer.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
Fixes the two live rollout blockers from #446:

1. **Operator CrashLoopBackOff**: `DELIVERY_JOB_S3_SECRET_NAME` is a required fail-closed env as of tycho #195 — set to `tycho-combine-s3` (delivery Jobs read the archive with the same Garage key combine uses).
2. **All six `fleet.tycho.dev` CRDs drifted** from `deploy/operator/`: the live ImagingSession CRD rejects `phase: Unsalvageable`, erroring every reconcile of the two unparked dead sessions since 01:11Z, and #195's new DeliveryTarget fields would be silently dropped on apply. Copied verbatim from tycho @ `b1f1a18`.

Systemic note: CRD sync isn't part of the image-bump habit — every operator bump that touches api/v1alpha1 has this trap. Worth a CI check or make target that diffs `deploy/operator/fleet.tycho.dev_*.yaml` against gitops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Delivery targets now support S3 adapters, multiple artifact classes, and optional backfill processing.
  - Delivery status now reports delivered revisions and details about failed artifacts.
  - Imaging sessions can now be marked as unsalvageable.
  - Delivery jobs can access configured source-side S3 credentials.

- **Documentation**
  - Added guidance clarifying that deployment schema definitions require manual synchronization before changes take effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->