### PR TITLE
tychofleet: deploy a2ea72c (setup-screen download unify)

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:fa3dbaf
+          image: zot.phillips-homelab.net/tychofleet:a2ea72c
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Deploys tychofleet #79. Setup/re-enrol screens now serve the current client from the public /dl/ manifest (one source of truth); stale Garage clients/ release path retired. Config download stays session-gated. Image pushed+verified. Render reviewed (shows v0.9.6, one visual system).

https://claude.ai/code/session_014bAhhgwJi6rLyHwmF7kd6k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the TychoFleet application to a newer container version.
  * This update includes the latest available application changes and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->