### PR TITLE
loopctl: image_from_template must capture full image tags

### DIFF
--- a/loops/bin/loopctl
+++ b/loops/bin/loopctl
@@ -29,7 +29,7 @@ TEMPLATE="$REPO_ROOT/loops/templates/loop-sandbox.yaml"
 
 die() { echo "loopctl: $*" >&2; exit 1; }
 
-image_from_template() { grep -oE 'zot\.phillips-homelab\.net/loop-dev:[a-z0-9]+' "$TEMPLATE" | head -1; }
+image_from_template() { grep -oE 'zot\.phillips-homelab\.net/loop-dev:[a-zA-Z0-9._-]+' "$TEMPLATE" | head -1; }
 
 # Run $2 (bash script text) in a short-lived in-cluster pod named loopctl-$1-*
 # with loop-secrets in env. Prints the pod's logs. Optional $3 = extra pod


### PR DESCRIPTION
One-character-class fix: `[a-z0-9]+` stops at the first hyphen, so the `260808-reviewwait` loop-dev tag truncated to `loop-dev:260808` (nonexistent) and every loopctl helper pod (pr/answer/merge/reap) has been ImagePullBackOff-with-mute-output since that image shipped. Found while filing tycho PR #215; verified fixed by filing that PR through the patched script.

Note: the loud-failure hardening for mute helper pods is still queued — this fixes the outage, not the muteness.

https://claude.ai/code/session_014bAhhgwJi6rLyHwmF7kd6k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image tags used with templates now support uppercase letters, periods, underscores, and hyphens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->