### PR TITLE
tycho: sync rbac.yaml — delivery Role reads sessions + targetmasters (tycho #198)

### DIFF
--- a/gitops/tools/apps/tycho/operator/rbac.yaml
+++ b/gitops/tools/apps/tycho/operator/rbac.yaml
@@ -75,8 +75,12 @@ metadata:
   name: tycho-deliver
   namespace: tycho
 rules:
+  # The full read surface, grepped from every c.Get in
+  # internal/deliveryjob + cmd/deliverjob: the Delivery itself, its
+  # DeliveryTarget, the session (driver.go — stacks class reads
+  # ResultKeys off the CR), and the TargetMaster (masterfilesource).
   - apiGroups: ["fleet.tycho.dev"]
-    resources: ["deliveries", "deliverytargets"]
+    resources: ["deliveries", "deliverytargets", "imagingsessions", "targetmasters"]
     verbs: ["get"]
   - apiGroups: ["fleet.tycho.dev"]
     resources: ["deliveries/status"]


### PR DESCRIPTION
YAML-only: the tycho-deliver Role gains get on imagingsessions + targetmasters (stacks/masters artifact classes read those CRs). No image change. Last piece before the backfill runs clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated delivery operations to read imaging session and target master information, improving compatibility with related workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->