### PR TITLE
tycho: operator+deliver 3f41dd5 — results artifact class (tycho #204)

### DIFF
--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -118,7 +118,7 @@ spec:
             # or the adapter changes — same drift hazard as
             # COMBINE_IMAGE above.
             - name: DELIVERY_JOB_IMAGE
-              value: "zot.phillips-homelab.net/tycho-deliver:91d41d0"
+              value: "zot.phillips-homelab.net/tycho-deliver:3f41dd5"
             # SA delivery Job pods run as (rbac.yaml's tycho-deliver:
             # get deliveries/deliverytargets, update deliveries/status,
             # nothing else). REQUIRED, fail-closed (tycho #197).

--- a/gitops/tools/apps/tycho/operator/fleet.tycho.dev_deliverytargets.yaml
+++ b/gitops/tools/apps/tycho/operator/fleet.tycho.dev_deliverytargets.yaml
@@ -114,6 +114,7 @@ spec:
                   - stacks
                   - masters
                   - everything
+                  - results
                   type: string
                 minItems: 1
                 type: array

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -15,4 +15,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "91d41d0"
+    newTag: "3f41dd5"


### PR DESCRIPTION
Both images verified in zot at `3f41dd5`. deliverytargets CRD synced (new `results` enum). After sync: Conner's target gains `results` and his per-night stacks deliver.