### PR TITLE
etcd: observability, DB-quota headroom, and the global alert-route (blackhole) fix

### DIFF
--- a/cluster/talos/omni/phillips-homelab/patches/etcd-hardening.yml
+++ b/cluster/talos/omni/phillips-homelab/patches/etcd-hardening.yml
@@ -1,0 +1,32 @@
+# etcd hardening for the control-plane (homelab-01, the single etcd member).
+#
+# APPLY MANUALLY — this is a Talos machine-config change, applied via Omni with
+# the operator's PGP-authed omnictl, NOT by ArgoCD. See PR body / README.
+# Applying restarts etcd on the sole control-plane member => a brief
+# control-plane / API pause. Do it deliberately.
+#
+#   omnictl cluster template sync \
+#     -f cluster/talos/omni/phillips-homelab/template.yaml
+#
+# Two changes, both passed through to etcd via cluster.etcd.extraArgs (Talos's
+# documented escape hatch for arbitrary etcd flags):
+#
+# 1. quota-backend-bytes: raise the etcd DB quota from the 2 GiB default
+#    (2147483648) to 8 GiB (8589934592) — etcd's recommended maximum. The
+#    2026-08 NOSPACE incident filled the 2 GiB quota and froze the cluster;
+#    8 GiB gives real headroom while staying within etcd's supported range.
+#
+# 2. listen-metrics-urls: expose etcd's Prometheus metrics on :2381 over plain
+#    HTTP (no auth, metrics only). Required for the VMStaticScrape in
+#    gitops/core/apps/etcd-monitoring to populate etcd_mvcc_db_total_size_in_bytes
+#    and up{job="etcd"}. Without this, :2381 is closed and the scrape reads 0.
+#
+# SCHEMA NOTE / uncertainty: cluster.etcd.extraArgs is the stable Talos field
+# for etcd flags (values must be strings). If a future Talos version rejects
+# quota-backend-bytes via extraArgs, the alternative is the typed field — but as
+# of Talos v1.12.6 extraArgs is correct. Verify after apply (see README).
+cluster:
+  etcd:
+    extraArgs:
+      quota-backend-bytes: "8589934592"
+      listen-metrics-urls: http://0.0.0.0:2381

--- a/cluster/talos/omni/phillips-homelab/template.yaml
+++ b/cluster/talos/omni/phillips-homelab/template.yaml
@@ -27,6 +27,11 @@ patches:
     inline:
       cluster:
         allowSchedulingOnControlPlanes: true
+  # etcd DB-quota raise (2 GiB -> 8 GiB) + metrics listener on :2381.
+  # Takes effect only on `omnictl cluster template sync` (restarts etcd on
+  # the sole control-plane member; apply deliberately). See the patch file.
+  - name: etcd-hardening
+    file: patches/etcd-hardening.yml
 systemExtensions:
   - siderolabs/amd-ucode
   - siderolabs/iscsi-tools

