### PR TITLE
tycho: bump COMBINE_IMAGE to aa2f7bd (combine multi-member resilience)

### DIFF
--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -107,7 +107,7 @@ spec:
               # feature was live everywhere except the container that
               # reads it (tycho #154). Bump this whenever combine/
               # changes, and check it moved after ArgoCD syncs.
-              value: "zot.phillips-homelab.net/tycho-combine:b06bf2f"
+              value: "zot.phillips-homelab.net/tycho-combine:aa2f7bd"
             # ADR 0010 outbound delivery. Both are REQUIRED: the
             # operator fails closed at startup without them, so this
             # block must land in the same commit as the image bump.


### PR DESCRIPTION
Bumps the operator's COMBINE_IMAGE tag from `b06bf2f` to `aa2f7bd`, built from loop-bot/tycho main HEAD (combine multi-member resilience).

Image pushed to `zot.phillips-homelab.net/tycho-combine:aa2f7bd` (digest `sha256:392e5fbc58ffb1ebe29709761807449105648365254f2c735375a6fad775a283`), verified present in registry (manifest HTTP 200).

Only the COMBINE_IMAGE env value in `gitops/tools/apps/tycho/operator/deployment.yaml` is changed.

https://claude.ai/code/session_014vgmYsVtNb1DwwQ5pnCr9c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the deployed Combine image to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->