### PR TITLE
tycho: bump COMBINE_IMAGE to e7d36e2 (v1 sub-pipeline: raw OSC subs combine)

### DIFF
--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -107,7 +107,7 @@ spec:
               # feature was live everywhere except the container that
               # reads it (tycho #154). Bump this whenever combine/
               # changes, and check it moved after ArgoCD syncs.
-              value: "zot.phillips-homelab.net/tycho-combine:aa2f7bd"
+              value: "zot.phillips-homelab.net/tycho-combine:e7d36e2"
             # ADR 0010 outbound delivery. Both are REQUIRED: the
             # operator fails closed at startup without them, so this
             # block must land in the same commit as the image bump.


### PR DESCRIPTION
Bumps the operator's COMBINE_IMAGE to `zot.phillips-homelab.net/tycho-combine:e7d36e2`, built from loop-bot/tycho main HEAD (e7d36e2). Ships the v1 sub-pipeline (raw OSC subs combine).

Pushed digest: `sha256:c382b39148fb6e34d6788e8e31d8ca229ef7a07e712eb8c01b6a90f0d17bfbbd`
Zot manifest verified: HTTP 200.

Do not merge yet - leaving for Casey.

https://claude.ai/code/session_014vgmYsVtNb1DwwQ5pnCr9c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the deployed Combine image version to a newer release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->