### PR TITLE
tycho: operator+deliver 8aed7ac — delivery hardening (tycho #200)

### DIFF
--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -118,12 +118,19 @@ spec:
             # or the adapter changes — same drift hazard as
             # COMBINE_IMAGE above.
             - name: DELIVERY_JOB_IMAGE
-              value: "zot.phillips-homelab.net/tycho-deliver:20807b5"
+              value: "zot.phillips-homelab.net/tycho-deliver:8aed7ac"
             # SA delivery Job pods run as (rbac.yaml's tycho-deliver:
             # get deliveries/deliverytargets, update deliveries/status,
             # nothing else). REQUIRED, fail-closed (tycho #197).
             - name: DELIVERY_JOB_SERVICE_ACCOUNT_NAME
               value: "tycho-deliver"
+            # DELIVERY_MAX_CONCURRENT is optional (default 1): how many
+            # delivery Jobs run at once (tycho #200's cap — ~20 ran
+            # concurrently during the 2026-08-06 etcd incident). 2 is
+            # safe now that S3-adapter status is O(1)+rate-limited, and
+            # halves large-backfill wall clock.
+            - name: DELIVERY_MAX_CONCURRENT
+              value: "2"
             # Names the Secret whose `uri` key is the catalog DSN the
             # delivery Job injects as DELIVERY_CATALOG_DSN (SecretKeyRef,
             # tycho #196) — the CNPG <cluster>-app Secret, same one the

--- a/gitops/tools/apps/tycho/operator/fleet.tycho.dev_deliveries.yaml
+++ b/gitops/tools/apps/tycho/operator/fleet.tycho.dev_deliveries.yaml
@@ -150,7 +150,11 @@ spec:
             description: |-
               DeliveryStatus is load-bearing state, not a progress bar (ADR 0010
               §1/§9): the per-file ledger and the commit record are the only
-              idempotency that exists anywhere in this pipeline, on either side.
+              idempotency that exists anywhere in this pipeline, on either side --
+              except for an adapter that declares its own independent idempotency
+              (internal/delivery.SelfIdempotentAdapter, ADR 0010 §9's exemption),
+              which trades Files' per-file record for ClassProgress's O(1) rollup
+              instead, relying on the adapter itself rather than this object.
             properties:
               attempts:
                 description: |-
@@ -174,6 +178,58 @@ spec:
                   MemberID, without any join through object storage (ADR §4).
                 format: int64
                 type: integer
+              classProgress:
+                description: |-
+                  ClassProgress is the O(1) per-class rollup a self-idempotent
+                  adapter's StatusLedger writes INSTEAD of Files -- see
+                  DeliveryClassProgress. Empty for the default (non-self-idempotent)
+                  path, where Files carries this information per-file instead.
+                items:
+                  description: |-
+                    DeliveryClassProgress is one artifact class's O(1) progress rollup:
+                    count, bytes, and the most recent artifact's name -- the replacement
+                    for a per-file Files entry when the bound adapter is self-idempotent
+                    (internal/delivery.SelfIdempotentAdapter) and therefore does not need
+                    Files' per-file G1 protection (ADR 0010 §9's exemption). At most one
+                    entry per DeliveryArtifactClass the target selects, so this list's
+                    size is bounded by the number of artifact classes, never by object
+                    count -- the delivery-hardening O(1)-status-size requirement.
+                  properties:
+                    artifactClass:
+                      description: ArtifactClass is which class this rollup is
+                        for.
+                      type: string
+                    bytesTransferred:
+                      description: |-
+                        BytesTransferred is bytes actually moved for this class, within
+                        the current attempt -- only counted when the adapter's own
+                        SendFile call reported a real transfer, never for a call that
+                        resolved via the adapter's own idempotency check (already
+                        present at the destination, nothing moved).
+                      format: int64
+                      type: integer
+                    currentArtifact:
+                      description: |-
+                        CurrentArtifact is the ChunkKey of the most recently acked
+                        artifact in this class -- a live "what's happening now" pointer,
+                        not a history.
+                      type: string
+                    filesAcked:
+                      description: |-
+                        FilesAcked counts SendFile calls that returned success for this
+                        class, within the CURRENT attempt only -- a self-idempotent
+                        adapter's Ledger keeps no per-file record (Acknowledged always
+                        reports false, see StatusLedger's doc comment), so a Job restart
+                        re-lists and re-sends the whole class from scratch, and this
+                        counter restarts with it rather than accumulating across
+                        attempts. Reaches the class's true total exactly when the class
+                        finishes without a restart -- the common case.
+                      format: int32
+                      type: integer
+                  required:
+                  - artifactClass
+                  type: object
+                type: array
               commit:
                 description: |-
                   Commit is the far end's commit response, persisted before
@@ -255,12 +311,21 @@ spec:
               failureReason:
                 description: |-
                   FailureReason is the error message from that same failed
-                  SendFile attempt.
+                  SendFile attempt, OR -- when the Delivery controller's Job-watch
+                  safety net (watchJob, delivery_controller.go) is what marked
+                  Phase=Failed instead of the driver itself -- the failed Job's
+                  Pod termination evidence (deliveryJobFailureMessage), so a
+                  Failed Delivery is never left with an empty reason regardless of
+                  which path set it (delivery-hardening item 2, 2026-08-06).
                 type: string
               files:
                 description: |-
                   Files is the per-file ledger keyed by (ChunkKey, ContentHash) —
-                  the only idempotency in the pipeline (G1, G8; ADR 0010 §9).
+                  the only idempotency in the pipeline (G1, G8; ADR 0010 §9) for any
+                  adapter that has not declared itself self-idempotent
+                  (internal/delivery.SelfIdempotentAdapter). Unbounded in the
+                  number of files a Delivery ever sends — the default, safest
+                  behavior, and the one every adapter gets unless it opts out.
                 items:
                   description: |-
                     DeliveryFileStatus is one file's delivery record, keyed by

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -14,4 +14,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "20807b5"
+    newTag: "8aed7ac"


### PR DESCRIPTION
The full hardening deploy: images at `8aed7ac` (digests verified), **deliveries CRD synced in the same PR** (status schema changed to the O(1) rollup for self-idempotent adapters), and `DELIVERY_MAX_CONCURRENT=2` (new cap; ~20 concurrent deliveries were a co-conspirator in the etcd incident).

After sync: re-enable `fleetsync-fleet-zero` and the archive mirror finishes on the hardened engine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional control for limiting concurrent delivery processing.
  - Added delivery status details for progress by artifact class, including transferred bytes, acknowledged files, and the current artifact.
  - Improved failure reporting with evidence from terminated delivery pods.

- **Documentation**
  - Clarified how progress tracking differs between self-idempotent and standard adapters.
  - Documented file tracking limits and the expanded delivery status fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->