### PR TITLE
tycho: operator+deliver e8e2fa1 — CrowdSky adapter (tycho #201)

### DIFF
--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -118,7 +118,7 @@ spec:
             # or the adapter changes — same drift hazard as
             # COMBINE_IMAGE above.
             - name: DELIVERY_JOB_IMAGE
-              value: "zot.phillips-homelab.net/tycho-deliver:8aed7ac"
+              value: "zot.phillips-homelab.net/tycho-deliver:e8e2fa1"
             # SA delivery Job pods run as (rbac.yaml's tycho-deliver:
             # get deliveries/deliverytargets, update deliveries/status,
             # nothing else). REQUIRED, fail-closed (tycho #197).

--- a/gitops/tools/apps/tycho/operator/fleet.tycho.dev_deliveries.yaml
+++ b/gitops/tools/apps/tycho/operator/fleet.tycho.dev_deliveries.yaml
@@ -316,7 +316,11 @@ spec:
                   Phase=Failed instead of the driver itself -- the failed Job's
                   Pod termination evidence (deliveryJobFailureMessage), so a
                   Failed Delivery is never left with an empty reason regardless of
-                  which path set it (delivery-hardening item 2, 2026-08-06).
+                  which path set it (delivery-hardening item 2, 2026-08-06). Also
+                  set on a terminal Unknown Delivery (G2): the commit call's own
+                  error, session context and all, so an operator resolving an
+                  Unknown Delivery out of band has something to act on beyond the
+                  bare phase name.
                 type: string
               files:
                 description: |-

--- a/gitops/tools/apps/tycho/operator/fleet.tycho.dev_deliverytargets.yaml
+++ b/gitops/tools/apps/tycho/operator/fleet.tycho.dev_deliverytargets.yaml
@@ -95,6 +95,7 @@ spec:
                 enum:
                 - fake
                 - s3
+                - crowdsky
                 type: string
               artifactClasses:
                 description: |-

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -14,4 +14,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "8aed7ac"
+    newTag: "e8e2fa1"


### PR DESCRIPTION
Images at `e8e2fa1` (digests verified), both changed CRDs synced in the same PR (drift check ran pre-authoring). The adapter is fully inert after deploy — no CrowdSky target exists until Casey creates one deliberately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `crowdsky` delivery targets.
  * Expanded delivery failure details for terminal `Unknown` states, including commit errors and context.

* **Updates**
  * Updated the Tycho operator and delivery job images to the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->