### PR TITLE
tycho: dedicated tycho-alerts ntfy topic (split from /loops)

### DIFF
--- a/gitops/tools/apps/tycho/gateway/deployment.yaml
+++ b/gitops/tools/apps/tycho/gateway/deployment.yaml
@@ -132,7 +132,7 @@ spec:
             # Casey already subscribes to for the loop rig; ntfy is the
             # paging layer, the DLQ record stays the source of truth.
             - name: NTFY_URL
-              value: "https://ntfy.tail852f61.ts.net/loops"
+              value: "https://ntfy.tail852f61.ts.net/tycho-alerts"
           readinessProbe:
             # /readyz actually checks Postgres/Garage/NATS (operator-
             # survivability item 3) — readiness ONLY, so a dependency

--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -220,7 +220,7 @@ spec:
             # alerting layer dark. The tailnet ntfy topic Casey already
             # subscribes to for the loop rig.
             - name: NTFY_URL
-              value: "https://ntfy.tail852f61.ts.net/loops"
+              value: "https://ntfy.tail852f61.ts.net/tycho-alerts"
             # - name: NTFY_URL
             #   value: "https://ntfy.sh/your-topic-here"
             # WEATHER_ENABLED is the tier-2 sky-conditions kill-switch


### PR DESCRIPTION
Operator + gateway alerts now post to ntfy topic tycho-alerts instead of sharing /loops with the loop rig, so alpha member issues are distinct and noticeable. Subscribe to https://ntfy.tail852f61.ts.net/tycho-alerts.

https://claude.ai/code/session_014bAhhgwJi6rLyHwmF7kd6k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Tycho alert notifications to use the dedicated `tycho-alerts` destination instead of the shared `loops` topic.
  * Applied the notification routing update to both gateway and operator components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->