### PR TITLE
infra: garage 150Gi, site litestream→B2, fleetsync RBAC

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -18,6 +18,10 @@ spec:
       labels:
         app: tychofleet
     spec:
+      # fleetsync-rbac.yaml's SA: lets the site write DeliveryTarget
+      # CRs/Secrets into the tycho namespace (tychofleet #65). Without
+      # it the storage page saves but shows "not materialized".
+      serviceAccountName: tychofleet-fleetsync
       securityContext:
         runAsNonRoot: true
         runAsUser: 1001
@@ -133,7 +137,48 @@ spec:
               port: 4321
             initialDelaySeconds: 5
             periodSeconds: 10
+        # Litestream sidecar: continuous SQLite replication to B2 —
+        # the site DB (waitlist/members/fleet-storage settings) was
+        # the last un-backed-up state in the system. Same bucket as
+        # the archive mirror, its own prefix; creds are the existing
+        # MANAGED_STORAGE_* keys from tychofleet-config (ESO). RWO PVC
+        # is fine: sidecar shares the app's pod.
+        - name: litestream
+          image: litestream/litestream:0.3.13
+          args: ["replicate", "-config", "/etc/litestream.yml"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: LITESTREAM_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: tychofleet-config
+                  key: MANAGED_STORAGE_ACCESS_KEY_ID
+            - name: LITESTREAM_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: tychofleet-config
+                  key: MANAGED_STORAGE_SECRET_ACCESS_KEY
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: litestream-config
+              mountPath: /etc/litestream.yml
+              subPath: litestream.yml
+          resources:
+            requests:
+              memory: 32Mi
+              cpu: 10m
+            limits:
+              memory: 128Mi
+              cpu: 100m
       volumes:
         - name: data
           persistentVolumeClaim:
             claimName: tychofleet-data
+        - name: litestream-config
+          configMap:
+            name: tychofleet-litestream

--- a/gitops/apps/tychofleet/fleetsync-rbac.yaml
+++ b/gitops/apps/tychofleet/fleetsync-rbac.yaml
@@ -1,0 +1,51 @@
+# RBAC for the site's per-fleet backup/sync admin UI (tychofleet #65),
+# added on Casey's explicit instruction (2026-08-06). The site pod
+# writes DeliveryTarget CRs + their creds Secrets into the tycho
+# namespace and reads delivery status back; the tycho operator does
+# all actual syncing.
+#
+# Secrets scoping note: the RUNBOOK brief asked for resourceNames
+# "prefixed fleetsync-", which k8s RBAC cannot express (exact match
+# only, and `create` ignores resourceNames). So mutating verbs are
+# pinned to exact per-fleet names — extend the list as fleets are
+# added, one reviewed line each — and `create` is namespace-wide on
+# secrets because it cannot be narrower.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tychofleet-fleetsync
+  namespace: tychofleet
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tychofleet-fleetsync
+  namespace: tycho
+rules:
+- apiGroups: ["fleet.tycho.dev"]
+  resources: ["deliverytargets"]
+  verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
+- apiGroups: ["fleet.tycho.dev"]
+  resources: ["deliveries"]
+  verbs: ["get", "list", "watch"] # status readback on the settings page
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"] # cannot be resourceName-scoped; see header comment
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: ["fleetsync-fleet-zero"]
+  verbs: ["get", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tychofleet-fleetsync
+  namespace: tycho
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tychofleet-fleetsync
+subjects:
+- kind: ServiceAccount
+  name: tychofleet-fleetsync
+  namespace: tychofleet

--- a/gitops/apps/tychofleet/litestream-configmap.yaml
+++ b/gitops/apps/tychofleet/litestream-configmap.yaml
@@ -1,0 +1,23 @@
+# Litestream replication config for the site's SQLite (see the
+# sidecar in deployment.yaml). Continuous WAL shipping to B2 —
+# restore is `litestream restore -config /etc/litestream.yml
+# /data/tychofleet.db` from a fresh pod. Same bucket as the archive
+# mirror, its own prefix; ~10s replication lag, pennies of storage.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tychofleet-litestream
+  namespace: tychofleet
+data:
+  litestream.yml: |
+    dbs:
+      - path: /data/tychofleet.db
+        replicas:
+          - type: s3
+            bucket: tf-fleet-bak-01
+            path: site-backups/tychofleet.db
+            endpoint: https://s3.us-east-005.backblazeb2.com
+            region: us-east-005
+            force-path-style: false
+            sync-interval: 10s
+            retention: 720h

--- a/gitops/core/apps/garage.yml
+++ b/gitops/core/apps/garage.yml
@@ -70,7 +70,7 @@ spec:
             size: 1Gi
           data:
             storageClass: "syno-iscsi-default"
-            size: 50Gi
+            size: 150Gi
 
         deployment:
           kind: StatefulSet


### PR DESCRIPTION
The three closers: Garage data volume to 150Gi (values honest; live PVC patch is a separate kubectl step, same as the documented 20→50Gi expansion), litestream sidecar giving the site SQLite continuous B2 replication (last un-backed-up state in the system), and the fleetsync SA/RBAC from #446's body (Casey-authorized) + `serviceAccountName` so the admin storage page materializes for real. After merge I patch the live PVC and verify all three.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added continuous backup and recovery support for the TychoFleet SQLite database.
  * Enabled TychoFleet to manage delivery targets and required secrets through Kubernetes.
* **Reliability**
  * Added persistent database replication with configurable retention.
  * Increased Garage storage capacity from 50 GiB to 150 GiB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->