### PR TITLE
tycho: bump operator to 87a04c7 (combine-source-identity)

### DIFF
--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -15,4 +15,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "3f41dd5"
+    newTag: "87a04c7"

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -15,4 +15,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "87a04c7"
+    newTag: "87a04c7c"


### PR DESCRIPTION
Deploys tycho #216: source-qualified combine Job names, owner-verified Job adoption, (sourceID, sessionID, revision) master bookkeeping — fixes the deterministic cross-member collision on the alpha's shared-target scenario. Image pushed at this tag before merge. Upgrade note: any in-flight Jobs under old-style names are treated as stale; nothing is Combining right now, so the window is clean.

https://claude.ai/code/session_014bAhhgwJi6rLyHwmF7kd6k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Tycho operator to a newer container image version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->