### PR TITLE
deploy: identity fix (site) + unknown-target quarantine (operator)

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:9dd25be
+          image: zot.phillips-homelab.net/tychofleet:6407483
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/gitops/tools/apps/tycho/operator/kustomization.yaml
+++ b/gitops/tools/apps/tycho/operator/kustomization.yaml
@@ -15,4 +15,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-operator
-    newTag: "644f54e8"
+    newTag: "f866352a"

--- a/loops/specs/operator-unknown-target-quarantine/SPEC.md
+++ b/loops/specs/operator-unknown-target-quarantine/SPEC.md
@@ -1,0 +1,96 @@
+# SPEC — operator-unknown-target-quarantine: no-target frames must not become targets
+
+Repo: `loop-bot/tycho`. Gate: `make build test lint`.
+
+## The failure (real member, 2026-08-17)
+
+Member Glen's Seestar carried July frames shot without a named target
+— the firmware names these `Light_Unknown_...` with OBJECT "Unknown".
+The client uploaded them (correct: archive everything), the gateway
+accepted them into sessions `unknown-2026-07-21` / `unknown-2026-07-23`
+(correct), the session stacker stacked them (acceptable) — and then
+the master trigger treated **"unknown" as a target identity**:
+TargetMaster `master-scp-97358c6b-unknown` pooled BOTH nights (almost
+certainly different sky coordinates), spawned five master combine
+Jobs, all Failed, retry budget exhausted (Attempts=5). The m-13
+quota-churn incident's shape, reborn via a garbage target name — and
+had a second member shot untargeted frames, the FleetMaster layer
+would pool "unknown" ACROSS members.
+
+## What to build
+
+### 1. Quarantine placeholder target identities at the master triggers
+
+A single predicate (e.g. `targetmaster.IsPlaceholderTarget(slug)`)
+true for "unknown" (case-insensitive, the firmware's placeholder) and
+empty/whitespace slugs. Both the per-source master trigger
+(`operator/internal/controller/master_trigger.go`,
+ensureMasterCombineForKey's key.Target guard is the natural seat —
+it already skips empty) and the FleetMaster trigger path skip
+placeholder targets: no TargetMaster/FleetMaster CR creation, no
+master combine spawn. Log once per session at INFO with a reason,
+not silently.
+
+Session-level behavior is unchanged: unknown-target subs still
+archive, still session-stack (harmless, per-night, single-coordinate
+in practice), still count in per-source storage. This quarantine is
+about cross-night/cross-member POOLING identity only.
+
+### 2. Existing garbage goes terminal, honestly
+
+Placeholder-target TargetMaster/FleetMaster CRs that already exist
+(e.g. `master-scp-97358c6b-unknown`, Failed, Attempts=5) must not
+revive: the trigger skip covers new spawns, and the retrier/periodic
+paths must also skip placeholder-target CRs so growth events can
+never re-arm them. Document (PR.md) the one-time operator cleanup for
+the CRs + failed Jobs (delete commands), rather than automating
+deletion in this loop.
+
+### 3. File the real design as a decision, don't build it
+
+The correct long-term identity for pooling is COORDINATES, not names
+(the alpha-readiness audit's own conclusion): frames/sessions pooled
+by sky position with named targets as labels. That is a design change
+touching session naming, master keying, and fleet pooling — write it
+as a `decisions/` file with options (coordinate-clustered target
+keys; name-with-coordinate-verification; status quo + quarantine) and
+a recommendation, for founder sign-off. This loop ships only the
+quarantine.
+
+### 4. Bounded secondary: the zero-input session result
+
+`stack-scp-97358c6b-m-31-2026-07-23` recorded a session result with
+`inputs: 0` and WARN "no completion report at combine time". Diagnose
+why a combine produced/uploaded a result with no recorded inputs
+(likely a device-stack-only session shape). If the behavior is
+intended, assert it with a test + comment; if it is a bug with a
+small fix, fix it; if large, write the finding in PR.md and stop.
+
+## Tests
+
+- [ ] Red first: a session close for target "Unknown" today reaches
+  the master trigger and creates the CR/Job — assert the current
+  broken behavior, then the skip.
+- [ ] Predicate: "unknown"/"Unknown"/""/whitespace are placeholders;
+  real slugs (m-31, sh2-157, c-20) are not.
+- [ ] Both triggers (source master + fleet master) and the
+  retrier/periodic paths skip placeholder targets; a growth event on
+  an existing placeholder CR does not respawn.
+- [ ] Session-level pipeline for unknown-target subs unchanged
+  (stack job still spawns).
+- [ ] The zero-input result behavior asserted per its diagnosis.
+
+## Warts / traps
+
+- Do NOT touch the combine engine (combine/), the fingerprint/GC
+  work, or delivery. Operator trigger logic + the predicate only.
+- Do not conflict with in-flight agent-side loops: nothing under
+  agent/ should change here.
+- The gateway accepting unknown-target uploads is CORRECT (archive
+  everything) — do not add gateway-side rejection.
+- `docs/design/**` is read-only law.
+
+Finish: `/workspace/PR.md` with the trigger-path audit (every place a
+target slug becomes a pooling identity), the one-time cleanup
+commands, the coordinate-pooling decision file, and the zero-input
+diagnosis.

--- a/loops/specs/webapp-member-identity-display/SPEC.md
+++ b/loops/specs/webapp-member-identity-display/SPEC.md
@@ -1,0 +1,92 @@
+# SPEC — webapp-member-identity-display: contributing members shown as nameless/scopeless
+
+Repo: `loop-bot/tychofleet`. Gate: `make build test lint`.
+
+## The failure (real member, 2026-08-17)
+
+Member Glen: scope registered via the modern deck flow, online, in
+fleet-zero, actively pushing frames (catalog counts his contributions).
+But the site shows:
+
+1. The fleet-zero page does not show his CHANGED display name.
+2. The Lobster Claw campaign page lists him as contributing but his
+   row reads **"no scope id on file"**.
+
+## Evidence from triage (verify, then fix)
+
+**Bug 2 root cause (pinned):** the campaign/fleet pages resolve a
+member's scope as `enrollment.sourceId ?? member.scopeId`
+(`src/lib/campaign-page.ts` ~line 81, `src/pages/fleet/[slug]/ops.astro:180`,
+`src/pages/campaign/[id]/index.astro` ~line 300). Both legs are dead
+for modern members: v1 enrolment only ever writes null-sourceId
+"all my scopes" rows (see `deck.ts` scopeIdsForMember's own doc), and
+`members.scopeId` is a legacy column the modern gateway/deck
+registration flow never writes. Related: `getFleetRoster`'s
+`scopeCountFor` (`src/lib/fleet.ts` ~246) counts only non-null
+enrollment sourceIds, so contributing members also read as 0 scopes.
+
+**Bug 1 (not yet pinned — reproduce first):** the rendering helpers
+look correct (`publicMemberLabel` prefers displayName;
+`ops.astro:178` uses `member.displayName ?? member.email`). So the
+defect is upstream: either (a) the profile display-name save path
+does not persist to `members.displayName`, or (b) some fleet-zero
+surface renders a name from a source that bypasses these helpers
+(team name, denormalized snapshot, catalog label). Write the failing
+test FIRST from the reproduced cause; do not guess-fix rendering.
+
+## What to build
+
+### 1. One member→scopes resolution seam
+
+A single function answering "which scope/source ids belong to this
+member" that consults, in order: explicit per-scope enrollment
+sourceIds, THEN the member's registered scopes from the catalog/
+gateway seam the scope deck and observer pages already use (that is
+the source that actually knows Glen's scope), THEN legacy
+`members.scopeId` for old rows. Every current consumer of
+`enrollment.sourceId ?? member.scopeId` migrates onto it — audit the
+repo for that pattern and table the call sites in PR.md (campaign
+page, fleet ops, roster scopeCount, join page, anywhere else).
+"no scope id on file" should become an honest rarity (a member with
+genuinely no registered scope), not the default for modern members.
+
+### 2. Fix the display-name defect at its reproduced root
+
+Whichever of (a)/(b) reproduces: fix the save path or migrate the
+bypassing surface onto `publicMemberLabel`. Respect the existing
+privacy posture — `publicMemberLabel`'s email fallback only where
+`allowEmail` is already true today; public pages keep the
+`Observer <id>` stand-in for members with no display name.
+
+### 3. Red-first tests
+
+- [ ] A member shaped like Glen (gateway-registered scope, null
+  enrollment sourceId, null members.scopeId, changed displayName):
+  campaign pooling row shows the scope id (linked), fleet ops row
+  shows scope id, roster scopeCount ≥ 1, and every fleet-zero surface
+  shows the CURRENT display name. These fail on main today.
+- [ ] Legacy member (members.scopeId set, no catalog scopes) still
+  resolves — no regression.
+- [ ] Member with genuinely no scope still reads "no scope id on
+  file" / "No scope id on file yet." where those strings live.
+- [ ] Display-name change propagates: save, re-render, assert — at
+  the reproduced defect layer, not just the helper.
+
+## Warts / traps
+
+- The catalog seam degrades when the gateway is unreachable
+  (CATALOG_DEGRADED_NOTE pattern) — the resolution seam must degrade
+  the same honest way, never render a modern member as scopeless
+  because one request failed. State the degraded rendering.
+- Do not build per-scope enrollment UI (deck.ts's documented
+  deferral) — this is display resolution, not enrollment redesign.
+- Do not touch the download/enrolment flows shipped this week
+  (prefetch/POST-form work).
+- PR.md carries before/after renders (ASCII or textual DOM excerpts)
+  of the campaign pooling row and fleet ops row for the Glen-shaped
+  fixture — experience-layer evidence, not just green tests.
+- `docs/design/**` is read-only law.
+
+Finish: `/workspace/PR.md` with the consumer audit table, the
+reproduced root cause of bug 1 stated plainly, before/after renders,
+and the degraded-catalog rendering note.


### PR DESCRIPTION
Two founder-approved merges, one deploy:

- tychofleet 9dd25be -> 6407483 (loop-bot/tychofleet#88): member-scopes resolution seam — gateway-registered members no longer read as 'no scope id on file'/0 scopes on campaign, fleet, roster, join, and delivery-attribution surfaces. Digest sha256:3871ba86...
- tycho-operator 644f54e8 -> f866352a (loop-bot/tycho#239): placeholder-target quarantine — 'unknown' can no longer become a TargetMaster/FleetMaster pooling identity (the master-scp-97358c6b-unknown incident). Digest sha256:c1970d1e...

Both loop SPECs committed alongside. Post-merge manual cleanup (PR #239's PR.md): delete the failed master-scp-97358c6b-unknown* jobs and the Failed TargetMaster CR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated TychoFleet and Tycho operator components to newer releases.

* **Documentation**
  * Added guidance for preventing placeholder target identities from being unintentionally restored.
  * Documented requirements for reliable member identity and scope display, including fallback behavior and regression coverage.
  * Added operational guidance for cleanup, privacy, enrollment, and troubleshooting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->