### PR TITLE
tycho: sync rbac.yaml — operator observations RBAC (tycho #202)

### DIFF
--- a/gitops/tools/apps/tycho/operator/rbac.yaml
+++ b/gitops/tools/apps/tycho/operator/rbac.yaml
@@ -43,6 +43,16 @@ rules:
   - apiGroups: ["fleet.tycho.dev"]
     resources: ["imagingsessions/status", "seestars/status", "targetmasters/status", "fleetmasters/status", "deliverytargets/status", "deliveries/status"]
     verbs: ["get", "patch", "update"]
+  # Observations are created by fleet clients, never by the operator
+  # itself (unlike every other resource above) -- no create/delete
+  # verb, matching the dispatch controller's own read/reconcile-only
+  # relationship to this CRD.
+  - apiGroups: ["fleet.tycho.dev"]
+    resources: ["observations"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["fleet.tycho.dev"]
+    resources: ["observations/status"]
+    verbs: ["get", "patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
YAML-only. The operator SA needs list/watch/write on the new observations CRD; regenerated rbac.yaml synced verbatim. Fixes the Forbidden watch + cache-sync restarts.