### PR TITLE
deploy: gdrive delivery adapter (tycho #227 → edcc46c)

### DIFF
--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -118,7 +118,7 @@ spec:
             # or the adapter changes — same drift hazard as
             # COMBINE_IMAGE above.
             - name: DELIVERY_JOB_IMAGE
-              value: "zot.phillips-homelab.net/tycho-deliver:3f41dd5"
+              value: "zot.phillips-homelab.net/tycho-deliver:edcc46c"
             # SA delivery Job pods run as (rbac.yaml's tycho-deliver:
             # get deliveries/deliverytargets, update deliveries/status,
             # nothing else). REQUIRED, fail-closed (tycho #197).

--- a/gitops/tools/apps/tycho/operator/fleet.tycho.dev_deliverytargets.yaml
+++ b/gitops/tools/apps/tycho/operator/fleet.tycho.dev_deliverytargets.yaml
@@ -96,6 +96,7 @@ spec:
                 - fake
                 - s3
                 - crowdsky
+                - gdrive
                 type: string
               artifactClasses:
                 description: |-

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -15,4 +15,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "0032f607"
+    newTag: "edcc46c"


### PR DESCRIPTION
Deploys the merged **gdrive delivery adapter** (loop-bot/tycho #227) — dual-reviewed (conductor + Sol/codex), ledger-authoritative, with the dup-on-retry (Finding 1) and 401-recovery (Finding 3) fixes landed.

**Changes** (all `gitops/tools/apps/tycho/operator/`):
- `kustomization.yaml`: `tycho-operator` newTag `3f41dd5` → `edcc46c`
- `deployment.yaml`: `DELIVERY_JOB_IMAGE` → `tycho-deliver:edcc46c`
- `fleet.tycho.dev_deliverytargets.yaml`: adapterKind enum + `gdrive` (without it the API server rejects a `adapterKind: gdrive` DeliveryTarget)

**Images** built + pushed to zot at `edcc46c` (`tycho-operator`, `tycho-deliver`), both verified pullable.

**Rollout:** merging restarts the operator (new env/tag); delivery Jobs it spawns then use the new `tycho-deliver` image. After merge I wire a `gdrive` DeliveryTarget at the *Tycho Delivery Test* folder and watch a raw sub land.

https://claude.ai/code/session_014bAhhgwJi6rLyHwmF7kd6k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Google Drive as a supported delivery adapter.

* **Updates**
  * Updated the Tycho operator and delivery job images to a newer release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->