### PR TITLE
deploy: per-session zip bundling (tycho #229 → 09ad13a0)

### DIFF
--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -118,7 +118,7 @@ spec:
             # or the adapter changes — same drift hazard as
             # COMBINE_IMAGE above.
             - name: DELIVERY_JOB_IMAGE
-              value: "zot.phillips-homelab.net/tycho-deliver:edcc46c"
+              value: "zot.phillips-homelab.net/tycho-deliver:09ad13a0"
             # SA delivery Job pods run as (rbac.yaml's tycho-deliver:
             # get deliveries/deliverytargets, update deliveries/status,
             # nothing else). REQUIRED, fail-closed (tycho #197).

--- a/gitops/tools/apps/tycho/operator/fleet.tycho.dev_deliverytargets.yaml
+++ b/gitops/tools/apps/tycho/operator/fleet.tycho.dev_deliverytargets.yaml
@@ -139,6 +139,27 @@ spec:
                   delivery -- a large backfill is not special-cased, only bounded
                   by the member's own byte allowance (DeliveryQuota).
                 type: boolean
+              bundle:
+                default: false
+                description: |-
+                  Bundle opts this target into per-session zip delivery: instead of
+                  SendFile-ing each matching artifact loose, the deliver Job streams
+                  the session's artifacts into a SINGLE zip (STORE method, built on
+                  a scratch disk volume, never in memory) and delivers that one
+                  file. Default false -- loose-file delivery, today's shipped
+                  behavior, is unchanged when this is unset.
+
+                  Delta-safety (do not defeat this): a bundle Delivery is only ever
+                  built for a TERMINAL session (Done/Unsalvageable) and delivered
+                  EXACTLY ONCE -- a re-arm (master-rebuild, resync, the m-13-style
+                  churn) must find the zip already at the destination and skip
+                  before re-fetching or re-zipping anything. Unlike the loose-file
+                  model, a remote zip cannot be incrementally updated, so this flag
+                  is not meant for a target whose session keeps growing after this
+                  target first delivers it. Per-target/campaign AGGREGATE zips
+                  (which would grow across sessions) are explicitly out of scope --
+                  this flag only ever produces one zip per (session, target).
+                type: boolean
               consentRecord:
                 description: |-
                   ConsentRecord captures what the member was shown before

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -15,4 +15,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "e95f17a4"
+    newTag: "09ad13a0"


### PR DESCRIPTION
Deploys **per-session ZIP bundling** (loop-bot/tycho #229) — dual-reviewed (conductor + Sol/codex), all 3 of Sol's findings fixed (Phase=Committing re-arm, ledger metering, resumable recovery budget).

Opt-in `bundle: true` on a DeliveryTarget delivers a completed session's subs as one delta-safe `.zip` (built on scratch disk, STORE, gdrive resumable upload for multi-GB), instead of loose files. Loose-file delivery is byte-for-byte unchanged.

**Changes** (`gitops/tools/apps/tycho/operator/`):
- `kustomization.yaml`: `tycho-operator` newTag `e95f17a4` → `09ad13a0`
- `deployment.yaml`: `DELIVERY_JOB_IMAGE` → `tycho-deliver:09ad13a0`
- `fleet.tycho.dev_deliverytargets.yaml`: + `bundle` field (else the API server prunes `spec.bundle`)

`DELIVERY_SCRATCH_SIZE` defaults to 10 Gi (enough for an m-13-scale ~5 GB zip; only mounted for bundle targets) — no env change needed.

**Images** built + pushed to zot at `09ad13a0` (`tycho-operator`, `tycho-deliver`), both verified pullable.

**Rollout:** operator restarts on the new tag; delivery Jobs it spawns use the new deliver image. Existing loose-file targets (conner, fleetsync) are unaffected; `bundle: true` is opt-in per target.

https://claude.ai/code/session_014bAhhgwJi6rLyHwmF7kd6k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional bundle delivery for terminal sessions, producing a per-session ZIP file when enabled.
  * Existing destination ZIP files are reused to prevent duplicate delivery.

* **Improvements**
  * Updated the Tycho operator and delivery job to the latest release version.

* **Limitations**
  * Aggregate and incrementally updated ZIP deliveries are not supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->