### PR TITLE
tychofleet: truth pass live (a530d21)

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:9abae62
+          image: zot.phillips-homelab.net/tychofleet:a530d21
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Every content block true or gone: coordination claims → attribution truth, two-nights fix, real master sizes, S50 qualifier, nightly-stack preview wired real. Founder-approved (dual review, conductor pre-verified). Note: loop budget-exhausted during review wait — PR filed manually; rig fix (review-wait must not burn iterations) queued.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TychoFleet application to a newer container image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->