### PR TITLE
tychofleet: site DB backup to in-cluster Garage (fix broken B2 backup)

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -141,8 +141,10 @@ spec:
         # the site DB (waitlist/members/fleet-storage settings) was
         # the last un-backed-up state in the system. Same bucket as
         # the archive mirror, its own prefix; creds are the existing
-        # MANAGED_STORAGE_* keys from tychofleet-config (ESO). RWO PVC
-        # is fine: sidecar shares the app's pod.
+        # LITESTREAM_GARAGE_* keys from tychofleet-config (ESO) — replicates
+        # to in-cluster Garage (the pod has no internet egress, so the old
+        # B2 target failed continuously). RWO PVC is fine: sidecar shares
+        # the app's pod.
         - name: litestream
           image: litestream/litestream:0.3.13
           args: ["replicate", "-config", "/etc/litestream.yml"]
@@ -156,12 +158,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: tychofleet-config
-                  key: MANAGED_STORAGE_ACCESS_KEY_ID
+                  key: LITESTREAM_GARAGE_ACCESS_KEY_ID
             - name: LITESTREAM_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: tychofleet-config
-                  key: MANAGED_STORAGE_SECRET_ACCESS_KEY
+                  key: LITESTREAM_GARAGE_SECRET_ACCESS_KEY
           volumeMounts:
             - name: data
               mountPath: /data

--- a/gitops/apps/tychofleet/external-secret.yaml
+++ b/gitops/apps/tychofleet/external-secret.yaml
@@ -85,3 +85,17 @@ spec:
     remoteRef:
       key: tycho
       property: b2_delivery_application_key
+  # Litestream backup of the site DB (member accounts, scopes, setup
+  # codes) to the in-cluster Garage bucket tychofleet-backups. Replaces
+  # the B2 target, which the pod cannot reach (no egress) — the B2
+  # replica was failing continuously. Key is scoped RW to that one
+  # bucket. Its own 1Password item (like atuin-garage-backup), not the
+  # shared tychofleet/tycho items.
+  - secretKey: LITESTREAM_GARAGE_ACCESS_KEY_ID
+    remoteRef:
+      key: tychofleet-garage-backup
+      property: access_key_id
+  - secretKey: LITESTREAM_GARAGE_SECRET_ACCESS_KEY
+    remoteRef:
+      key: tychofleet-garage-backup
+      property: secret_access_key

--- a/gitops/apps/tychofleet/litestream-configmap.yaml
+++ b/gitops/apps/tychofleet/litestream-configmap.yaml
@@ -1,8 +1,11 @@
 # Litestream replication config for the site's SQLite (see the
-# sidecar in deployment.yaml). Continuous WAL shipping to B2 —
-# restore is `litestream restore -config /etc/litestream.yml
-# /data/tychofleet.db` from a fresh pod. Same bucket as the archive
-# mirror, its own prefix; ~10s replication lag, pennies of storage.
+# sidecar in deployment.yaml). Continuous WAL shipping to the in-cluster
+# Garage S3 (the tychofleet pod has no internet egress, so the previous
+# B2 target failed continuously — member accounts/scopes/setup-codes had
+# no working off-box backup). Restore is `litestream restore -config
+# /etc/litestream.yml /data/tychofleet.db` from a fresh pod. ~10s
+# replication lag. force-path-style + region "garage" are required by
+# Garage (same pattern as lighttheham/atuin/forgejo).
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,10 +17,10 @@ data:
       - path: /data/tychofleet.db
         replicas:
           - type: s3
-            bucket: tf-fleet-bak-01
-            path: site-backups/tychofleet.db
-            endpoint: https://s3.us-east-005.backblazeb2.com
-            region: us-east-005
-            force-path-style: false
+            bucket: tychofleet-backups
+            path: tychofleet.db
+            endpoint: http://garage.garage.svc:3900
+            region: garage
+            force-path-style: true
             sync-interval: 10s
             retention: 720h


### PR DESCRIPTION
Fixes alpha-readiness S3: the tychofleet pod has no egress, so the litestream backup to B2 was failing continuously — member DB (accounts/scopes/setup codes) had no working off-box copy. Repoints litestream at in-cluster Garage (bucket tychofleet-backups, RW key scoped to it, verified to resolve via ESO before merge). Pattern mirrors lighttheham/atuin/forgejo.

https://claude.ai/code/session_014vgmYsVtNb1DwwQ5pnCr9c