### PR TITLE
tycho: operator+deliver 20807b5 (tycho #199)

### DIFF
--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -118,7 +118,7 @@ spec:
             # or the adapter changes — same drift hazard as
             # COMBINE_IMAGE above.
             - name: DELIVERY_JOB_IMAGE
-              value: "zot.phillips-homelab.net/tycho-deliver:c7202c6"
+              value: "zot.phillips-homelab.net/tycho-deliver:20807b5"
             # SA delivery Job pods run as (rbac.yaml's tycho-deliver:
             # get deliveries/deliverytargets, update deliveries/status,
             # nothing else). REQUIRED, fail-closed (tycho #197).

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -14,4 +14,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "c7202c6"
+    newTag: "20807b5"


### PR DESCRIPTION
Both images at `20807b5`, digests verified. Reader checksum validation WhenRequired (the master.fit fix) + the env-contract completion (Job DSN var renamed inside the image pair; no gitops env change). After sync: re-add `masters` to Conner's target and the final artifact delivers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Tycho operator and delivery job images to a newer version for improved deployment consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->