### PR TITLE
deploy tychofleet 6cc54a1: scope display ordering

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:6407483
+          image: zot.phillips-homelab.net/tychofleet:6cc54a1
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Bumps tychofleet 6407483 -> 6cc54a1 (loop-bot/tychofleet#89, merged): liveness-aware scope ordering — a member's attested/heartbeating scope leads single-slot displays; dead registrations sort last (Glen now shows scp_97358c6b, not his dead scp_3ac6927a). Digest sha256:372c04c9...