### PR TITLE
deploy tychofleet 9dd25be: prefetch fix + POST-form downloads (one image)

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:a5d0225
+          image: zot.phillips-homelab.net/tychofleet:a718c95
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:a718c95
+          image: zot.phillips-homelab.net/tychofleet:9dd25be
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/loops/specs/webapp-download-post/SPEC.md
+++ b/loops/specs/webapp-download-post/SPEC.md
@@ -1,0 +1,98 @@
+# SPEC — webapp-download-post: config downloads become POST forms
+
+Repo: `loop-bot/tychofleet`. Gate: `make build test lint`.
+
+## Why
+
+Founder-approved follow-up to loop `webapp-download-prefetch` (PR #86,
+merged): its decision file 001 compared destroy-on-redemption, POST
+forms, and status quo — the founder approved the recommendation,
+**option (b): POST forms**, on 2026-08-16.
+
+PR #86 closed the hover-prefetch vector, but the root flaw remains: the
+five config-download endpoints are GETs with destructive side effects
+(destroy-on-read of a single-use key). Anything that fires a GET the
+user never clicked — AV/security scanners, corporate link-rewriting
+proxies, link-preview bots, some browser accessibility tooling — can
+still silently consume a member's one config download. The rest of this
+codebase is already form-POST-only for side-effectful actions (see the
+re-enrol page's "Generate new code" form); downloads join that idiom.
+
+## What to build
+
+### 1. The five download controls become POST forms
+
+The five places PR #86 tagged with `data-astro-prefetch="false"`:
+
+| control | route |
+|---|---|
+| `src/pages/scopes/[scopeId]/setup.astro` (tycho.yaml button) | `/api/scopes/<id>/tycho-yaml` |
+| `src/components/deck/ScopesPanel.astro` | `/api/profile/tycho-conf` |
+| `src/pages/profile/index.astro` | `/api/profile/tycho-conf` |
+| `src/pages/admin/approved/[token].astro` | `/api/members/<token>/tycho-conf` |
+| `src/pages/m/[token].astro` | `/api/members/<token>/tycho-conf` |
+
+Each becomes a `<form method="POST">` with a submit button styled as
+the control is today; query-string inputs (`code`, `expires` on the
+tycho-yaml route) move to hidden fields. Browser-native form submission
+— no client JS. A POSTed response with `content-disposition:
+attachment` downloads exactly as the GET did; the filename must not
+change.
+
+### 2. The routes serve on POST; GET must never consume
+
+Each route gains a `POST` handler with the exact current logic —
+auth/ownership gates, single-use destroy-on-read, refusal paths, log
+lines all unchanged, just triggered by POST.
+
+`GET` on these routes must return **405** and — the property this whole
+SPEC exists for — **must not touch the pending key / authkey state**.
+No consume, no delete, no side effect of any kind on GET.
+
+### 3. Retire the now-moot prefetch attributes and their tests
+
+With no anchors left, `data-astro-prefetch="false"` on these controls
+disappears with them. Replace `src/tests/pages/download-prefetch.test.ts`
+(which asserts those anchors) rather than deleting coverage — see Tests.
+Keep the `prefetchAll: false` pin in `astro.config.mjs` and its test:
+that's site policy, not part of this change.
+
+## Tests
+
+- [ ] Red first, per route: GET returns 405 **and** a pending key
+  stashed before the GET is still redeemable by a subsequent POST — the
+  never-consume property, asserted directly.
+- [ ] POST serves the config once (body, content-type,
+  content-disposition filename asserted) and a second POST gets the
+  same refusal the second GET used to get.
+- [ ] Auth/ownership behavior identical under POST: session-gated
+  routes still 401 without a session; the token routes (`/api/members/
+  <token>/…`) still work token-only; the scopeId-mismatch refusal still
+  refuses without consuming.
+- [ ] Source-based replacement for `download-prefetch.test.ts`: no
+  `<a>` in the repo targets any of the three routes; the five controls
+  are forms with `method="POST"`.
+- [ ] `astro.config.mjs` `prefetchAll: false` assertion stays.
+
+## Warts / traps
+
+- Do NOT change `pending-keys.ts` / `tycho-conf-delivery.ts` internals
+  — destroy-on-read stays; only the HTTP method guarding it changes.
+  (Option (a), destroy-on-redemption, was considered and not chosen.)
+- The `m/[token]` and `admin/approved/[token]` pages are deliberately
+  session-less (invite-token auth). Do not add session gates while
+  converting.
+- The tycho-yaml route's `code`/`expires` currently ride the query
+  string by design ("never persists a code anywhere"). As hidden form
+  fields they keep that property; do not start persisting them.
+- Update SPEC `webapp-tailscale-minting`'s "destroy on handoff" note
+  where it implies GET delivery, referencing decision 001 — do not
+  otherwise edit shipped specs.
+- Commit decision file `decisions/001-destroy-on-read-vs-destroy-on-
+  redemption.json` to the repo this time (PR #86 left it sandbox-only),
+  marked approved/option-b.
+- `docs/design/**` is read-only law.
+
+Finish: `/workspace/PR.md` with before/after of one control, the
+five-conversion table, and the GET-never-consumes test named as the
+headline property.

--- a/loops/specs/webapp-download-prefetch/SPEC.md
+++ b/loops/specs/webapp-download-prefetch/SPEC.md
@@ -1,0 +1,122 @@
+# SPEC — webapp-download-prefetch: hover-prefetch destroys single-use config downloads
+
+Repo: `loop-bot/tychofleet`. Gate: `make build test lint`.
+
+## The failure
+
+Founder re-enrolled a scope (2026-08-16), reached the setup screen with
+a fresh code, clicked the `tycho.yaml` download button, and got a failed
+download — "file not found." Reproduced live, deterministically: **hover
+the button, then click, and the click always fails.** Site log at the
+moment of each failed click:
+
+```
+tycho-yaml: no tailnet key waiting for this code -- refusing to serve a config
+```
+
+Four of those in last night's onboarding window (01:21–01:23Z), zero
+matching consume errors — because the consumes were silent.
+
+## The mechanism
+
+Three facts compose:
+
+1. `astro.config.mjs` sets no `prefetch` option, and Starlight fills
+   the gap site-wide: `@astrojs/starlight/index.ts:139-140` —
+   *"If not already configured, default to prefetching all links on
+   hover"* → `prefetch: { prefetchAll: true }`. This applies to every
+   `<a>` on every page of the site, not just docs.
+2. The setup screen's download button is a plain anchor GET
+   (`src/pages/scopes/[scopeId]/setup.astro:183-188`):
+   `<a href="/api/scopes/<id>/tycho-yaml?code=...&expires=...">`.
+3. That route destroys its own key on read
+   (`src/lib/tsmint/pending-keys.ts`, `pendingScopeKey` — the row is
+   deleted the moment a matching read happens).
+
+So: mouse hovers the button on its way to clicking → Astro's prefetch
+script fires a real GET → route serves the config into the prefetch
+cache (a 200, logged nowhere) and destroys the single-use key → the
+user's actual click is a second GET → row gone → 503 → failed download.
+Whether the click instead reuses the browser's prefetch-cache entry is
+a timing lottery, which is why the flow occasionally succeeds and
+mostly doesn't.
+
+**This is not one link.** The member-config route has the same
+destroy-on-read semantics (`src/lib/tycho-conf-delivery.ts`, nulls
+`members.authkey` after building the body) and is linked by plain
+anchors from at least three places:
+
+| anchor | route |
+|---|---|
+| `src/pages/scopes/[scopeId]/setup.astro:183` | `/api/scopes/<id>/tycho-yaml` |
+| `src/components/deck/ScopesPanel.astro:101` | `/api/profile/tycho-conf` |
+| `src/pages/admin/approved/[token].astro:81` | `/api/members/<token>/tycho-conf` |
+| `src/pages/m/[token].astro:225` | `/api/members/<token>/tycho-conf` |
+
+Member onboarding has been rolling the same dice.
+
+## What to build
+
+### 1. Opt every side-effectful download anchor out of prefetch
+
+`data-astro-prefetch="false"` on each of the four anchors above. Astro
+honors per-link opt-out even under `prefetchAll`.
+
+### 2. Pin the site-wide prefetch policy explicitly
+
+Set `prefetch: { prefetchAll: false }` in `astro.config.mjs`, with a
+comment naming this incident, so Starlight's default can never silently
+re-arm the behavior when the config is next touched. Docs links lose
+hover-prefetch; if you judge that worth preserving, justify the
+alternative in PR.md — but the default posture is safety.
+
+### 3. Audit, and make the audit the deliverable
+
+Enumerate **every** `<a href>` in the repo (`.astro` templates and any
+client `<script>`-built links) that targets an `/api/` route, and for
+each: does a GET have side effects (consume, delete, null, mark, mint)?
+Table in PR.md — route, side effect, anchor locations, prefetch-opt-out
+applied or why not needed. This is the same "a fact re-derived in many
+places" shape as SPEC `webapp-setup-in-progress`; the audit is what
+keeps a fifth instance from shipping.
+
+### 4. File the durable fix as a decision — do not implement it here
+
+The root design flaw is a GET with destructive side effects: browsers,
+AV scanners and link previewers all fire GETs the user never clicked.
+The durable fix is idempotent download within the code's TTL (destroy
+the pending key on gateway *redemption* or expiry, not on read) or a
+POST-form download button. Both revise SPEC "webapp-tailscale-minting"'s
+"destroy on handoff" posture, so: write it up as a decision file for
+founder approval, with the trade-offs, and leave the implementation out
+of this loop.
+
+## Tests
+
+- [ ] Red first: rendered setup screen's `tycho.yaml` anchor carries
+  `data-astro-prefetch="false"`. This is the founder's failed download
+  and the test should say so.
+- [ ] Red first: same assertion for the three `tycho-conf` anchors.
+- [ ] `astro.config.mjs` explicitly sets `prefetch.prefetchAll: false`
+  (config-level assertion or lint grep — pick one and justify).
+- [ ] Existing download-route behavior tests unchanged and green: the
+  routes themselves are correct; only the anchors and site config move.
+
+## Warts / traps
+
+- Do NOT change `pending-keys.ts` or `tycho-conf-delivery.ts`
+  destroy-on-read semantics in this loop — that is the decision-gated
+  item 4. The fix here is entirely "stop firing GETs the user didn't
+  click."
+- Do not disable the prefetch integration wholesale by removing
+  Starlight config — docs still want their sidebar; only the
+  `prefetch` default changes.
+- The four anchors are load-bearing for three different flows
+  (scope setup/re-enrol, member self-service, admin approval). Touch
+  the `data-astro-prefetch` attribute only; no copy, layout, or route
+  changes.
+- `docs/design/**` is read-only law.
+
+Finish: `/workspace/PR.md` with the audit table (item 3), before/after
+of each anchor, the incident narrative (hover → silent consume → 503),
+and the decision file from item 4.


### PR DESCRIPTION
Bumps tychofleet a5d0225 -> 9dd25be, shipping BOTH merged fixes in one image per founder direction:

- loop-bot/tychofleet#86: 5 download anchors opt out of hover-prefetch, prefetchAll pinned false
- loop-bot/tychofleet#87: those 5 downloads become POST forms; GET returns 405 and never consumes (closes the whole destructive-GET class: scanners, link proxies, preview bots)

Both loop SPECs committed alongside. Image digest sha256:28425824... ArgoCD rolls out on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the TychoFleet service deployment to a newer container version.

* **Documentation**
  * Added specifications for preventing unintended download activation during page navigation.
  * Documented plans to use secure POST-based configuration downloads while preserving authorization, single-use access, file delivery, and refusal behavior.
  * Defined testing and rollout requirements for download safety and prefetch handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->