### PR TITLE
deploy tychofleet 1310a60: patch-notes page

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:1327c1a
+          image: zot.phillips-homelab.net/tychofleet:1310a60
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Bumps tychofleet 1327c1a -> 1310a60 (loop-bot/tychofleet#91, merged): public /patch-notes page seeded with this week's member-facing fixes, linked from the fleet page + footer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TychoFleet deployment to use a newer container image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->