### PR TITLE
loop rig: render-time --image substitution + rust-dev image + OSC specs

### DIFF
--- a/gitops/tools/apps/tycho/operator/deployment.yaml
+++ b/gitops/tools/apps/tycho/operator/deployment.yaml
@@ -107,7 +107,7 @@ spec:
               # feature was live everywhere except the container that
               # reads it (tycho #154). Bump this whenever combine/
               # changes, and check it moved after ArgoCD syncs.
-              value: "zot.phillips-homelab.net/tycho-combine:6bc387e"
+              value: "zot.phillips-homelab.net/tycho-combine:7a6308a1"
             # ADR 0010 outbound delivery. Both are REQUIRED: the
             # operator fails closed at startup without them, so this
             # block must land in the same commit as the image bump.

--- a/loops/bin/loopctl
+++ b/loops/bin/loopctl
@@ -29,7 +29,8 @@ TEMPLATE="$REPO_ROOT/loops/templates/loop-sandbox.yaml"
 
 die() { echo "loopctl: $*" >&2; exit 1; }
 
-image_from_template() { grep -oE 'zot\.phillips-homelab\.net/loop-dev:[a-zA-Z0-9._-]+' "$TEMPLATE" | head -1; }
+default_image_tag() { sed -n 's/.*# default-image-tag: //p' "$TEMPLATE" | head -1; }
+image_from_template() { echo "zot.phillips-homelab.net/loop-dev:$(default_image_tag)"; }
 
 # Run $2 (bash script text) in a short-lived in-cluster pod named loopctl-$1-*
 # with loop-secrets in env. Prints the pod's logs. Optional $3 = extra pod
