### PR TITLE
loops: ENGINE=codex lane (Codex review loops on the ChatGPT-sub budget)

### DIFF
--- a/loops/bin/loopctl
+++ b/loops/bin/loopctl
@@ -2,7 +2,7 @@
 # loopctl — conductor verbs for the loop rig. Deterministic single commands
 # so the conductor never improvises multi-step kubectl.
 #
-#   loopctl spawn <name> <owner/repo> --spec <file> [--max-iter N] [--image TAG]
+#   loopctl spawn <name> <owner/repo> --spec <file> [--max-iter N] [--image TAG] [--engine claude|codex] [--gate CMD]
 #   loopctl status [name]
 #   loopctl logs <name> [-f]
 #   loopctl answer <name> <json-or-text>
@@ -61,17 +61,23 @@ helper_pod() {
 }
 
 cmd_spawn() {
-  local name=${1:?usage: loopctl spawn <name> <owner/repo> --spec <file> [--max-iter N] [--image TAG]}
+  local name=${1:?usage: loopctl spawn <name> <owner/repo> --spec <file> [--max-iter N] [--image TAG] [--engine claude|codex] [--gate CMD]}
   local repo=${2:?owner/repo required}; shift 2
-  local spec="" max_iter=15 image=""
+  local spec="" max_iter=15 image="" engine=claude gate=""
   while [ $# -gt 0 ]; do case $1 in
     --spec) spec=$2; shift 2;; --max-iter) max_iter=$2; shift 2;; --image) image=$2; shift 2;;
+    --engine) engine=$2; shift 2;; --gate) gate=$2; shift 2;;
     *) die "unknown flag $1";;
   esac; done
   [ -f "$spec" ] || die "--spec <file> required and must exist"
+  case "$engine" in claude|codex) ;; *) die "--engine must be claude or codex";; esac
+  if [ "$engine" = codex ]; then
+    kubectl -n "$NS" get secret codex-auth >/dev/null 2>&1 \
+      || die "--engine codex needs secret codex-auth (kubectl -n $NS create secret generic codex-auth --from-file=CODEX_AUTH_JSON=\$HOME/.codex/auth.json)"
+  fi
   kubectl -n "$NS" get sandbox "$name" >/dev/null 2>&1 && die "sandbox '$name' already exists (reap it first)"
 
-  LOOP=$name REPO=$repo MAX_ITER=$max_iter python3 - "$TEMPLATE" <<'EOF' | kubectl apply -f - >/dev/null
+  LOOP=$name REPO=$repo MAX_ITER=$max_iter ENGINE=$engine python3 - "$TEMPLATE" <<'EOF' | kubectl apply -f - >/dev/null
 import os, re, sys
 t = open(sys.argv[1]).read()
 print(re.sub(r'\$\{(\w+)\}', lambda m: os.environ[m.group(1)], t))
@@ -79,6 +85,10 @@ EOF
   if [ -n "$image" ]; then
     kubectl -n "$NS" patch sandbox "$name" --type=json \
       -p "[{\"op\":\"replace\",\"path\":\"/spec/podTemplate/spec/containers/0/image\",\"value\":\"zot.phillips-homelab.net/loop-dev:${image}\"}]" >/dev/null
+  fi
+  if [ -n "$gate" ]; then
+    kubectl -n "$NS" patch sandbox "$name" --type=json \
+      -p "[{\"op\":\"add\",\"path\":\"/spec/podTemplate/spec/containers/0/env/-\",\"value\":{\"name\":\"GATE_CMD\",\"value\":$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$gate")}}]" >/dev/null
   fi
   echo "spawned sandbox/$name; waiting for pod..."
   kubectl -n "$NS" wait --for=condition=Ready "pod/$name" --timeout=300s >/dev/null

