### PR TITLE
deploy: combine-jobs churn/GC fix (tycho #228 → e95f17a4)

### DIFF
--- a/gitops/tools/apps/tycho/operator/fleet.tycho.dev_fleetmasters.yaml
+++ b/gitops/tools/apps/tycho/operator/fleet.tycho.dev_fleetmasters.yaml
@@ -173,6 +173,22 @@ spec:
                     sessionID:
                       description: SessionID is the contributing session's ImagingSessionSpec.SessionID.
                       type: string
+                    sourceID:
+                      description: |-
+                        SourceID is the contributing session's ImagingSessionSpec.SourceID
+                        -- optional so a status persisted before this field existed keeps
+                        deserializing (a zero-value SourceID); sameSessionRevisionSet
+                        treats any such legacy entry as stale (see that function's doc
+                        comment), so it triggers exactly one rebuild and then tracks
+                        correctly off this field from then on, same "rebuild once, then
+                        track correctly" rule the sibling CombinedSessions-absent case
+                        already established. Without this field, two different sources
+                        sharing one bare SessionID (same slugify(target)-YYYY-MM-DD, the
+                        pooled-target alpha's primary shape) collapse onto the same map
+                        entry in sameSessionRevisionSet, and a master whose contributing
+                        sources' revisions genuinely differ can never compare equal to
+                        its own just-spawned candidate set -- an endless rebuild loop.
+                      type: string
                   required:
                   - revision
                   - sessionID
@@ -228,6 +244,13 @@ spec:
                 items:
                   type: string
                 type: array
+              fingerprint:
+                description: |-
+                  Fingerprint mirrors TargetMasterStatus.Fingerprint: combinejob.
+                  Fingerprint's hash of the current Revision's actual combinable
+                  content, spanning every contributing source. See that field's
+                  doc comment for the full rationale (combine-jobs-resilience).
+                type: string
               masterCompletedAt:
                 description: |-
                   MasterCompletedAt is when the current Revision's Job finished
@@ -260,6 +283,7 @@ spec:
                 - Combining
                 - Done
                 - Failed
+                - Stalled
                 type: string
               resultKey:
                 description: |-
@@ -278,6 +302,11 @@ spec:
                   already completed. Mirrors TargetMasterStatus.Revision.
                 format: int32
                 type: integer
+              stalledReason:
+                description: |-
+                  StalledReason explains why Phase is Stalled, mirroring
+                  ImagingSessionStatus.StalledReason.
+                type: string
             type: object
         type: object
     served: true

--- a/gitops/tools/apps/tycho/operator/fleet.tycho.dev_imagingsessions.yaml
+++ b/gitops/tools/apps/tycho/operator/fleet.tycho.dev_imagingsessions.yaml
@@ -222,6 +222,17 @@ spec:
                   spawned to combine. Compared against a later close event's
                   sub_count to detect the session growing past what the latest
                   revision covered.
+
+                  Relied on as append-only (monotonic non-decreasing, same as
+                  SubCount) by combinejob.Fingerprint, which treats "same
+                  (SourceID, SessionID) identity + same CombinedSubCount" as "same
+                  combinable content" -- a cheap proxy that only holds because a
+                  session's subs are never removed and replaced, only added. If a
+                  future change ever lets this count regress (e.g. discarding a
+                  bad sub and re-adding a correction, or a manual CR edit), a
+                  same-count-but-different-membership set would fingerprint
+                  identically and Fingerprint would silently under-fire, skipping
+                  a combine that genuinely needed to run.
                 format: int32
                 type: integer
               jobStartedPublishedRevision:
@@ -246,6 +257,7 @@ spec:
                 - Done
                 - Failed
                 - Unsalvageable
+                - Stalled
                 type: string
               resultKeys:
                 description: |-
@@ -265,8 +277,23 @@ spec:
                   same revision keep hitting the same deterministic name.
                 format: int32
                 type: integer
+              stalledReason:
+                description: |-
+                  StalledReason explains why Phase is Stalled -- e.g. the missing
+                  combine Job's name -- legible to a human via kubectl, mirroring
+                  FailureReason-shaped fields elsewhere (DeliveryTargetStatus.
+                  RefusalReason) rather than requiring a log dive. Empty whenever
+                  Phase is not Stalled; not cleared retroactively once Phase moves
+                  on, same "last reason recorded" convention as
+                  CombineCompletedAt.
+                type: string
               subCount:
-                description: SubCount is the accepted-sub count as of close.
+                description: |-
+                  SubCount is the accepted-sub count as of close. Monotonic
+                  non-decreasing through the public path (sessionclose.go pins it
+                  to the last recorded value rather than ever storing a
+                  regression) -- combinejob.Fingerprint's dedupe correctness
+                  depends on this invariant holding (see CombinedSubCount below).
                 format: int32
                 type: integer
             type: object

--- a/gitops/tools/apps/tycho/operator/fleet.tycho.dev_targetmasters.yaml
+++ b/gitops/tools/apps/tycho/operator/fleet.tycho.dev_targetmasters.yaml
@@ -197,6 +197,22 @@ spec:
                     sessionID:
                       description: SessionID is the contributing session's ImagingSessionSpec.SessionID.
                       type: string
+                    sourceID:
+                      description: |-
+                        SourceID is the contributing session's ImagingSessionSpec.SourceID
+                        -- optional so a status persisted before this field existed keeps
+                        deserializing (a zero-value SourceID); sameSessionRevisionSet
+                        treats any such legacy entry as stale (see that function's doc
+                        comment), so it triggers exactly one rebuild and then tracks
+                        correctly off this field from then on, same "rebuild once, then
+                        track correctly" rule the sibling CombinedSessions-absent case
+                        already established. Without this field, two different sources
+                        sharing one bare SessionID (same slugify(target)-YYYY-MM-DD, the
+                        pooled-target alpha's primary shape) collapse onto the same map
+                        entry in sameSessionRevisionSet, and a master whose contributing
+                        sources' revisions genuinely differ can never compare equal to
+                        its own just-spawned candidate set -- an endless rebuild loop.
+                      type: string
                   required:
                   - revision
                   - sessionID
@@ -212,6 +228,25 @@ spec:
                 items:
                   type: string
                 type: array
+              fingerprint:
+                description: |-
+                  Fingerprint is combinejob.Fingerprint's hash of the current
+                  Revision's actual combinable content -- each contributing
+                  session's identity paired with its CombinedSubCount (not the raw
+                  Revision counter, which bumps on any recombine including one that
+                  leaves CombinedSubCount unchanged) plus the combine Job's own
+                  parameters/algorithm version. ensureCombine's dedupe treats an
+                  unchanged Fingerprint as a true no-op trigger and skips spawning a
+                  new Job, in addition to (not instead of) the existing
+                  CombinedSessions/sameSessionRevisionSet check -- see
+                  combinejob.Fingerprint's doc comment for why this is what keeps
+                  the churn incident's named trigger (a Seestar re-solving/
+                  rewriting an already-archived sub) from forcing a master rebuild.
+                  Empty for a TargetMaster written before this field existed, or
+                  one that has never yet combined -- ensureCombine then relies on
+                  CombinedSessions alone, exactly as it did before this field
+                  existed, until the next successful spawn stamps a real value.
+                type: string
               masterCompletedAt:
                 description: |-
                   MasterCompletedAt is when the current Revision's master Job
@@ -245,6 +280,7 @@ spec:
                 - Combining
                 - Done
                 - Failed
+                - Stalled
                 type: string
               resultKey:
                 description: |-
@@ -263,6 +299,11 @@ spec:
                   2, ...), mirroring ImagingSessionStatus.Revision (#33).
                 format: int32
                 type: integer
+              stalledReason:
+                description: |-
+                  StalledReason explains why Phase is Stalled, mirroring
+                  ImagingSessionStatus.StalledReason.
+                type: string
             type: object
         type: object
     served: true

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -15,4 +15,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "edcc46c"
+    newTag: "e95f17a4"


### PR DESCRIPTION
Deploys the **combine-jobs churn/GC fix** (loop-bot/tycho #228) — dual-reviewed (conductor + Sol/codex, Sol's Finding-1 retry-budget bug fixed). Stops the m-13 re-combine churn that filled `jobs.batch` (100/100 incident) and, tonight, starved delivery (held both delivery slots so the gdrive backfill couldn't run).

**Changes** (`gitops/tools/apps/tycho/operator/`):
- `kustomization.yaml`: `tycho-operator` newTag `edcc46c` → `e95f17a4`
- CRDs `fleetmasters` / `targetmasters` / `imagingsessions`: add the `fingerprint` (+ `sourceID`) status fields. **Required** — without the schema the API server prunes `status.fingerprint`, the idempotency gate reads empty, and the churn continues.

**Operator-only** — no `tycho-combine` image change. Image built + pushed to zot at `e95f17a4`, verified pullable.

**Rollout:** operator restarts on `e95f17a4`; the fingerprint gate + Job GC take effect → m-13 stops re-combining (r733→ halts), `jobs.batch` stays low without the janitor, delivery slots free up.

**Follow-up after this deploys:** the `tycho-job-janitor` CronJob becomes redundant and can be removed.

https://claude.ai/code/session_014bAhhgwJi6rLyHwmF7kd6k