### PR TITLE
tycho: operator+deliver 3b46e98 — Job-side catalog DSN (tycho #196)

### DIFF
--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -118,7 +118,13 @@ spec:
             # or the adapter changes — same drift hazard as
             # COMBINE_IMAGE above.
             - name: DELIVERY_JOB_IMAGE
-              value: "zot.phillips-homelab.net/tycho-deliver:b1f1a18"
+              value: "zot.phillips-homelab.net/tycho-deliver:3b46e98"
+            # Names the Secret whose `uri` key is the catalog DSN the
+            # delivery Job injects as DELIVERY_CATALOG_DSN (SecretKeyRef,
+            # tycho #196) — the CNPG <cluster>-app Secret, same one the
+            # gateway reads. REQUIRED, fail-closed at operator startup.
+            - name: DELIVERY_JOB_CATALOG_DSN_SECRET_NAME
+              value: "tycho-pg-app"
             # Source-side S3 creds for delivery Jobs (reading the
             # Garage archive) — the same Secret combine Jobs use.
             # REQUIRED: the operator fails closed at startup without

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -14,4 +14,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "b1f1a18"
+    newTag: "3b46e98"


### PR DESCRIPTION
Images pushed at `3b46e98`. One new required env: `DELIVERY_JOB_CATALOG_DSN_SECRET_NAME=tycho-pg-app` — the delivery Job now gets `DELIVERY_CATALOG_DSN` via SecretKeyRef instead of not at all. After sync, the 9 Failed backfill Deliveries get cleared and respawn clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the Tycho operator and delivery processing components to a newer version.
  * Added required catalog database configuration to support reliable delivery operations.
  * Improved deployment configuration by documenting the expected catalog credentials contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->