### PR TITLE
tychofleet: onboarding docs live (1d35cb6)

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:2816c0a
+          image: zot.phillips-homelab.net/tychofleet:1d35cb6
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Site image at `1d35cb6` (zot-verified) with the six-page /docs section from tychofleet #66. Findings from that PR (invite-email path mismatch, stewardship gap on /scopes enrollment) remain open product items.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TychoFleet application to a newer container release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->