### PR TITLE
deploy: de-vibe the UI copy (tychofleet → a5d0225)

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:f864659
+          image: zot.phillips-homelab.net/tychofleet:a5d0225
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Deploys the **UI copy cleanup** (loop-bot/tychofleet #83). Strips ~90 instances of "design-vibe" copy across the whole site and the internal details that were leaking into user-facing text.

**What changed (copy-only, 26 files, net −44 lines):**
- Quippy/editorial taglines → plain functional copy ("Attribution is a table, not a thank-you" → dropped; "Fielded by team X" → "Contributed by team X").
- "Interim scaffolding / dies when X ships / built to be demolished" admin framing → plain admin tools.
- Not-built placeholders → a single neutral **"Coming soon"** (honest limitations preserved in plain language, never faking that something works).
- **Leaked internals removed from all rendered text:** SPEC names, ADR numbers, an env-var name (`TYCHO_GATEWAY_PUBLIC_URL`), internal function names, design screen numbers ("1f"/"1a"), and the founder's name ("ask Casey" → "ask an admin").

No logic/route/schema changes — verified by build + full test suite.

**Change:** `gitops/apps/tychofleet/deployment.yaml` image `f864659` → `a5d0225`.

Gate green: 1292 tests pass (incl. 2 updated copy assertions), lint clean, build OK. Image built + pushed to zot, verified pullable.

**After rollout:** eyeball the live site; any wording is easily tweakable copy.

https://claude.ai/code/session_014bAhhgwJi6rLyHwmF7kd6k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TychoFleet application to a newer container version, including the latest available updates and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->