### PR TITLE
tycho: bump tycho-gateway to 66ea3d9 (configurable setup-code TTL)

### DIFF
--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-gateway
-    newTag: "61691b5"
+    newTag: "66ea3d9"


### PR DESCRIPTION
Bumps the pinned tycho-gateway image tag from `61691b5` to `66ea3d9` (current main of loop-bot/tycho).

Image built on the workstation via `make image-gateway` and pushed to zot.phillips-homelab.net; registry manifest verified (HTTP 200). `kubectl kustomize` renders `zot.phillips-homelab.net/tycho-gateway:66ea3d9`.

Digest: `sha256:7f61af746fb5ca9ce094cb42d0e36c7d2eea60e3c589c36b53880550f9acb19f`

https://claude.ai/code/session_014vgmYsVtNb1DwwQ5pnCr9c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Tycho Gateway container image to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->