### PR TITLE
deploy tychofleet 1327c1a: observer pages + name nudge

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:6cc54a1
+          image: zot.phillips-homelab.net/tychofleet:1327c1a
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Bumps tychofleet 6cc54a1 -> 1327c1a (loop-bot/tychofleet#90, merged): /observer/<id> and gallery credits resolve gateway-registered scopes (Glen's 404), dead scope links render as text, profile display-name form gets anchor + visible save feedback + self-row nudge. Digest sha256:ae709df2...