### PR TITLE
loopctl: image tag regex must survive hyphens

### DIFF
--- a/loops/bin/loopctl
+++ b/loops/bin/loopctl
@@ -29,7 +29,7 @@ TEMPLATE="$REPO_ROOT/loops/templates/loop-sandbox.yaml"
 
 die() { echo "loopctl: $*" >&2; exit 1; }
 
-image_from_template() { grep -oE 'zot\.phillips-homelab\.net/loop-dev:[a-z0-9]+' "$TEMPLATE" | head -1; }
+image_from_template() { grep -oE 'zot\.phillips-homelab\.net/loop-dev:[a-zA-Z0-9._-]+' "$TEMPLATE" | head -1; }
 
 # Run $2 (bash script text) in a short-lived in-cluster pod named loopctl-$1-*
 # with loop-secrets in env. Prints the pod's logs. Optional $3 = extra pod


### PR DESCRIPTION
One-line fix: the helper-pod image regex truncated hyphenated tags, silently breaking answer/reap/merge/pr since the review-wait image landed. Working-tree fix already applied locally (that's how the concepts approval finally published); this PR makes it permanent. Follow-up noted: helper pods should surface pod status when logs come back empty instead of failing mute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image tags can now include uppercase letters, digits, periods, underscores, and hyphens when creating images from templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->