### PR TITLE
deploy: fix member-approve auth-key minting (tychofleet → 314cc03)

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:30f5303
+          image: zot.phillips-homelab.net/tychofleet:314cc03
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
**Unblocks member onboarding.** The Approve button failed "Minting an auth key failed" for glenn (the first real member). Root cause: the approve flow minted `tag:tycho-agent` via a legacy `TS_API_KEY` (Basic auth) that was never provisioned into the deployment.

Fix (tychofleet #81): mint **`tag:scope`** — the fleet ACL's actual member-telescope tag (owned by `tag:scope-minter`, the only tag with a gateway ACL rule) — via the **OAuth minter** (`TS_MINTER_CLIENT_ID/SECRET`, already synced and used by the `tycho.yaml` enrolment path). No new secret/env. Verified against the live tailnet: `tag:scope` mints 200, `tag:tycho-agent` 400s.

**Change:** `gitops/apps/tychofleet/deployment.yaml` image `30f5303` → `314cc03`.

Gate green: 1287 tests pass, lint clean, build OK. Image built + pushed to zot at `314cc03`, verified pullable.

**After rollout:** click Approve on glenn → mints his `tag:scope` key → member record created. Fixes it for every future member too.

https://claude.ai/code/session_014bAhhgwJi6rLyHwmF7kd6k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the TychoFleet application to a newer container release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->