### PR TITLE
tycho: bump COMBINE_IMAGE to 6bc387e (blind-solve, parity-fixed)

### DIFF
--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -107,7 +107,7 @@ spec:
               # feature was live everywhere except the container that
               # reads it (tycho #154). Bump this whenever combine/
               # changes, and check it moved after ArgoCD syncs.
-              value: "zot.phillips-homelab.net/tycho-combine:e7d36e2"
+              value: "zot.phillips-homelab.net/tycho-combine:6bc387e"
             # ADR 0010 outbound delivery. Both are REQUIRED: the
             # operator fails closed at startup without them, so this
             # block must land in the same commit as the image bump.


### PR DESCRIPTION
Deploys tycho #215: constrained catalog plate-solve for zero-solve raw sessions, conductor parity fix included (real S30 det(CD)>0). Truth-tested against real archive frames: recovered device WCS to 2.1–2.4 arcsec. Image pushed at this tag before merge.

https://claude.ai/code/session_014bAhhgwJi6rLyHwmF7kd6k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Combine service to use a newer container image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->