### PR TITLE
tycho: images → 91d41d0 (Dockerfile proto fix, tycho #203)

### DIFF
--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -118,7 +118,7 @@ spec:
             # or the adapter changes — same drift hazard as
             # COMBINE_IMAGE above.
             - name: DELIVERY_JOB_IMAGE
-              value: "zot.phillips-homelab.net/tycho-deliver:61691b5"
+              value: "zot.phillips-homelab.net/tycho-deliver:91d41d0"
             # SA delivery Job pods run as (rbac.yaml's tycho-deliver:
             # get deliveries/deliverytargets, update deliveries/status,
             # nothing else). REQUIRED, fail-closed (tycho #197).

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -15,4 +15,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "61691b5"
+    newTag: "91d41d0"


### PR DESCRIPTION
Replaces the phantom `61691b5` operator tag (build failed, push chain masked it, old pod kept serving — no outage). `91d41d0` = dispatch + the one-line COPY fix; operator and deliver pushes verified against zot's tag list directly. Gateway re-pinned to the same sha for tag hygiene.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Tycho operator and delivery job to use the latest container image version.
  * Improves deployment consistency across Tycho components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->