### PR TITLE
deploy: tychofleet per-campaign delivery Phase 2 (site → 30f5303)

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:a2ea72c
+          image: zot.phillips-homelab.net/tychofleet:30f5303
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Deploys **per-campaign delivery Phase 2** (loop-bot/tychofleet #80, ADR 0011) — the SITE side. Dual-reviewed (conductor + Sol/codex), Sol **GO** with all 3 fast-follows fixed.

The site now materializes a `scope: campaign` DeliveryTarget from a campaign's `campaignTargets` (RA/Dec) + `enrollments` (sources), fixes the long-standing `v1`→`v1alpha1` DeliveryTarget CR drift, and adds a per-campaign delivery admin surface. Sol verified the two critical risks correct: CR field-exactness (matches the operator CRD verbatim) and the empty-allowlist fleet-wide-leak guard (a campaign with no enrolled sources / no targets never gets an enabled CR).

**Change:** `gitops/apps/tychofleet/deployment.yaml` image `a2ea72c` → `30f5303`.

**DB migration** `0023` (additive `CREATE TABLE` + unique index, no data loss) applies automatically on pod start via `docker-entrypoint.sh`'s migrate step.

**Depends on Phase 1** (operator `644f54e8`, campaign CRD fields) — already deployed via #491, verified live (CRD `scope` field present).

**Image** built + pushed to zot at `30f5303`, verified pullable.

**After rollout:** an admin can enable delivery for a campaign → the site writes a `scope: campaign` target → the operator attributes matching sessions by coordinate → only that campaign's data delivers. Campaign scoping is live end-to-end.

https://claude.ai/code/session_014bAhhgwJi6rLyHwmF7kd6k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TychoFleet application to a newer container image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->