--- a/gitops/core/apps/etcd-monitoring.yml
+++ b/gitops/core/apps/etcd-monitoring.yml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: etcd-monitoring
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  project: default
+  source:
+    path: gitops/core/apps/etcd-monitoring
+    repoURL: https://github.com/AlverezYari/phillips-homelab.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/gitops/core/apps/etcd-monitoring/README.md
+++ b/gitops/core/apps/etcd-monitoring/README.md
@@ -1,0 +1,82 @@
+# etcd observability & hardening
+
+Follow-up to the 2026-08 etcd NOSPACE incident (the 2 GiB etcd DB quota filled
+and froze the cluster). The app-level cause (delivery status churn) is already
+fixed. This addresses the residual etcd risks: no db-size metric was scraped,
+the DB quota was still the 2 GiB default, and there is no automated defrag.
+
+## What ArgoCD ships here
+
+- **`vmstaticscrape.yaml`** — a `VMStaticScrape` (job `etcd`) that scrapes
+  etcd's Prometheus metrics from the control-plane node on `:2381`. This makes
+  `etcd_mvcc_db_total_size_in_bytes` and `up{job="etcd"}` populate, giving the
+  chart-installed `vmstack-etcd` VMRule real data to alert on.
+
+  The chart's own `vmstack-kube-etcd` VMServiceScrape does **not** work on
+  Talos: it selects pods labeled `component: etcd`, but Talos runs etcd as a
+  host service, not a pod — so its Service has zero endpoints. Leave it; it's
+  harmless (different job name, no targets). This static scrape replaces it.
+
+> **This scrape reads `up=0` until the Talos patch below is applied.** It
+> depends on etcd's `listen-metrics-urls` being enabled on `:2381`.
+
+## Talos changes (apply MANUALLY via Omni — NOT ArgoCD)
+
+`cluster/talos/omni/phillips-homelab/patches/etcd-hardening.yml`, wired into the
+ControlPlane block of `template.yaml`, sets two etcd flags:
+
+| flag | value | why |
+|------|-------|-----|
+| `quota-backend-bytes` | `8589934592` (8 GiB) | raise from 2 GiB default; headroom above the incident |
+| `listen-metrics-urls` | `http://0.0.0.0:2381` | expose etcd metrics for the scrape above |
+
+Apply (needs the operator's PGP-authed omnictl; restarts etcd on the sole
+control-plane member => brief control-plane/API pause — do deliberately):
+
+```bash
+omnictl cluster template sync \
+  -f cluster/talos/omni/phillips-homelab/template.yaml
+```
+
+### Verify after apply
+
+```bash
+# metrics listener is up (was Connection-refused before)
+kubectl -n monitoring run etcdprobe --rm -it --restart=Never \
+  --image=curlimages/curl -- -s http://192.168.10.191:2381/metrics | head
+
+# quota raised to 8 GiB
+kubectl -n monitoring exec deploy/vmsingle-vmstack -- \
+  wget -qO- 'http://localhost:8429/api/v1/query?query=etcd_server_quota_backend_bytes'
+# => 8589934592
+
+# db size + target are now scraped
+#   up{job="etcd"} == 1
+#   etcd_mvcc_db_total_size_in_bytes present
+```
+
+## Defrag — MANUAL, do NOT automate (yet)
+
+etcd's on-disk file only shrinks after a `defrag`, and defrag **blocks the
+member it runs against**. This cluster has a **single** etcd member, so a
+defrag briefly freezes the entire control plane. An in-cluster CronJob is
+deliberately **not** shipped because:
+
+1. `etcdctl defrag` needs the etcd client cert (mutual-TLS on `:2379`) from
+   `/system/secrets/etcd/*` on the node. Those certs can't be managed
+   declaratively here and they rotate — a stale secret would be a silent
+   failure at best.
+2. With one member, a wedged/slow defrag takes the whole API down. Not worth
+   automating unattended.
+
+Run it manually, deliberately, off-peak, using Talos's native command (it uses
+the node's own etcd certs — no secret wrangling):
+
+```bash
+# defrag the etcd member on the control-plane node
+talosctl -n 192.168.10.191 etcd defrag
+```
+
+Revisit an automated weekly, one-member-at-a-time CronJob only if/when the
+control plane grows to 3 etcd members (defrag one, wait, next). Until then the
+8 GiB quota + the db-size alerting above are the guardrails.

--- a/gitops/core/apps/etcd-monitoring/kustomization.yaml
+++ b/gitops/core/apps/etcd-monitoring/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+- vmstaticscrape.yaml

--- a/gitops/core/apps/etcd-monitoring/vmstaticscrape.yaml
+++ b/gitops/core/apps/etcd-monitoring/vmstaticscrape.yaml
@@ -1,0 +1,40 @@
+# Scrape Talos etcd's Prometheus metrics so etcd db-size / quota / health land
+# in VictoriaMetrics and the (already-installed) chart VMRule `vmstack-etcd`
+# has data to alert on.
+#
+# Why a VMStaticScrape (not the chart's VMServiceScrape): on Talos, etcd runs
+# as a host-level Talos service, NOT a Kubernetes pod. The chart's
+# `vmstack-kube-etcd` VMServiceScrape selects pods labeled `component: etcd`,
+# which don't exist here, so its Service has zero endpoints and produces no
+# data (`etcd_mvcc_db_total_size_in_bytes` and `up{job="etcd"}` are empty).
+#
+# etcd exposes two ports:
+#   * 2379 — client API, mutual-TLS; scraping needs the etcd client cert from
+#     the control-plane node (/system/secrets/etcd/*), which can't be managed
+#     declaratively here and rotates. Verified: a plain TLS probe to :2379 gets
+#     "Request CERT" back (client cert required).
+#   * 2381 — etcd's dedicated metrics/health listener, plain HTTP, no auth.
+#     This is the Talos-recommended way to scrape etcd metrics.
+#
+# DEPENDENCY — this scrape stays at up=0 until the Talos patch that sets
+# `listen-metrics-urls: http://0.0.0.0:2381` on etcd is applied via Omni
+# (cluster/talos/omni/phillips-homelab/patches/etcd-hardening.yml). As of
+# authoring, :2381 is Connection-refused (metrics listener not yet enabled).
+#
+# Target is the single control-plane node homelab-01 (192.168.10.191); it is
+# the only etcd member. Update this IP if the control-plane node changes.
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMStaticScrape
+metadata:
+  name: etcd
+  namespace: monitoring
+spec:
+  jobName: etcd
+  targetEndpoints:
+    - targets:
+        - "192.168.10.191:2381"
+      scheme: http
+      path: /metrics
+      interval: 30s
+      labels:
+        job: etcd