--- a/loops/bin/loopctl
+++ b/loops/bin/loopctl
@@ -77,7 +77,8 @@ cmd_spawn() {
   fi
   kubectl -n "$NS" get sandbox "$name" >/dev/null 2>&1 && die "sandbox '$name' already exists (reap it first)"
 
-  LOOP=$name REPO=$repo MAX_ITER=$max_iter ENGINE=$engine python3 - "$TEMPLATE" <<'EOF' | kubectl apply -f - >/dev/null
+  LOOP=$name REPO=$repo MAX_ITER=$max_iter ENGINE=$engine GATE="${gate:-make build test lint}" \
+    python3 - "$TEMPLATE" <<'EOF' | kubectl apply -f - >/dev/null
 import os, re, sys
 t = open(sys.argv[1]).read()
 print(re.sub(r'\$\{(\w+)\}', lambda m: os.environ[m.group(1)], t))
@@ -85,10 +86,6 @@ EOF
   if [ -n "$image" ]; then
     kubectl -n "$NS" patch sandbox "$name" --type=json \
       -p "[{\"op\":\"replace\",\"path\":\"/spec/podTemplate/spec/containers/0/image\",\"value\":\"zot.phillips-homelab.net/loop-dev:${image}\"}]" >/dev/null
-  fi
-  if [ -n "$gate" ]; then
-    kubectl -n "$NS" patch sandbox "$name" --type=json \
-      -p "[{\"op\":\"add\",\"path\":\"/spec/podTemplate/spec/containers/0/env/-\",\"value\":{\"name\":\"GATE_CMD\",\"value\":$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$gate")}}]" >/dev/null
   fi
   echo "spawned sandbox/$name; waiting for pod..."
   kubectl -n "$NS" wait --for=condition=Ready "pod/$name" --timeout=300s >/dev/null
@@ -144,6 +141,21 @@ cmd_answer() {
 
 cmd_pause()  { kubectl -n "$NS" patch sandbox "${1:?name}" --type=merge -p '{"spec":{"operatingMode":"Suspended"}}' && echo "paused (PVC retained)"; }
 cmd_resume() { kubectl -n "$NS" patch sandbox "${1:?name}" --type=merge -p '{"spec":{"operatingMode":"Running"}}' && echo "resumed"; }
+
+# cat: read a file off a loop's workspace PVC, running or reaped-not-yet-
+# deleted -- the forensics verb the codex-smoke debugging was missing
+# (a Completed pod is not exec-able, and reap deletes the PVC without
+# ever showing the iteration logs).
+cmd_cat() {
+  local name=${1:?usage: loopctl cat <name> <path-relative-to-workspace>}
+  local path=${2:?path required}
+  kubectl -n "$NS" get pvc "workspace-$name" >/dev/null 2>&1 || die "no PVC workspace-$name"
+  helper_pod cat "cat /ws/${path} 2>&1 || echo \"(cannot read /ws/${path})\"" \
+      "  volumes:
+  - name: ws
+    persistentVolumeClaim: {claimName: workspace-$name}" \
+      "    volumeMounts: [{name: ws, mountPath: /ws}]"
+}
 
 cmd_reap() {
   local name=${1:?usage: loopctl reap <name> [--no-pr]}
@@ -252,6 +264,7 @@ case $cmd in
   pause) cmd_pause "$@";;
   resume) cmd_resume "$@";;
   reap) cmd_reap "$@";;
+  cat) cmd_cat "$@";;
   pr) cmd_pr "$@";;
   merge) cmd_merge "$@";;
   release) cmd_release "$@";;