@@ -78,15 +79,12 @@ cmd_spawn() {
   kubectl -n "$NS" get sandbox "$name" >/dev/null 2>&1 && die "sandbox '$name' already exists (reap it first)"
 
   LOOP=$name REPO=$repo MAX_ITER=$max_iter ENGINE=$engine GATE="${gate:-make build test lint}" \
+    IMAGE="${image:-$(default_image_tag)}" \
     python3 - "$TEMPLATE" <<'EOF' | kubectl apply -f - >/dev/null
 import os, re, sys
 t = open(sys.argv[1]).read()
 print(re.sub(r'\$\{(\w+)\}', lambda m: os.environ[m.group(1)], t))
 EOF
-  if [ -n "$image" ]; then
-    kubectl -n "$NS" patch sandbox "$name" --type=json \
-      -p "[{\"op\":\"replace\",\"path\":\"/spec/podTemplate/spec/containers/0/image\",\"value\":\"zot.phillips-homelab.net/loop-dev:${image}\"}]" >/dev/null
-  fi
   echo "spawned sandbox/$name; waiting for pod..."
   kubectl -n "$NS" wait --for=condition=Ready "pod/$name" --timeout=300s >/dev/null
   kubectl -n "$NS" cp "$spec" "$name:/workspace/SPEC.md" >/dev/null 2>&1

--- a/loops/images/rust-dev/Dockerfile
+++ b/loops/images/rust-dev/Dockerfile
@@ -1,0 +1,51 @@
+# Loop rust-dev image: Rust toolchain + claude CLI + nats CLI + kubectl +
+# harness. The Rust sibling of images/dev (Go) — first consumer is
+# loop-bot/OpenSteamController, whose gate needs cargo + clippy + rustfmt
+# and the native headers for hidapi (libudev) and the dbus crate
+# (libdbus-1). Same push pattern as images/dev, tag loop-dev:rust-<n> so
+# `loopctl spawn --image rust-<n>` selects it.
+#
+# Build (in-pod variant of the house pattern — no local buildctl needed):
+#   kubectl -n buildkit cp loops/images/rust-dev <pod>:/tmp/rust-ctx
+#   kubectl -n buildkit exec <pod> -- buildctl build \
+#     --frontend dockerfile.v0 \
+#     --local context=/tmp/rust-ctx --local dockerfile=/tmp/rust-ctx \
+#     --output type=image,name=zot.phillips-homelab.net/loop-dev:rust-1,push=true
+FROM rust:1-bookworm
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git make jq curl ca-certificates ripgrep unzip \
+      pkg-config libudev-dev libdbus-1-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN rustup component add clippy rustfmt
+
+# claude CLI (native installer drops it in ~/.local/bin; promote to PATH)
+RUN curl -fsSL https://claude.ai/install.sh | bash && \
+    install -m 0755 /root/.local/bin/claude /usr/local/bin/claude && \
+    rm -rf /root/.local
+
+# nats CLI (releases ship zips)
+RUN NATS_CLI_VERSION=0.4.0 && \
+    curl -fsSL -o /tmp/nats.zip "https://github.com/nats-io/natscli/releases/download/v${NATS_CLI_VERSION}/nats-${NATS_CLI_VERSION}-linux-amd64.zip" && \
+    unzip -q /tmp/nats.zip -d /tmp/natscli && \
+    install -m 0755 /tmp/natscli/nats-*/nats /usr/local/bin/nats && rm -rf /tmp/nats.zip /tmp/natscli
+
+# kubectl (only used to patch the loop's own Sandbox state label)
+RUN KUBECTL_VERSION="$(curl -fsSL https://dl.k8s.io/release/stable.txt)" && \
+    curl -fsSL -o /usr/local/bin/kubectl \
+      "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
+    chmod 0755 /usr/local/bin/kubectl
+
+# The loop user must own a writable cargo home; the base image's
+# /usr/local/cargo is root's. Registry cache lands in /workspace (PVC)
+# via CARGO_HOME so iteration 2+ doesn't re-download the world.
+RUN useradd -m -u 1000 -s /bin/bash loop && mkdir -p /workspace && chown loop:loop /workspace && \
+    chmod -R a+rX /usr/local/rustup /usr/local/cargo
+COPY harness.sh /usr/local/bin/harness.sh
+RUN chmod 0755 /usr/local/bin/harness.sh
+USER loop
+ENV HOME=/home/loop
+ENV CARGO_HOME=/workspace/.cargo
+WORKDIR /workspace
+ENTRYPOINT ["/usr/local/bin/harness.sh"]

--- a/loops/images/rust-dev/harness.sh
+++ b/loops/images/rust-dev/harness.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# Loop harness: the authoritative layer for loop mechanics.
+# The agent proposes, the harness disposes: validation gates and git push
+# live here, where the agent cannot rationalize around them.
+#
+# Contract (from the loop-rig brief):
+#   - stateless `claude -p` per iteration
+#   - harness-owned gate (GATE_CMD, default "make build test lint")
+#   - commit+push on green only; MAX_ITER budget
+#   - decisions: agent writes /workspace/decisions/NNN-slug.json, harness
+#     relays to NATS; answers drain from loops.<name>.inbox to /workspace/.inbox
+#   - done: all boxes checked + gate green -> agent writes /workspace/.loop-done
+#   - exit codes: 0 done, 2 blocked-needs-human, 3 budget exhausted
+#   - state label loop.phillips.dev/state on own Sandbox CR
+set -uo pipefail
+
+: "${LOOP_NAME:?LOOP_NAME required (sandbox name)}"
+: "${REPO_URL:?REPO_URL required (Forgejo clone URL, no creds)}"
+: "${FORGEJO_TOKEN:?FORGEJO_TOKEN required}"
+# ENGINE selects the model CLI an iteration runs: claude (default,
+# Casey's Pro OAuth token — ONE such loop at a time, shared with his
+# interactive use) or codex (OpenAI Codex CLI on the ChatGPT-sub auth —
+# a separate budget, so a codex loop may run alongside a claude one;
+# Plus-tier limits fit short review-shaped loops, not 15-iteration
+# builds).
+ENGINE="${ENGINE:-claude}"
+case "$ENGINE" in
+  claude)
+    : "${CLAUDE_CODE_OAUTH_TOKEN:?CLAUDE_CODE_OAUTH_TOKEN required (claude setup-token)}"
+    # Pro-subscription auth: an API key would take precedence over the
+    # OAuth token and break auth if both are set.
+    unset ANTHROPIC_API_KEY
+    ;;
+  codex)
+    : "${CODEX_AUTH_JSON:?CODEX_AUTH_JSON required (contents of ~/.codex/auth.json; secret codex-auth)}"
+    mkdir -p "$HOME/.codex"
+    printf '%s' "$CODEX_AUTH_JSON" > "$HOME/.codex/auth.json"
+    chmod 600 "$HOME/.codex/auth.json"
+    ;;
+  *) echo "unknown ENGINE '$ENGINE' (claude|codex)" >&2; exit 2 ;;
+esac
+BRANCH="${BRANCH:-loop/${LOOP_NAME}}"
+MAX_ITER="${MAX_ITER:-30}"
+GATE_CMD="${GATE_CMD:-make build test lint}"
+NATS_SERVER="${NATS_SERVER:-nats.loops.svc.cluster.local:4222}"
+NATS_URL="nats://loop:${NATS_PASSWORD:-}@${NATS_SERVER}"
+WS=/workspace
+REPO_DIR="$WS/repo"
+MEMORY_URL="${MEMORY_URL:-}"   # optional read-only memory repo
+
+log()  { echo "[harness $(date -u +%H:%M:%S)] $*"; }
+term() { echo "$*" > /dev/termination-log 2>/dev/null || true; }
+
+npub() { # npub <subject-suffix> <json> — best-effort, never fatal
+  nats --server "$NATS_URL" pub "loops.${LOOP_NAME}.$1" "$2" >/dev/null 2>&1 \
+    || log "WARN nats pub $1 failed"
+}
+
+set_state() { # running|blocked|done — best-effort
+  kubectl -n loops patch sandbox "$LOOP_NAME" --type=merge \
+    -p "{\"metadata\":{\"labels\":{\"loop.phillips.dev/state\":\"$1\"}}}" \
+    >/dev/null 2>&1 || log "WARN state label patch failed ($1)"
+}
+
+ensure_inbox_consumer() { # durable pull consumer: answers persist in the
+  # LOOPS stream even when published mid-iteration, drained at iteration start
+  nats --server "$NATS_URL" consumer add LOOPS "inbox-${LOOP_NAME}" \
+    --filter "loops.${LOOP_NAME}.inbox" --pull --deliver all --ack explicit \
+    --defaults >/dev/null 2>&1 || true
+}
+
+drain_inbox() { # answers published to loops.<name>.inbox land in .inbox/
+  mkdir -p "$WS/.inbox"
+  local n=0
+  while msg=$(timeout 5 nats --server "$NATS_URL" consumer next LOOPS \
+      "inbox-${LOOP_NAME}" --raw 2>/dev/null) && [ -n "$msg" ]; do
+    n=$((n+1))
+    echo "$msg" > "$WS/.inbox/$(date -u +%s)-$n.json"
+  done
+  if [ "$n" -gt 0 ]; then
+    log "drained $n inbox message(s)"
+    # Answered-decision ledger: pairs with decisions/.sent count so the
+    # review-wait check below knows whether a filed decision is still
+    # unanswered. PVC-persistent like .iter-count.
+    echo $(( $(cat "$WS/.answers-count" 2>/dev/null || echo 0) + n )) > "$WS/.answers-count"
+  fi
+}
+
+unanswered_decisions() { # true if more decisions were relayed than answered
+  local sent answered
+  sent=$(ls "$WS/decisions/.sent" 2>/dev/null | wc -l)
+  answered=$(cat "$WS/.answers-count" 2>/dev/null || echo 0)
+  [ "$sent" -gt "$answered" ]
+}
+
+relay_decisions() { # new decision files -> NATS (file-then-relay per brief)
+  mkdir -p "$WS/decisions/.sent"
+  local f
+  for f in "$WS"/decisions/*.json; do
+    [ -e "$f" ] || continue
+    if jq -e . "$f" >/dev/null 2>&1; then
+      npub decisions "$(jq -c --arg loop "$LOOP_NAME" '. + {loop: $loop}' "$f")"
+      mv "$f" "$WS/decisions/.sent/"
+      log "relayed decision $(basename "$f")"
+    else
+      log "WARN malformed decision file $(basename "$f"), leaving in place"
+    fi
+  done
+}
+
+# ---- bootstrap -------------------------------------------------------------
+log "loop ${LOOP_NAME} starting; waiting for SPEC.md"
+for _ in $(seq 1 360); do [ -f "$WS/SPEC.md" ] && break; sleep 5; done
+if [ ! -f "$WS/SPEC.md" ]; then
+  term "no SPEC.md after 30m"; set_state blocked; exit 2
+fi
+
+git config --global credential.helper store
+FORGEJO_SCHEME=$(echo "$REPO_URL" | sed -E 's#^(https?)://.*#\1#')
+FORGEJO_HOST=$(echo "$REPO_URL" | sed -E 's#^https?://([^/]+)/.*#\1#')
+echo "${FORGEJO_SCHEME}://loop-bot:${FORGEJO_TOKEN}@${FORGEJO_HOST}" > ~/.git-credentials
+git config --global user.name "loop-bot"
+git config --global user.email "loop-bot@phillips-homelab.net"
+
+if [ ! -d "$REPO_DIR/.git" ]; then
+  git clone "$REPO_URL" "$REPO_DIR" || { term "clone failed"; set_state blocked; exit 2; }
+  git -C "$REPO_DIR" checkout -B "$BRANCH"
+fi
+if [ -n "$MEMORY_URL" ] && [ ! -d "$WS/memory/.git" ]; then
+  git clone --depth 1 "$MEMORY_URL" "$WS/memory" || log "WARN memory clone failed"
+fi
+[ -f "$WS/PROGRESS.md" ] || printf '# PROGRESS\n\n(harness: no iterations yet)\n' > "$WS/PROGRESS.md"
+
+PROMPT='You are one iteration of an autonomous coding loop. Read /workspace/SPEC.md (the task, checkboxes, guardrails) and /workspace/PROGRESS.md (state so far), and check /workspace/.inbox/ for operator answers to earlier decisions. Then do exactly ONE thing: the next unchecked SPEC item. Work in /workspace/repo. Follow SPEC guardrails strictly. If an item is blocked after 3 distinct attempts (see PROGRESS), write a decision file to /workspace/decisions/NNN-slug.json (fields: question, context, options[2-3], recommendation, risk) and move to the next item. Update PROGRESS.md: what you did, gate expectations, what is next, any BLOCKED items. If ALL items are done, create /workspace/.loop-done containing a one-paragraph summary, AND /workspace/PR.md: a reviewer-facing pull-request description in markdown (sections: What changed, How it was verified, Review notes — call out any tradeoffs, dependency changes, or deviations a human reviewer should scrutinize). Write PR.md for a human who has NOT read PROGRESS.md; no process narration or iteration numbers. If ALL remaining items are BLOCKED, or if your ONLY remaining action is waiting for an operator answer to a decision you already filed (a review gate counts — waiting is not working), create /workspace/.loop-blocked with a summary; the harness waits for the answer without spending iterations. Never write secrets to logs or files. Do not run git push (the harness pushes). Consult /workspace/memory/ (gotchas, conventions) if present.'
+
+# ---- iteration loop --------------------------------------------------------
+ensure_inbox_consumer
+set_state running
+# iteration budget survives container restarts (the workspace is a PVC)
+iter=$(cat "$WS/.iter-count" 2>/dev/null || echo 0)
+[ "$iter" -gt 0 ] && log "resuming at iteration $((iter+1)) after restart"
+while [ "$iter" -lt "$MAX_ITER" ]; do
+  iter=$((iter+1))
+  echo "$iter" > "$WS/.iter-count"
+  log "=== iteration ${iter}/${MAX_ITER} ==="
+  drain_inbox
+
+  head_before=$(git -C "$REPO_DIR" rev-parse HEAD 2>/dev/null || echo none)
+  if [ "$ENGINE" = codex ]; then
+    # danger-full-access mirrors --dangerously-skip-permissions: the
+    # gVisor sandbox pod IS the isolation boundary, same as claude.
+    # cwd must be the REPO (codex's trust check refuses a non-git cwd;
+    # first smoke died on exactly that from $WS) and the check is
+    # skipped outright -- full-access mode reaches the $WS files
+    # regardless of cwd. Prompt on stdin ('-'); reasoning high: these
+    # are review-shaped loops.
+    (cd "$REPO_DIR" && codex exec \
+      --skip-git-repo-check \
+      --sandbox danger-full-access \
+      -c model_reasoning_effort=high \
+      - <<<"$PROMPT") \
+      > "$WS/.iter-${iter}.log" 2>&1
+  else
+    claude -p "$PROMPT" \
+      --dangerously-skip-permissions \
+      --add-dir "$WS" \
+      > "$WS/.iter-${iter}.log" 2>&1
+  fi
+  agent_rc=$?
+  log "agent exited rc=${agent_rc} ($(wc -l < "$WS/.iter-${iter}.log") log lines)"
+
+  # Pro-plan rate limiting: iterations draw from the shared 5h prompt window.
+  # Back off without burning budget; give up after too many in a row.
+  if [ "$agent_rc" -ne 0 ] && grep -qiE 'rate.?limit|usage limit|limit (reached|exceeded)' "$WS/.iter-${iter}.log"; then
+    rl_count=$(( ${rl_count:-0} + 1 ))
+    if [ "$rl_count" -ge "${RATE_LIMIT_MAX_BACKOFFS:-8}" ]; then
+      npub done "{\"iter\":${iter},\"exhausted\":true,\"reason\":\"rate-limited\"}"
+      set_state blocked; term "persistent rate limiting"; exit 3
+    fi
+    iter=$((iter-1))
+    log "rate limited (${rl_count}); sleeping ${RATE_LIMIT_BACKOFF:-900}s, iteration not counted"
+    sleep "${RATE_LIMIT_BACKOFF:-900}"
+    continue
+  fi
+  rl_count=0
+
+  relay_decisions
+
+  gate_result=red
+  if (cd "$REPO_DIR" && eval "$GATE_CMD") > "$WS/.gate-${iter}.log" 2>&1; then
+    gate_result=green
+    if ! git -C "$REPO_DIR" diff --quiet || ! git -C "$REPO_DIR" diff --cached --quiet \
+       || [ -n "$(git -C "$REPO_DIR" status --porcelain)" ]; then
+      git -C "$REPO_DIR" add -A
+      git -C "$REPO_DIR" commit -m "loop(${LOOP_NAME}): iteration ${iter}" >/dev/null
+    fi
+    git -C "$REPO_DIR" push -u origin "$BRANCH" >/dev/null 2>&1 || log "WARN push failed"
+  else
+    log "gate RED (tail): $(tail -3 "$WS/.gate-${iter}.log" | tr '\n' ' ')"
+    printf '\n> harness: iteration %s gate FAILED:\n```\n%s\n```\n' \
+      "$iter" "$(tail -20 "$WS/.gate-${iter}.log")" >> "$WS/PROGRESS.md"
+  fi
+
+  npub events "{\"iter\":${iter},\"gate\":\"${gate_result}\",\"agent_rc\":${agent_rc},\"ts\":\"$(date -u +%FT%TZ)\"}"
+
+  if [ -f "$WS/.loop-done" ]; then
+    if [ "$gate_result" = green ]; then
+      log "done sentinel + green gate: finishing"
+      npub done "{\"iter\":${iter},\"summary\":$(jq -Rs . < "$WS/.loop-done")}"
+      set_state done; term "done in ${iter} iterations"; exit 0
+    fi
+    log "done sentinel but gate RED: removing sentinel, continuing"
+    rm -f "$WS/.loop-done"
+    printf '\n> harness: .loop-done rejected, gate is red.\n' >> "$WS/PROGRESS.md"
+  fi
+  if [ -f "$WS/.loop-blocked" ]; then
+    npub done "{\"iter\":${iter},\"blocked\":true,\"summary\":$(jq -Rs . < "$WS/.loop-blocked")}"
+    set_state blocked
+    # Wait in-process instead of exiting: exit 2 + restartPolicy OnFailure
+    # crashloops, and each relaunch burns prompts re-assessing state. Inbox
+    # polling costs nothing. Exit 2 only after the decision timeout.
+    log "blocked; polling inbox for operator answers"
+    waited=0
+    while :; do
+      if [ "$waited" -ge "${BLOCKED_TIMEOUT:-172800}" ]; then
+        term "blocked after ${iter} iterations; no answer in $((waited/3600))h"
+        exit 2
+      fi
+      sleep "${BLOCKED_POLL:-120}"; waited=$((waited + ${BLOCKED_POLL:-120}))
+      before=$(ls "$WS/.inbox" 2>/dev/null | wc -l)
+      drain_inbox
+      after=$(ls "$WS/.inbox" 2>/dev/null | wc -l)
+      if [ "$after" -gt "$before" ]; then
+        log "operator answer received after ${waited}s; resuming"
+        rm -f "$WS/.loop-blocked"
+        set_state running
+        break
+      fi
+    done
+  fi
+
+  # Review-wait: an unanswered decision exists, the inbox is empty, and this
+  # iteration changed nothing in the repo — the loop is waiting on a human,
+  # not working. Poll the inbox for free instead of burning budget on no-op
+  # iterations. (webapp-docs-voice burned 8 iterations idle-polling;
+  # webapp-truth-pass EXHAUSTED its budget mid-review and died. This block is
+  # the harness-side backstop; the PROMPT also now tells agents to write
+  # .loop-blocked in this situation, but agent judgment proved inconsistent.)
+  if unanswered_decisions \
+     && [ -z "$(ls "$WS/.inbox" 2>/dev/null)" ] \
+     && [ "$(git -C "$REPO_DIR" rev-parse HEAD 2>/dev/null || echo none)" = "$head_before" ]; then
+    set_state waiting
+    log "review-wait: unanswered decision, no repo change; polling inbox (budget frozen at ${iter}/${MAX_ITER})"
+    npub events "{\"iter\":${iter},\"waiting\":true,\"ts\":\"$(date -u +%FT%TZ)\"}"
+    waited=0
+    while :; do
+      if [ "$waited" -ge "${BLOCKED_TIMEOUT:-172800}" ]; then
+        term "review-wait timeout after ${iter} iterations; no answer in $((waited/3600))h"
+        set_state blocked
+        exit 2
+      fi
+      sleep "${BLOCKED_POLL:-120}"; waited=$((waited + ${BLOCKED_POLL:-120}))
+      before=$(ls "$WS/.inbox" 2>/dev/null | wc -l)
+      drain_inbox
+      after=$(ls "$WS/.inbox" 2>/dev/null | wc -l)
+      if [ "$after" -gt "$before" ]; then
+        log "operator answer received after ${waited}s; resuming"
+        set_state running
+        break
+      fi
+    done
+  fi
+done
+
+# Budget spent: terminal, not an error. Exit 0 so the pod completes instead
+# of CrashLoopBackOff-ing forever "resuming" at iter MAX+1 (webapp-truth-pass
+# restarted 15 times doing exactly that). State 'exhausted' tells loopctl and
+# the conductor what happened; the workspace PVC keeps everything for reap.
+npub done "{\"iter\":${iter},\"exhausted\":true}"
+set_state exhausted
+term "budget exhausted (${MAX_ITER} iterations)"
+exit 0

--- a/loops/specs/combine-normalization-guard/SPEC.md
+++ b/loops/specs/combine-normalization-guard/SPEC.md
@@ -1,0 +1,109 @@
+# SPEC — combine-normalization-guard: no more negative photometric scales
+
+Repo: `loop-bot/tycho`. Gate: `make build test lint`.
+
+## The failure (live master, 2026-08-16)
+
+The sh2-157 master (`master-seestar-1-sh2-157`, 2 night-stack inputs)
+integrated one night with a NEGATIVE photometric scale factor —
+actively subtracting that night's signal from the master. External
+analysis of `masters/sh2-157/master.fit`'s `INnSCALE` provenance cards
+surfaced it; the mechanism is confirmed in code:
+
+- `combine/src/tycho_combine/normalization.py` is designed for RAW,
+  pre-background-subtraction inputs — its docstring's premise is that
+  sky brightness dominates the overlap median (large, positive,
+  stable).
+- **Master mode violates that premise**: its inputs are per-night
+  `stack.fit` products the session combine already background-
+  subtracted, so the overlap median is residual noise around zero.
+  `pipeline.py:1143-1144` measures the median before this run's own
+  background stage — i.e. on the already-subtracted stack.
+- `scale_factor_from_medians` (`normalization.py:44-55`) falls back to
+  1.0 only for non-finite or EXACTLY zero medians. A residual median
+  of −1e-5 passes the guard and flips the ratio's sign.
+
+## What to build
+
+### 1. Statistical-zero guard, not exact-zero
+
+A median is unusable when it is indistinguishable from zero, not only
+when it equals zero. Alongside each overlap median, measure the
+overlap's robust noise (MAD-based) and treat the median as invalid
+when |median| is below a small multiple of that noise scaled for the
+sample size. Both call paths — `compute_scale_factors` and the
+streaming path in `pipeline.py` (`overlap_median` +
+`scale_factor_from_medians`) — must apply the same rule:
+
+- invalid input median → that input's factor is 1.0;
+- invalid REFERENCE median → every factor 1.0 (the existing exact-zero
+  pattern, widened).
+
+Pick the threshold constant deliberately and document why (it must not
+disable normalization on genuinely sky-dominated session inputs, whose
+medians are orders of magnitude above their noise — show that margin
+in PR.md with realistic numbers).
+
+### 2. A computed factor must never be non-positive
+
+Defense in depth regardless of how it was computed: a factor ≤ 0 is
+never applied — fall back to 1.0. A negative multiplicative
+photometric scale has no physical meaning in this pipeline.
+
+### 3. Say so in the recipe/provenance
+
+This codebase's rule: a skipped stage must never read as a ran stage
+(see `rejection_skip_reason`, pipeline.py). When the guard forces
+factors to 1.0 — per-input or wholesale — the recipe and the result
+header must record that normalization was skipped/degraded and why
+(reference-median-indistinguishable-from-zero, input-median-invalid,
+non-positive-factor-clamped). `INnSCALE` cards keep being written
+(they'll read 1.0).
+
+### 4. File the master-mode question as a decision, don't solve it here
+
+Even guarded, a sky-median ratio measured on background-subtracted
+stacks is meaningless as a *normalization signal* — the guard makes it
+harmless (1.0), not right. The correct master-mode normalization (e.g.
+positive-signal/star-flux ratio between night stacks) is a design
+change: write it as a `decisions/` file with options and a
+recommendation for founder sign-off, and leave master-mode behavior at
+"guarded to 1.0" in this loop.
+
+## Tests (red first)
+
+- [ ] The sign-flip reproduction: reference median a realistic sky
+  value, input median −1e-5 with realistic overlap noise → factor is
+  1.0, and specifically NOT negative. Name the sh2-157 incident in the
+  test comment.
+- [ ] Property: for any pair of finite medians, the returned factor is
+  > 0.
+- [ ] Statistically-zero reference (both signs) → all factors 1.0 +
+  skip reason recorded.
+- [ ] Sky-dominated medians far above noise → ratio behavior UNCHANGED
+  (existing session-mode tests keep passing untouched).
+- [ ] Streaming path (pipeline.py) and list path
+  (compute_scale_factors) agree on the same inputs.
+- [ ] Provenance: header/recipe carry the skip/degrade reason; a run
+  with healthy normalization records none.
+- [ ] Tests are REAL: no fixture-gated self-skips (the known gate-debt
+  trap) — these must run in the ordinary `make test` combine leg.
+
+## Warts / traps
+
+- Do not touch the combine-job fingerprint/GC/idempotency work — that
+  is a separate loop's territory. This loop changes only
+  normalization math, its guards, and provenance.
+- Session-mode behavior on genuinely raw inputs must be bit-identical
+  when medians are healthy — this is a guard, not a re-tune.
+- Deploy note for PR.md: dev dark mode means merge ≠ live — the
+  combine image must be built/pushed and gitops-bumped, AND the
+  master's combinable-set fingerprint keys on inputs, not engine
+  version, so the existing sh2-157 master will NOT self-recombine on
+  deploy. Spell out the operator step to force the re-run (or note
+  that the next night's new input retriggers it naturally).
+- `docs/design/**` is read-only law.
+
+Finish: `/workspace/PR.md` with the threshold rationale + margin
+numbers, before/after factor tables for the sh2-157-shaped case, the
+decision file, and the deploy/re-run note.

--- a/loops/specs/osc-mode-system/SPEC.md
+++ b/loops/specs/osc-mode-system/SPEC.md
@@ -1,0 +1,95 @@
+# SPEC — osc-mode-system: Gamepad / Desktop / Hybrid input modes
+
+Repo: `loop-bot/OpenSteamController`. Gate: `make build test lint`.
+Image: rust-1 (cargo + clippy + rustfmt + libudev/libdbus headers).
+
+**Read first, both on main:** `CLAUDE.md` (sandbox constraints — no
+hardware, no /dev/uinput, Windows must keep compiling blind) and
+`docs/design/input-modes.md`, which is **law** for this loop: mode
+semantics, the Desktop parity table, the Hybrid table, chord rules,
+transition hygiene, zone math, and the scope fences all live there.
+This spec sequences the work; the design doc defines it. Where they
+appear to conflict, say so in PR.md rather than silently picking.
+
+## Why
+
+The app has one real layout plus a half-finished momentary "alt mode".
+Steam Input on the same controller ships a polished desktop layer and
+per-layer paddle bindings; users drop to this app for non-Steam games
+and lose all of it. The design doc turns that into three fixed modes.
+Two real bugs die as side effects: chords currently match *mapped*
+outputs, so Steam+Y power-off is dead while alt mode is active
+(`parse_button_combinations` matching `ControllerInput::Y`); and mode
+changes can strand held outputs (hold RT, tap Menu → phantom trigger).
+
+## Build, in order
+
+1. - [ ] **Red-first: the mapping test harness.** Extract per-mode
+   button mapping into a pure function (mode, button, states) →
+   ControllerInput, and write table-driven tests asserting the FULL
+   Gamepad table (current behavior — this pins the refactor) plus the
+   Desktop and Hybrid tables from the design doc. Desktop/Hybrid tests
+   fail red at this point because only the plumbing exists. Commit the
+   red tests before the green.
+2. - [ ] **`InputMode` enum + plumbing.** In `DeviceProperties` beside
+   `nintendo_layout`; `DeviceCommand::{SetInputMode, InputModeCycle}`
+   handled in `try_apply`; effective-mode resolution (Menu-hold
+   momentary Desktop overlay) per the design.
+3. - [ ] **New `ControllerInput` variants** (Space/Tab/PageUp/PageDown
+   keys): registered at uinput device creation AND mapped in the Linux
+   emit path — both sites, same commit; explicit Ignore arms with a
+   comment in `windows.rs`.
+4. - [ ] **Chords to raw-Button level** per the design's "chords are
+   pre-mode" section, including the swallow rule. Regression test: the
+   Steam+Y power-off command fires identically in all three modes and
+   while Menu is held.
+5. - [ ] **Desktop mode** to the parity table, including triggers,
+   sticks, trackpads. The analog-trigger and joystick handlers gain
+   mode arms; trackpad wheel/mouse behavior per table.
+6. - [ ] **Transition hygiene.** The held-output tracker: every press
+   recorded, every effective-mode change releases the old mode's
+   still-held outputs first. Tests: the phantom-RT sequence from the
+   design; Menu tapped while a Desktop key held; chord swallow does
+   not double-release.
+7. - [ ] **Hybrid mode**: right pad mouse+click, left pad click-gated
+   4-zone d-pad (pure `dpad_zone` + the remembered-direction state
+   machine, tested exhaustively over the sequence space the design
+   enumerates), paddles L4/R4→stick clicks, L5/R5→Shift/Ctrl.
+8. - [ ] **Tray**: "Input mode" per-controller submenu via the existing
+   Int-with-options `PropertyDescriptorWrapper` → `SetInputMode`.
+
+## Warts / traps
+
+- **No hardware exists in your world.** Anything needing a HID device,
+  uinput, or D-Bus cannot run here; if a test needs one, the design of
+  that code is wrong — purify it. The binary is validated on Casey's
+  machine after merge, not by you. The word "verified" may not appear
+  in PR.md for anything you could not execute.
+- **Do not touch**: HID packet parsing offsets/constants, lizard-mode
+  keepalive, battery/status handling, `multi_threading.rs` beyond what
+  command plumbing strictly needs, trackpad speed constants.
+- **Nintendo layout composes above modes** (the A/B–X/Y swap in
+  `passive_refresh_state`). Do not re-implement it inside mode tables;
+  do add the test that Desktop's A→Enter is NOT swapped by Nintendo
+  mode (keys are not gamepad A/B).
+- Left-stick arrows in Desktop: implement per the design doc's
+  resolution of the repeat question (post-Sol). If the doc still
+  leaves repeat timing ambiguous when you read it, file a decision —
+  do not invent a timer thread.
+- Adding a crate is a founder decision. So is any deviation from the
+  parity table.
+- Never `git add -A`.
+
+## Finish — PR.md must contain
+
+- The **mapping audit table**: every physical input × every mode →
+  emitted output, side by side with the design table, divergences
+  called out (there should be none).
+- The chord-in-every-mode test evidence and the transition-hygiene
+  test list, named individually.
+- Founder-verification checklist for on-hardware smoke: the exact
+  manual sequences Casey should run (Steam+X cycle visible in tray;
+  Steam+Y in each mode; phantom-RT sequence; left-pad zones in a
+  gamepad tester; Desktop typing/scroll/paddles).
+- Anything you could not test in-sandbox, listed honestly under
+  "Untested here".

--- a/loops/specs/osc-mode-system/SPEC.md
+++ b/loops/specs/osc-mode-system/SPEC.md
@@ -5,58 +5,73 @@ Image: rust-1 (cargo + clippy + rustfmt + libudev/libdbus headers).
 
 **Read first, both on main:** `CLAUDE.md` (sandbox constraints — no
 hardware, no /dev/uinput, Windows must keep compiling blind) and
-`docs/design/input-modes.md`, which is **law** for this loop: mode
-semantics, the Desktop parity table, the Hybrid table, chord rules,
-transition hygiene, zone math, and the scope fences all live there.
-This spec sequences the work; the design doc defines it. Where they
-appear to conflict, say so in PR.md rather than silently picking.
+`docs/design/input-modes.md` **v2**, which is **law** for this loop:
+the mapper-transaction/reconciliation model, mode semantics, both
+mapping tables, the deviations table, chord rules, the pad-zone state
+machine, `reset_outputs`, and the scope fences all live there. It has
+already survived an adversarial design review (REVIEW.md on branch
+`loop/sol-review-osc-modes` — read it; the design's §Mapper
+transaction is the answer to its findings 1–3, and the review's
+concrete failure sequences are your test cases). This spec sequences
+the work; the design doc defines it. Where they appear to conflict,
+say so in PR.md rather than silently picking.
 
 ## Why
 
 The app has one real layout plus a half-finished momentary "alt mode".
 Steam Input on the same controller ships a polished desktop layer and
 per-layer paddle bindings; users drop to this app for non-Steam games
-and lose all of it. The design doc turns that into three fixed modes.
-Two real bugs die as side effects: chords currently match *mapped*
-outputs, so Steam+Y power-off is dead while alt mode is active
-(`parse_button_combinations` matching `ControllerInput::Y`); and mode
-changes can strand held outputs (hold RT, tap Menu → phantom trigger).
+and lose all of it. Two real bugs die as side effects of the design:
+chords match *mapped* outputs today, so Steam+Y power-off is dead
+while alt mode is active; and mode/overlay changes can strand held
+outputs (hold RT, tap Menu → phantom 80% throttle, forever).
 
 ## Build, in order
 
-1. - [ ] **Red-first: the mapping test harness.** Extract per-mode
-   button mapping into a pure function (mode, button, states) →
-   ControllerInput, and write table-driven tests asserting the FULL
-   Gamepad table (current behavior — this pins the refactor) plus the
-   Desktop and Hybrid tables from the design doc. Desktop/Hybrid tests
-   fail red at this point because only the plumbing exists. Commit the
-   red tests before the green.
-2. - [ ] **`InputMode` enum + plumbing.** In `DeviceProperties` beside
-   `nintendo_layout`; `DeviceCommand::{SetInputMode, InputModeCycle}`
-   handled in `try_apply`; effective-mode resolution (Menu-hold
-   momentary Desktop overlay) per the design.
+1. - [ ] **The mapper core, red-first.** Implement `RawState` parsing
+   and the pure boundary from the design:
+   `(RawState, ModeState, ConsumedSources) -> DesiredOutputs` and
+   `diff(EmittedOutputs, DesiredOutputs) -> Vec<ControllerInput>`.
+   Before wiring anything, commit red table-driven tests asserting the
+   FULL Gamepad table (pins current behavior) plus Desktop and Hybrid
+   tables, plus the review's failure sequences: RT-held-across-mode-
+   change neutralizes; B+Start alias keeps Esc; stale L5 cannot
+   release X's Meta; Menu+A in one report maps atomically.
+2. - [ ] **`InputMode` plumbing.** Enum with `Display` +
+   `TryFrom<u8>`, latch in `DeviceProperties`,
+   `DeviceCommand::{SetInputMode, InputModeCycle}` routed through the
+   mapper transaction (commands emit their cleanup deltas in the same
+   transaction — `try_apply` alone must not mutate the mode). HID
+   report first, then pending command, per the design's ordering.
 3. - [ ] **New `ControllerInput` variants** (Space/Tab/PageUp/PageDown
    keys): registered at uinput device creation AND mapped in the Linux
-   emit path — both sites, same commit; explicit Ignore arms with a
-   comment in `windows.rs`.
-4. - [ ] **Chords to raw-Button level** per the design's "chords are
-   pre-mode" section, including the swallow rule. Regression test: the
-   Steam+Y power-off command fires identically in all three modes and
-   while Menu is held.
-5. - [ ] **Desktop mode** to the parity table, including triggers,
-   sticks, trackpads. The analog-trigger and joystick handlers gain
-   mode arms; trackpad wheel/mouse behavior per table.
-6. - [ ] **Transition hygiene.** The held-output tracker: every press
-   recorded, every effective-mode change releases the old mode's
-   still-held outputs first. Tests: the phantom-RT sequence from the
-   design; Menu tapped while a Desktop key held; chord swallow does
-   not double-release.
-7. - [ ] **Hybrid mode**: right pad mouse+click, left pad click-gated
-   4-zone d-pad (pure `dpad_zone` + the remembered-direction state
-   machine, tested exhaustively over the sequence space the design
-   enumerates), paddles L4/R4→stick clicks, L5/R5→Shift/Ctrl.
-8. - [ ] **Tray**: "Input mode" per-controller submenu via the existing
-   Int-with-options `PropertyDescriptorWrapper` → `SetInputMode`.
+   emit path — both sites, same commit; `EV_REP` capability on the
+   uinput keyboard device; explicit no-op arms in `windows.rs`.
+4. - [ ] **Chords, modifier-first.** Raw-bitmap detection, rising-edge-
+   while-Steam-held, consumed-until-release sources feeding
+   `DesiredOutputs`. Regression tests: Steam+Y fires identically in
+   all three modes and while Menu is held; X held before Steam does
+   NOT fire the chord; consumed X releases whatever it was bound to
+   (gamepad X, Meta, or Nintendo-swapped Y) exactly once.
+5. - [ ] **Desktop mode** to the parity table + deviations table,
+   including trigger clicks, both sticks, both pads; stick arrows via
+   hysteresis crossings with OS-delegated repeat (no timers, no
+   `Instant::now()` in mapping logic).
+6. - [ ] **`reset_outputs`** on wireless disconnect, `clear_state`,
+   read-loop exit, and virtual-device replacement, per the design;
+   fake-output-sink tests prove releases/neutrals precede device
+   teardown and that a recreated device starts from empty
+   `EmittedOutputs`.
+7. - [ ] **Hybrid mode**: right pad mouse+click, paddles
+   L3/R3/Shift/Ctrl, left-pad zone d-pad implementing the design's
+   transition table exactly — test every row, plus the review's
+   loss/regain-while-clicked and stale-coordinate cases.
+8. - [ ] **Windows policy**: effective mode forced to Gamepad, mode
+   control disabled in that tray, pure tests that Desktop/Hybrid/Menu
+   requests produce the exact Gamepad stream.
+9. - [ ] **Tray**: labelled-choice descriptor (value+label pairs) for
+   "Input mode" with checked `TryFrom` at the boundary, wired in BOTH
+   `status_tray.rs` and `status_tray_not_linux.rs`.
 
 ## Warts / traps
 
@@ -66,30 +81,29 @@ changes can strand held outputs (hold RT, tap Menu → phantom trigger).
   machine after merge, not by you. The word "verified" may not appear
   in PR.md for anything you could not execute.
 - **Do not touch**: HID packet parsing offsets/constants, lizard-mode
-  keepalive, battery/status handling, `multi_threading.rs` beyond what
-  command plumbing strictly needs, trackpad speed constants.
-- **Nintendo layout composes above modes** (the A/B–X/Y swap in
-  `passive_refresh_state`). Do not re-implement it inside mode tables;
-  do add the test that Desktop's A→Enter is NOT swapped by Nintendo
-  mode (keys are not gamepad A/B).
-- Left-stick arrows in Desktop: implement per the design doc's
-  resolution of the repeat question (post-Sol). If the doc still
-  leaves repeat timing ambiguous when you read it, file a decision —
-  do not invent a timer thread.
+  keepalive, battery/status handling, trackpad speed constants;
+  `multi_threading.rs` and `main.rs` only as far as command plumbing
+  strictly needs.
+- **Nintendo layout** applies to gamepad A/B/X/Y outputs only, inside
+  desired-state computation. Do not re-implement it in mode tables; do
+  add the test that Desktop's A→Enter is NOT swapped.
+- Relative mouse/wheel motion is never tracked in
+  `DesiredOutputs`/`EmittedOutputs` — emit-and-forget.
 - Adding a crate is a founder decision. So is any deviation from the
-  parity table.
+  tables beyond the deviations list.
 - Never `git add -A`.
 
 ## Finish — PR.md must contain
 
 - The **mapping audit table**: every physical input × every mode →
-  emitted output, side by side with the design table, divergences
+  emitted output, side by side with the design tables, divergences
   called out (there should be none).
-- The chord-in-every-mode test evidence and the transition-hygiene
-  test list, named individually.
-- Founder-verification checklist for on-hardware smoke: the exact
-  manual sequences Casey should run (Steam+X cycle visible in tray;
-  Steam+Y in each mode; phantom-RT sequence; left-pad zones in a
-  gamepad tester; Desktop typing/scroll/paddles).
+- The review-failure-sequence tests, named individually, with a
+  one-line statement of what each pins.
+- Founder-verification checklist for on-hardware smoke: Steam+X cycle
+  visible in tray; Steam+Y in each mode and under Menu-hold; the
+  phantom-RT sequence; B+Start alias in a key monitor; left-pad zones
+  in a gamepad tester; Desktop typing/scroll/paddles; wireless
+  power-off mid-hold releases everything.
 - Anything you could not test in-sandbox, listed honestly under
   "Untested here".

--- a/loops/specs/sol-review-osc-modes/SPEC.md
+++ b/loops/specs/sol-review-osc-modes/SPEC.md
@@ -1,0 +1,99 @@
+# SPEC — sol-review-osc-modes: adversarial review of the input-modes design (REVIEW ONLY)
+
+Repo: `loop-bot/OpenSteamController`. Gate: `test -s /workspace/repo/REVIEW.md`.
+Engine: codex (Sol). This is a DESIGN review — adversarial, before a
+build loop implements it. You change NOTHING except creating
+`REVIEW.md` at the repo root. Any other file modification is a spec
+violation.
+
+## What to review
+
+`docs/design/input-modes.md` on `main` — a three-mode input design
+(Gamepad / Desktop / Hybrid) for a Steam Controller userland driver —
+against the code it must land in: `src/devices/steam_controller.rs`
+(mapping tables, chord parsing, trackpad state), `src/devices/mod.rs`
+(DeviceProperties / DeviceCommand / tray property descriptors,
+`passive_refresh_state`'s Nintendo-layout swap), and
+`src/virtual_controller/{mod,linux,windows}.rs` (output vocabulary and
+backends). Read `CLAUDE.md` for the sandbox constraints the
+implementation will live under.
+
+## Ground truth for the Desktop table
+
+The design's Desktop mode claims parity with Valve's shipped desktop
+layer. This is the raw extract from Casey's Steam install
+(`controller_base/desktop_neptune.vdf`, active groups; triton chords in
+`controller_base/chord_triton.vdf`). Verify the design's table is a
+faithful transcription — flag every divergence not explicitly marked as
+a deliberate deviation:
+
+```
+button_diamond (four_buttons): A=RETURN B=ESCAPE X=SHOW_KEYBOARD Y=SPACE
+dpad (dpad): arrows (UP/DOWN/LEFT/RIGHT_ARROW)
+left stick (dpad mode): arrow keys
+right stick (joystick_mouse): mouse; click=LEFT mouse
+left_trigger (trigger, edge): RIGHT mouse
+right_trigger (trigger, edge): LEFT mouse
+right_trackpad (absolute_mouse): mouse; click=LEFT mouse
+left_trackpad (scrollwheel): scroll_clockwise=SCROLL_DOWN,
+  counterclockwise=SCROLL_UP; click=MIDDLE mouse
+switches: button_escape=ESCAPE (+CHANGE_PRESET), button_menu=TAB,
+  back_left=LEFT_WINDOWS, back_left_upper=LEFT_SHIFT,
+  back_right=PAGE_DOWN, back_right_upper=PAGE_UP,
+  button_capture=system_key_1
+chord_triton (Steam held): B=quit_application X=SHOW_KEYBOARD
+  Y=controller_poweroff, right pad=absolute_mouse+LEFT,
+  dpad=volume/TAB/RETURN/ESCAPE chords
+```
+
+## The brief — try to break it
+
+This design will be implemented by a build loop with no hardware and no
+human watching the first draft. Whatever the design underspecifies, the
+loop will guess. Hunt for:
+
+- **Stuck-input holes in the transition model.** The design's held-set
+  release rule: enumerate concrete sequences it still gets wrong.
+  Menu pressed while Steam+X chord half-held? Trigger analog nonzero
+  across a latch? Nintendo layout toggled (Steam+A) while Desktop mode
+  holds EnterKey via physical A? Pad clicked during a transition, then
+  released in the old mode's mapping? Wireless drop / `clear_state()`
+  mid-hold — does the virtual device see releases?
+- **Chord semantics.** Chords move to raw-Button level. Does the
+  swallow rule (emit releases so the game never sees X) actually work
+  with the held-set tracker, or does it double-release? What does the
+  physical X press emit in Desktop mode where X maps to Meta — does the
+  chord swallow keys as well as gamepad buttons?
+- **Mode-shift interactions.** Menu-hold = momentary Desktop over any
+  latched mode. What happens on Steam+X *while* Menu is held? Tray
+  `SetInputMode` racing the chord (different threads)? Is "effective
+  mode" evaluated consistently for buttons, triggers, sticks, AND
+  trackpads in the same report packet?
+- **The left-pad zone spec.** Click-gated, remembered direction,
+  no re-evaluation while held: any input sequence with an undefined
+  outcome? (Click with no touch sample yet; touch lost and regained
+  while clicked; force/position of (0,0) sentinel packets.)
+- **Left-stick arrow keys.** The design wants deflection→arrow-keys
+  with hysteresis and key repeat. Key repeat needs time; the mapping
+  layer is a pure function of HID packets today. Is the proposed
+  350ms/40ms repeat implementable without threading a clock through
+  the parser — or should the design delegate repeat to the OS
+  (uinput EV_REP) or drop it? This smells like the design's weakest
+  load-bearing claim; judge it.
+- **Backend reality.** New key variants (Space/Tab/PageUp/PageDown):
+  anything in `linux.rs`'s two-site registration/emit pattern the
+  design fails to demand? Windows: modes silently degrade — is
+  "degrade to gamepad everywhere" actually specified tightly enough to
+  compile AND behave (Desktop mode on Windows = what, exactly)?
+- **Scope fence integrity.** Anything the design implies but fences
+  out (per-game configs, gyro) that will force the build loop to
+  either violate a fence or file a decision it shouldn't need.
+
+## Output
+
+Create `REVIEW.md` at the repo root: ranked findings (most-severe
+first), each with the design-doc section or file:line, why it's a
+problem, a concrete failure sequence, and a suggested design edit.
+Distinguish genuine correctness/safety-of-input problems from taste.
+If the design is sound, say so plainly — do not invent problems to
+seem thorough. End with GO / NO-GO for handing it to a build loop.

--- a/loops/templates/loop-sandbox.yaml
+++ b/loops/templates/loop-sandbox.yaml
@@ -32,7 +32,11 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: loop
-        image: zot.phillips-homelab.net/loop-dev:260809-codex2
+        # default-image-tag: 260809-codex2
+        # (bump via PR; loopctl spawn --image TAG substitutes at render
+        # time — a patch after apply races the already-started pod and
+        # the pod keeps the old image, same trap as GATE_CMD below.)
+        image: zot.phillips-homelab.net/loop-dev:${IMAGE}
         envFrom:
         - secretRef:
             name: loop-secrets


### PR DESCRIPTION
Fixes the loopctl spawn --image post-apply patch race (pod kept the default image on both OSC spawns; same trap as GATE_CMD, now both substitute at template render). Adds the rust-dev loop image Dockerfile (pushed to zot as loop-dev:rust-1) and the three OpenSteamController specs (sol review, mode system, steam-tap-home) for the record. Merged on Casey's in-session instruction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Rust development environment with common build, formatting, container, and cluster tools.
  * Added an autonomous coding-loop harness supporting repository setup, validation, state tracking, retries, completion, and operator interaction.
  * Sandbox deployments now support configurable image tags with documented defaults.

* **Documentation**
  * Added specifications for photometric normalization safeguards and oscillator-mode system development.
  * Added a review plan for validating oscillator-mode behavior and compatibility.

* **Maintenance**
  * Updated the Combine deployment image to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->