### PR TITLE
tychofleet: bump to fa3dbaf (member-authz IDOR fix + scope_id migration)

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:1cdccd4
+          image: zot.phillips-homelab.net/tychofleet:fa3dbaf
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Bumps the tychofleet site image from `1cdccd4` to `fa3dbaf` (current main HEAD).

## Changes in this release
- Member-authz IDOR fix
- New drizzle migration `0022_silky_eternals.sql`: adds `scope_id` (text NOT NULL) to `pending_scope_keys` (clears the table first, since the column has no sane backfill default)

## Migration mechanism
Migrations auto-apply on container boot. The image ENTRYPOINT is `docker-entrypoint.sh`, which runs `node scripts/migrate.mjs` (drizzle `migrate()` against the SQLite DB at `DATABASE_PATH`) before `exec`-ing the server. No manual step required.

## Image
- Tag: `zot.phillips-homelab.net/tychofleet:fa3dbaf`
- Manifest digest: `sha256:5d37a02b33843a861ad780d3edabfd4f30cc62540a2a5af45ba66d0e793d3e2b`
- Verified present in zot (HTTP 200)

Do not merge — left for review.

https://claude.ai/code/session_014vgmYsVtNb1DwwQ5pnCr9c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TychoFleet application to a newer release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->