### PR TITLE
tycho: deploy operator-survivability (operator+gateway 8fd78255, /readyz, NTFY_URL)

### DIFF
--- a/gitops/tools/apps/tycho/gateway/deployment.yaml
+++ b/gitops/tools/apps/tycho/gateway/deployment.yaml
@@ -127,9 +127,19 @@ spec:
                 secretKeyRef:
                   name: tycho-config
                   key: SITE_API_TOKEN
+            # Optional best-effort paging for dead-lettered events
+            # (operator-survivability item 2) — the tailnet ntfy topic
+            # Casey already subscribes to for the loop rig; ntfy is the
+            # paging layer, the DLQ record stays the source of truth.
+            - name: NTFY_URL
+              value: "https://ntfy.tail852f61.ts.net/loops"
           readinessProbe:
+            # /readyz actually checks Postgres/Garage/NATS (operator-
+            # survivability item 3) — readiness ONLY, so a dependency
+            # outage sheds traffic without crash-looping the pod;
+            # liveness stays on the unconditional /healthz.
             httpGet:
-              path: /healthz
+              path: /readyz
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-gateway
-    newTag: "66ea3d9"
+    newTag: "8fd78255"

--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -212,12 +212,15 @@ spec:
             # old ceiling was arbitrary, not a capacity constraint.
             - name: COMBINE_MEMORY_LIMIT
               value: "12Gi"
-            # NTFY_URL is optional: a full ntfy topic URL for
-            # best-effort session-close/combine-result notifications.
-            # Unset (the default — no value here) disables
-            # notifications entirely; there's no real topic to point at
-            # yet, so it's deliberately left unset rather than set to a
-            # placeholder that would silently start posting somewhere.
+            # NTFY_URL: best-effort notifications (session close,
+            # combine results, and — operator-survivability — Stalled
+            # combines, dead-lettered events, source disconnect/
+            # reconnect). Set 2026-08-10 when the survivability work
+            # landed: leaving it unset would have deployed the entire
+            # alerting layer dark. The tailnet ntfy topic Casey already
+            # subscribes to for the loop rig.
+            - name: NTFY_URL
+              value: "https://ntfy.tail852f61.ts.net/loops"
             # - name: NTFY_URL
             #   value: "https://ntfy.sh/your-topic-here"
             # WEATHER_ENABLED is the tier-2 sky-conditions kill-switch

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -15,4 +15,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "87a04c7c"
+    newTag: "8fd78255"


### PR DESCRIPTION
Deploys tycho #217. Both images pushed at this tag before merge (build in flight, merge follows push verification). Notable beyond the pins: gateway readinessProbe → /readyz (real Postgres/Garage/NATS checks; liveness untouched), and NTFY_URL is now SET on operator+gateway pointing at the existing ntfy loops topic — it was deliberately unset before ('no real topic yet'), which today would have deployed the survivability alerting dark. Veto the topic choice if you want a dedicated one (any topic name works on first publish; your subscription is the constraint).

https://claude.ai/code/session_014bAhhgwJi6rLyHwmF7kd6k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional dead-letter event notifications through NTFY.
  * Configured operator notifications for the loop-rig topic.

* **Bug Fixes**
  * Improved gateway readiness checks to verify service dependencies, while preserving separate liveness checks.

* **Maintenance**
  * Updated the gateway and operator container images to newer versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->