### PR TITLE
tychofleet: Starlight docs live (9e61271)

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:1d35cb6
+          image: zot.phillips-homelab.net/tychofleet:9e61271
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Docs on Starlight with brand theming, docs link restored to the signed-in nav. Founder eyeball of header parity happens against this live deploy per the design-loop rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TychoFleet application to use the latest container image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->