### PR TITLE
deploy: add-member-directly-to-fleet admin tool (tychofleet → f864659)

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:314cc03
+          image: zot.phillips-homelab.net/tychofleet:f864659
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Deploys the **add-a-member-directly-to-a-fleet** admin tool (loop-bot/tychofleet #82).

Previously the only UI path to fleet membership was member → team → fleet, forcing a team wrapper even for a single member. This adds the direct path (the `fleet_members` table is already polymorphic — `principal_type: member` — so no schema change). On the admin page's "attach a member to a fleet" tool: pick a member + a fleet → **Add to fleet**, plus a list of direct memberships with Remove. The team path stays as the group option.

**Change:** `gitops/apps/tychofleet/deployment.yaml` image `314cc03` → `f864659`.

Gate green: 1292 tests pass (incl. 5 new), lint clean, build OK. Image built + pushed to zot at `f864659`, verified pullable.

**After rollout:** Casey uses it to add glenn + conner directly to Alpha Fleet.

https://claude.ai/code/session_014bAhhgwJi6rLyHwmF7kd6k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TychoFleet application to a newer container image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->