### PR TITLE
tychofleet: public /download page (1cdccd4)

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:a4190b9
+          image: zot.phillips-homelab.net/tychofleet:1cdccd4
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Deploy tychofleet site image `1cdccd4` (site repo main HEAD, PR #77 — public /download page).

- Image `zot.phillips-homelab.net/tychofleet:1cdccd4` built and pushed (digest `sha256:633cb6e8af9456777d221c92a640dda9b29d06e8437cf554c4e5d1ae37ff6981`).
- Bumps deployment from `a4190b9` (prior live, ancestor of 1cdccd4) → `1cdccd4`.

https://claude.ai/code/session_014vgmYsVtNb1DwwQ5pnCr9c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Tychofleet application to a newer container image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->