### PR TITLE
tycho: bump operator to 0032f607 (upload-honesty containment)

### DIFF
--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -15,4 +15,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "8fd78255"
+    newTag: "0032f607"


### PR DESCRIPTION
Deploys tycho #218's operator half: monotonic sub_count guard + strict-growth Recombining. The client correctness half rides v0.9.6. Image pushed+verified at this tag.

https://claude.ai/code/session_014bAhhgwJi6rLyHwmF7kd6k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Tycho operator to a newer container image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->