--- a/loops/images/dev/Dockerfile
+++ b/loops/images/dev/Dockerfile
@@ -34,6 +34,10 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     rm -rf /var/lib/apt/lists/* && \
     corepack enable
 
+# OpenAI Codex CLI: the harness's ENGINE=codex lane (review-shaped
+# loops on the ChatGPT-sub budget, separate from the claude token).
+RUN npm install -g @openai/codex && codex --version
+
 # kubectl (only used to patch the loop's own Sandbox state label)
 RUN KUBECTL_VERSION="$(curl -fsSL https://dl.k8s.io/release/stable.txt)" && \
     curl -fsSL -o /usr/local/bin/kubectl \

--- a/loops/images/dev/harness.sh
+++ b/loops/images/dev/harness.sh
@@ -149,9 +149,13 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
   if [ "$ENGINE" = codex ]; then
     # danger-full-access mirrors --dangerously-skip-permissions: the
     # gVisor sandbox pod IS the isolation boundary, same as claude.
-    # cwd=$WS so /workspace files and repo/ are all in reach; prompt on
-    # stdin ('-'). Reasoning high: these are review-shaped loops.
-    (cd "$WS" && codex exec \
+    # cwd must be the REPO (codex's trust check refuses a non-git cwd;
+    # first smoke died on exactly that from $WS) and the check is
+    # skipped outright -- full-access mode reaches the $WS files
+    # regardless of cwd. Prompt on stdin ('-'); reasoning high: these
+    # are review-shaped loops.
+    (cd "$REPO_DIR" && codex exec \
+      --skip-git-repo-check \
       --sandbox danger-full-access \
       -c model_reasoning_effort=high \
       - <<<"$PROMPT") \

--- a/loops/images/dev/harness.sh
+++ b/loops/images/dev/harness.sh
@@ -16,11 +16,29 @@ set -uo pipefail
 
 : "${LOOP_NAME:?LOOP_NAME required (sandbox name)}"
 : "${REPO_URL:?REPO_URL required (Forgejo clone URL, no creds)}"
-: "${CLAUDE_CODE_OAUTH_TOKEN:?CLAUDE_CODE_OAUTH_TOKEN required (claude setup-token)}"
 : "${FORGEJO_TOKEN:?FORGEJO_TOKEN required}"
-# Pro-subscription auth: an API key would take precedence over the OAuth
-# token and break auth if both are set.
-unset ANTHROPIC_API_KEY
+# ENGINE selects the model CLI an iteration runs: claude (default,
+# Casey's Pro OAuth token — ONE such loop at a time, shared with his
+# interactive use) or codex (OpenAI Codex CLI on the ChatGPT-sub auth —
+# a separate budget, so a codex loop may run alongside a claude one;
+# Plus-tier limits fit short review-shaped loops, not 15-iteration
+# builds).
+ENGINE="${ENGINE:-claude}"
+case "$ENGINE" in
+  claude)
+    : "${CLAUDE_CODE_OAUTH_TOKEN:?CLAUDE_CODE_OAUTH_TOKEN required (claude setup-token)}"
+    # Pro-subscription auth: an API key would take precedence over the
+    # OAuth token and break auth if both are set.
+    unset ANTHROPIC_API_KEY
+    ;;
+  codex)
+    : "${CODEX_AUTH_JSON:?CODEX_AUTH_JSON required (contents of ~/.codex/auth.json; secret codex-auth)}"
+    mkdir -p "$HOME/.codex"
+    printf '%s' "$CODEX_AUTH_JSON" > "$HOME/.codex/auth.json"
+    chmod 600 "$HOME/.codex/auth.json"
+    ;;
+  *) echo "unknown ENGINE '$ENGINE' (claude|codex)" >&2; exit 2 ;;
+esac
 BRANCH="${BRANCH:-loop/${LOOP_NAME}}"
 MAX_ITER="${MAX_ITER:-30}"
 GATE_CMD="${GATE_CMD:-make build test lint}"
@@ -128,10 +146,22 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
   drain_inbox
 
   head_before=$(git -C "$REPO_DIR" rev-parse HEAD 2>/dev/null || echo none)
-  claude -p "$PROMPT" \
-    --dangerously-skip-permissions \
-    --add-dir "$WS" \
-    > "$WS/.iter-${iter}.log" 2>&1
+  if [ "$ENGINE" = codex ]; then
+    # danger-full-access mirrors --dangerously-skip-permissions: the
+    # gVisor sandbox pod IS the isolation boundary, same as claude.
+    # cwd=$WS so /workspace files and repo/ are all in reach; prompt on
+    # stdin ('-'). Reasoning high: these are review-shaped loops.
+    (cd "$WS" && codex exec \
+      --sandbox danger-full-access \
+      -c model_reasoning_effort=high \
+      - <<<"$PROMPT") \
+      > "$WS/.iter-${iter}.log" 2>&1
+  else
+    claude -p "$PROMPT" \
+      --dangerously-skip-permissions \
+      --add-dir "$WS" \
+      > "$WS/.iter-${iter}.log" 2>&1
+  fi
   agent_rc=$?
   log "agent exited rc=${agent_rc} ($(wc -l < "$WS/.iter-${iter}.log") log lines)"
 

--- a/loops/templates/loop-sandbox.yaml
+++ b/loops/templates/loop-sandbox.yaml
@@ -32,7 +32,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: loop
-        image: zot.phillips-homelab.net/loop-dev:260808-reviewwait
+        image: zot.phillips-homelab.net/loop-dev:260809-codex
         envFrom:
         - secretRef:
             name: loop-secrets

--- a/loops/templates/loop-sandbox.yaml
+++ b/loops/templates/loop-sandbox.yaml
@@ -36,6 +36,13 @@ spec:
         envFrom:
         - secretRef:
             name: loop-secrets
+        # codex-auth exists only if the conductor has seeded it
+        # (kubectl -n loops create secret generic codex-auth
+        #    --from-file=CODEX_AUTH_JSON=$HOME/.codex/auth.json);
+        # optional so claude-engine loops never depend on it.
+        - secretRef:
+            name: codex-auth
+            optional: true
         env:
         - name: LOOP_NAME
           value: ${LOOP}
@@ -45,6 +52,8 @@ spec:
           value: http://forgejo-http.forgejo.svc.cluster.local:3000/loop-bot/memory.git
         - name: MAX_ITER
           value: "${MAX_ITER}"
+        - name: ENGINE
+          value: ${ENGINE}
         volumeMounts:
         - name: workspace
           mountPath: /workspace

--- a/loops/templates/loop-sandbox.yaml
+++ b/loops/templates/loop-sandbox.yaml
@@ -32,7 +32,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: loop
-        image: zot.phillips-homelab.net/loop-dev:260809-codex
+        image: zot.phillips-homelab.net/loop-dev:260809-codex2
         envFrom:
         - secretRef:
             name: loop-secrets
@@ -54,6 +54,13 @@ spec:
           value: "${MAX_ITER}"
         - name: ENGINE
           value: ${ENGINE}
+        # GATE_CMD must be set at pod creation: a patch after apply
+        # races the already-started pod and silently never applies
+        # (the first codex smoke ran the full default gate for exactly
+        # this reason). loopctl substitutes the harness default when
+        # --gate is not given.
+        - name: GATE_CMD
+          value: "${GATE}"
         volumeMounts:
         - name: workspace
           mountPath: /workspace


### PR DESCRIPTION
Adds a second engine to the loop rig: `loopctl spawn --engine codex --gate 'test -s /workspace/repo/REVIEW.md'` runs iterations through OpenAI's Codex CLI (high reasoning) instead of `claude -p`, authed from a `codex-auth` secret seeded off the laptop's `~/.codex/auth.json`. Separate budget from the Claude Pro token, so one codex review loop can run beside the one claude build loop. Image `loop-dev:260809-codex` (adds `@openai/codex`) pushed before this merges; template bumped.

Validated by today's Sol review: 10/10 verified findings including an alpha-blocker our own audit missed. Known tradeoff documented in the commit: in-pod token refresh can stale the seeded secret.

Smoke test to follow before merge (spawn a 2-iteration codex review loop from this branch's loopctl).

https://claude.ai/code/session_014bAhhgwJi6rLyHwmF7kd6k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running loops with either Claude or OpenAI Codex.
  * Added optional gate commands to validate each loop iteration.
  * Added `loopctl cat` for reading workspace files from a loop.
  * Development environments now include the Codex CLI.
* **Bug Fixes**
  * Added engine-specific authentication and validation, including required Codex credentials for Codex runs.
  * Improved loop setup with configurable engine and gate settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->