--- a/gitops/core/apps/victoria-metrics-k8s-stack.yml
+++ b/gitops/core/apps/victoria-metrics-k8s-stack.yml
@@ -16,6 +16,45 @@ spec:
     targetRevision: 0.39.2
     helm:
       values: |
+        alertmanager:
+          # GLOBAL Alertmanager config (the base route tree the VM operator
+          # merges every VMAlertmanagerConfig into). The chart default routes
+          # the top-level catch-all to a null "blackhole" receiver, so any
+          # alert without a matching per-namespace VMAlertmanagerConfig — etcd
+          # (no namespace label), garage/storage PVCs, node/kube-system — was
+          # silently dropped.
+          #
+          # Fix: point the top-level default receiver at the SAME ntfy webhook
+          # stock-bot/tycho use (stock-bot-serve's /alerthook formats the
+          # Alertmanager payload into a readable ntfy message). Now every
+          # unmatched cluster-level alert notifies instead of vanishing.
+          #
+          # The operator APPENDS each VMAlertmanagerConfig's route as a child
+          # of this root (selectAllByDefault: true), so the existing
+          # stock-bot (namespace=stock-bot) and tycho (namespace=tycho) routes
+          # keep working unchanged and are NOT duplicated here: an alert that
+          # matches a child route is handled there and never reaches this
+          # root receiver (Alertmanager only uses the root receiver when NO
+          # child route matches). The one explicit child below re-blackholes
+          # the always-firing Watchdog heartbeat and the InfoInhibitor so they
+          # don't spam ntfy.
+          config:
+            route:
+              receiver: ntfy-cluster
+              group_by: ["alertname", "namespace"]
+              group_wait: 30s
+              group_interval: 5m
+              repeat_interval: 3h
+              routes:
+                - receiver: blackhole
+                  matchers:
+                    - alertname =~ "Watchdog|InfoInhibitor"
+            receivers:
+              - name: blackhole
+              - name: ntfy-cluster
+                webhook_configs:
+                  - url: "http://stock-bot-serve.stock-bot.svc.cluster.local:8080/alerthook"
+                    send_resolved: true
         grafana:
           enabled: false
         defaultDashboards:


### PR DESCRIPTION
Follow-up to the 2026-08 etcd **NOSPACE** incident (the 2 GiB etcd DB quota filled and froze the cluster). The app-level cause is already fixed & deployed; this closes the residual etcd gaps and the global alert-routing blackhole.

Each item was investigated against the **live cluster** before authoring.

---

## 1. etcd metrics scrape — SHIPPED (functional only after item 3 is applied)

`etcd_mvcc_db_total_size_in_bytes` and `up{job="etcd"}` are both **empty** today (verified via vmsingle query). Root cause: the chart's `vmstack-kube-etcd` VMServiceScrape selects pods labeled `component: etcd`, but **Talos runs etcd as a host service, not a pod** — so that Service has **zero endpoints** and produces nothing.

Fix: `gitops/core/apps/etcd-monitoring/vmstaticscrape.yaml` — a `VMStaticScrape` (job `etcd`) targeting the control-plane node `192.168.10.191:2381`, etcd's plain-HTTP metrics listener. Wired in via a new `etcd-monitoring` ArgoCD app (picked up by `homelab-core`). Renders clean (`kubectl kustomize`) and passes **server-side dry-run**.

Port choice (both probed live):
- **:2379** — client API, returns `Request CERT` (mutual-TLS). Needs the etcd client cert from `/system/secrets/etcd/*`, which rotates and can't be managed declaratively → rejected.
- **:2381** — dedicated metrics listener, plain HTTP, no auth. The Talos-recommended path. Currently `Connection refused` because the listener isn't enabled yet — enabling it is part of item 3.

> **Dependency:** this scrape stays at `up=0` until the Talos `listen-metrics-urls` patch (item 3) is applied. That is called out in the manifest and README rather than shipping something that silently reads zero.

## 2. Global alert-route fix (the blackhole) — SHIPPED

The real blackhole is the chart's **base** Alertmanager route (no override existed in `victoria-metrics-k8s-stack.yml`). The VM operator appends each `VMAlertmanagerConfig` as a **child** of this root, so alerts without a matching per-namespace config (etcd — no namespace label; garage/storage PVCs; node/kube-system) fell through to the null `blackhole` receiver.

Fix: set the base config's **top-level default receiver** to the same ntfy webhook stock-bot/tycho already use.

