### PR TITLE
tychofleet: one docs shell live (39badbc)

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:d5db048
+          image: zot.phillips-homelab.net/tychofleet:39badbc
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Founder-approved via render review (index/deep/reference triptych, swatch-verified). One sidebar tree on every /docs route; legacy shell deleted; structure now machine-asserted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TychoFleet application to use the latest container image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->