### PR TITLE
tychofleet: consolidated docs live (04a8755)

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:39badbc
+          image: zot.phillips-homelab.net/tychofleet:04a8755
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
The 15→10 consolidation, founder-approved through the dual review gate (renders + full merged text + cluster table). Redirects for every moved URL; off-docs links fixed; all four structural gates green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TychoFleet application to a newer container release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->