### Before (live, decoded from `vmalertmanager-vmstack-config`)
```
route: receiver=blackhole            <-- everything unmatched DROPPED
├─ app=stock-bot, namespace=stock-bot   -> ntfy  (continue)
└─ namespace=tycho                       -> ntfy  (continue)
receivers: blackhole, stock-bot ntfy, tycho ntfy
```

### After
```
route: receiver=ntfy-cluster         <-- unmatched now NOTIFIES (etcd/garage/node/...)
├─ alertname=~"Watchdog|InfoInhibitor" -> blackhole   (mute heartbeat/inhibitor noise)
├─ app=stock-bot, namespace=stock-bot   -> ntfy  (continue)   [operator-appended, unchanged]
└─ namespace=tycho                       -> ntfy  (continue)   [operator-appended, unchanged]
receivers: blackhole, ntfy-cluster, stock-bot ntfy, tycho ntfy
```

Why this is safe and minimal:
- **No existing route touched.** stock-bot/tycho routes are operator-appended and unchanged.
- **No double-notify.** Alertmanager only uses the root receiver when *no* child route matches; stock-bot/tycho alerts match their child and never reach `ntfy-cluster`.
- **Nothing is silenced** — this is the opposite of the "wrong route silences everything" risk; the only things newly muted are the always-firing Watchdog and InfoInhibitor.
- **Tradeoff:** unmatched *warnings* (not just criticals) now notify too. If that's noisy, the follow-up is a severity-scoped child route; erring toward visibility over silence given the incident history. The embedded helm values parse and match the chart's live output shape 1:1.

## 3. etcd `quota-backend-bytes` raise — AUTHORED, APPLY MANUALLY (Talos/Omni)

`cluster/talos/omni/phillips-homelab/patches/etcd-hardening.yml`, wired into the ControlPlane block of `template.yaml`. Raises the quota **2 GiB → 8 GiB** (etcd's recommended max) via `cluster.etcd.extraArgs.quota-backend-bytes: "8589934592"`. Same patch also sets `listen-metrics-urls: http://0.0.0.0:2381` (item 1's dependency).

**DO NOT let this auto-apply. ArgoCD does not touch Talos.** It takes effect only when the operator runs, with PGP-authed omnictl:
```bash
omnictl cluster template sync -f cluster/talos/omni/phillips-homelab/template.yaml
```
This restarts etcd on the **single** control-plane member → a **brief control-plane/API pause**. Do it deliberately, off-peak.

Schema uncertainty: `cluster.etcd.extraArgs` is the documented Talos escape hatch for etcd flags (string values) and is correct for v1.12.6. If a future Talos rejects it, fall back to the typed etcd field. Verification steps (metrics listener up, `etcd_server_quota_backend_bytes == 8589934592`) are in the README.

## 4. Periodic defrag — DOCUMENTED AS MANUAL, no CronJob shipped (deliberate)

Not shipped as an automated CronJob because it would be unsafe here:
1. `etcdctl defrag` needs the mutual-TLS etcd client cert (`:2379`, `/system/secrets/etcd/*`) — rotates, can't be managed declaratively.
2. **Single etcd member** → defrag blocks the *only* member → a slow/wedged defrag freezes the whole API.

Documented manual procedure using Talos's native command (uses the node's own certs): `talosctl -n 192.168.10.191 etcd defrag`, run deliberately off-peak. Revisit an automated one-member-at-a-time CronJob only if the control plane grows to 3 etcd members. Until then the 8 GiB quota + the new db-size alerting are the guardrails.

---

### Validation done
- `kubectl kustomize gitops/core/apps/etcd-monitoring` renders.
- `kubectl apply --dry-run=server` on the VMStaticScrape: accepted.
- Embedded helm values + Talos patch + template.yaml all parse (yaml.safe_load).
- Live probes: `:2381` refused, `:2379` requires client cert, both etcd metrics empty — confirming the diagnosis.

### DO NOT MERGE / DO NOT APPLY blindly
- Merging ships items 1 & 2 via ArgoCD. **Item 1 reads `up=0` until item 3 is applied** — apply the Talos patch (item 3) around the same time.
- Item 3 is a control-plane change — apply manually via Omni as above.

https://claude.ai/code/session_014vgmYsVtNb1DwwQ5pnCr9c


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added etcd monitoring with metrics collection every 30 seconds.
  - Added automated deployment and self-healing for the monitoring application.
  - Configured an 8 GiB etcd backend quota and Prometheus metrics endpoint.
  - Added ntfy notifications for Alertmanager alerts.

- **Documentation**
  - Documented monitoring setup, verification steps, quota configuration, and manual defragmentation procedures.
  - Suppressed routine Watchdog and InfoInhibitor notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->