### PR TITLE
tycho: operator+deliver c7202c6 — delivery Job SA (tycho #197)

### DIFF
--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -118,7 +118,12 @@ spec:
             # or the adapter changes — same drift hazard as
             # COMBINE_IMAGE above.
             - name: DELIVERY_JOB_IMAGE
-              value: "zot.phillips-homelab.net/tycho-deliver:3b46e98"
+              value: "zot.phillips-homelab.net/tycho-deliver:c7202c6"
+            # SA delivery Job pods run as (rbac.yaml's tycho-deliver:
+            # get deliveries/deliverytargets, update deliveries/status,
+            # nothing else). REQUIRED, fail-closed (tycho #197).
+            - name: DELIVERY_JOB_SERVICE_ACCOUNT_NAME
+              value: "tycho-deliver"
             # Names the Secret whose `uri` key is the catalog DSN the
             # delivery Job injects as DELIVERY_CATALOG_DSN (SecretKeyRef,
             # tycho #196) — the CNPG <cluster>-app Secret, same one the

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -14,4 +14,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "3b46e98"
+    newTag: "c7202c6"

--- a/gitops/tools/apps/tycho/operator/rbac.yaml
+++ b/gitops/tools/apps/tycho/operator/rbac.yaml
@@ -56,3 +56,42 @@ subjects:
   - kind: ServiceAccount
     name: tycho-operator
     namespace: tycho
+---
+# ServiceAccount + minimal Role for delivery Jobs (tycho #195/#197):
+# cmd/deliverjob reads its own Delivery and its DeliveryTarget, and
+# writes per-artifact progress via Status().Update. Nothing else — a
+# delivery Job can never touch sessions, masters, or other CRDs.
+# The operator's Job template sets this SA by name
+# (DELIVERY_JOB_SERVICE_ACCOUNT_NAME, fail-closed).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tycho-deliver
+  namespace: tycho
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tycho-deliver
+  namespace: tycho
+rules:
+  - apiGroups: ["fleet.tycho.dev"]
+    resources: ["deliveries", "deliverytargets"]
+    verbs: ["get"]
+  - apiGroups: ["fleet.tycho.dev"]
+    resources: ["deliveries/status"]
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tycho-deliver
+  namespace: tycho
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tycho-deliver
+subjects:
+  - kind: ServiceAccount
+    name: tycho-deliver
+    namespace: tycho


### PR DESCRIPTION
Final piece of the delivery rollout: Jobs ran as `tycho/default` (no RBAC) and died Forbidden reading their own Delivery. Now they run as `tycho-deliver` — SA/Role/RoleBinding synced into rbac.yaml, scoped to exactly the binary's API surface. Images pushed at `c7202c6`. After sync: clear the Failed Deliveries, re-nudge the backfill, watch bytes flow to B2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated the Tycho operator and delivery job components to the latest release.
  * Added dedicated permissions for delivery jobs, allowing them to read delivery resources and update delivery status.
  * Improved delivery job configuration with the required service account assignment for more reliable execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->