### PR TITLE
loops tooling: one-command client release + loopctl timeout fix

### DIFF
--- a/loops/CONDUCTOR.md
+++ b/loops/CONDUCTOR.md
@@ -198,3 +198,10 @@ a green gate on anything SQL.
 **Correct yourself in public.** Several times the founder was right and
 the confident answer was wrong — about operator capabilities, about
 architecture that already existed. Go and check.
+
+## Standing code style: ponytail
+
+Every loop reads `loop-bot/memory` at spawn; `ponytail.md` there carries
+the rig-wide code-minimalism rules (founder-adopted 2026-08-18, vendored
+from github.com/dietrichgebert/ponytail). Specs outrank it where they
+conflict. When writing SPECs, do not re-state its rules; reference it.

--- a/loops/bin/loopctl
+++ b/loops/bin/loopctl
@@ -226,6 +226,24 @@ case \"\$code\" in
 esac"
 }
 
+cmd_issue() {
+  local repo=${1:?usage: loopctl issue <owner/repo> <title> <body-file>}
+  local title=${2:?title required}
+  local bodyfile=${3:?body-file required}
+  local body
+  body=$(cat "$bodyfile")
+  helper_pod issue "
+F=$FJO_API
+PAYLOAD=\$(jq -n --arg t \"$title\" --arg b \"\$ISSUE_BODY\" '{title: \$t, body: \$b}')
+code=\$(curl -s -o /tmp/r -w '%{http_code}' -X POST \"\$F/repos/${repo}/issues\" -H \"Authorization: token \${FORGEJO_TOKEN}\" -H 'Content-Type: application/json' -d \"\$PAYLOAD\")
+case \"\$code\" in
+  201) echo \"issue #\$(jq -r .number /tmp/r) filed: \$(jq -r .html_url /tmp/r)\";;
+  *) echo \"issue create failed: \$code\"; head -c 300 /tmp/r; exit 1;;
+esac" "" "    env:
+    - name: ISSUE_BODY
+      value: $(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$body")"
+}
+
 cmd_merge() {
   local repo=${1:?usage: loopctl merge <owner/repo> <pr#>}
   local idx=${2:?PR number required}
@@ -264,6 +282,7 @@ case $cmd in
   reap) cmd_reap "$@";;
   cat) cmd_cat "$@";;
   pr) cmd_pr "$@";;
+  issue) cmd_issue "$@";;
   merge) cmd_merge "$@";;
   release) cmd_release "$@";;
   *) sed -n '2,14p' "$0";;

--- a/loops/bin/loopctl
+++ b/loops/bin/loopctl
@@ -55,7 +55,7 @@ helper_pod() {
     [ -n "$extra_container" ] && printf '%s\n' "$extra_container"
     echo "    command: [bash, -c, $(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$script")]"
   } | kubectl apply -f - >/dev/null
-  kubectl -n "$NS" wait --for=jsonpath='{.status.phase}'=Succeeded "pod/$pod" --timeout=180s >/dev/null 2>&1 \
+  kubectl -n "$NS" wait --for=jsonpath='{.status.phase}'=Succeeded "pod/$pod" --timeout=900s >/dev/null 2>&1 \
     || { kubectl -n "$NS" logs "$pod" 2>/dev/null; kubectl -n "$NS" delete pod "$pod" --wait=false >/dev/null 2>&1; die "helper pod $verb failed"; }
   kubectl -n "$NS" logs "$pod" 2>/dev/null
   kubectl -n "$NS" delete pod "$pod" --wait=false >/dev/null 2>&1

--- a/loops/bin/publish-client.sh
+++ b/loops/bin/publish-client.sh
@@ -28,8 +28,8 @@ export KUBECONFIG=${KUBECONFIG:-$HOME/.kube/tycho-sa.yaml}
 # names are the S3-SDK convention release-publish reads; the values are
 # the B2 key. Override labels via env if the item changes.
 OP_ITEM=${OP_ITEM:-tycho}
-OP_FIELD_KEY_ID=${OP_FIELD_KEY_ID:-tf-releases-key-id}
-OP_FIELD_APP_KEY=${OP_FIELD_APP_KEY:-tf-releases-app-key}
+OP_FIELD_KEY_ID=${OP_FIELD_KEY_ID:-b2_releases_key_id}
+OP_FIELD_APP_KEY=${OP_FIELD_APP_KEY:-b2_releases_application_key}
 
 say() { printf '\n== %s\n' "$*"; }
 

--- a/loops/bin/publish-client.sh
+++ b/loops/bin/publish-client.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# publish-client.sh — the ENTIRE client release flow, one command:
+#
+#   op signin            # the only human step (any tab, once)
+#   publish-client.sh v0.10.0
+#
+# Idempotent: every step checks whether it's already done and skips.
+# Steps: verify tag on main -> Forgejo release + assets (loopctl
+# release, in-cluster) -> local dist build (scripts/release.sh) ->
+# public-bucket publish (release-publish, creds pulled from 1Password
+# at exec time, never displayed, never persisted) -> verify the public
+# manifest flipped.
+#
+# Publishing to the public bucket stays a human-KICKED step by design
+# (dev dark mode: merged != released); it is no longer a human-ASSEMBLED
+# one. Move into CI/Dagger later only with an explicit approval gate.
+set -euo pipefail
+
+VERSION=${1:?usage: publish-client.sh vX.Y.Z [title...]}
+shift || true
+TITLE=${*:-"Tycho client $VERSION"}
+
+REPO_DIR=${TYCHO_REPO:-/mnt/nix-projects/tycho}
+LOOPCTL=$(dirname "$0")/loopctl
+export KUBECONFIG=${KUBECONFIG:-$HOME/.kube/tycho-sa.yaml}
+
+# 1Password source of the Backblaze B2 releases key. The AWS_* env
+# names are the S3-SDK convention release-publish reads; the values are
+# the B2 key. Override labels via env if the item changes.
+OP_ITEM=${OP_ITEM:-tycho}
+OP_FIELD_KEY_ID=${OP_FIELD_KEY_ID:-tf-releases-key-id}
+OP_FIELD_APP_KEY=${OP_FIELD_APP_KEY:-tf-releases-app-key}
+
+say() { printf '\n== %s\n' "$*"; }
+
+say "op session"
+op whoami >/dev/null 2>&1 || { echo "not signed in — run: op signin"; exit 1; }
+op item get "$OP_ITEM" --fields "label=$OP_FIELD_KEY_ID" >/dev/null 2>&1 || {
+  echo "field '$OP_FIELD_KEY_ID' not found on item '$OP_ITEM'. Available labels:"
+  op item get "$OP_ITEM" --format json | python3 -c 'import json,sys; [print(" -",f.get("label")) for f in json.load(sys.stdin).get("fields",[])]'
+  echo "set OP_FIELD_KEY_ID / OP_FIELD_APP_KEY and re-run"; exit 1; }
+
+say "tag $VERSION on origin/main"
+cd "$REPO_DIR"
+git fetch -q origin main "refs/tags/$VERSION:refs/tags/$VERSION" 2>/dev/null || git fetch -q origin main
+if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+  git merge-base --is-ancestor "refs/tags/$VERSION" origin/main \
+    || { echo "tag exists but is NOT on origin/main — refusing"; exit 1; }
+  echo "tag exists on main"
+else
+  echo "tag will be created from origin/main by the release helper"
+fi
+
+say "Forgejo release + assets (in-cluster)"
+"$LOOPCTL" release loop-bot/tycho "$VERSION" "$TITLE" \
+  || { echo "loopctl release failed — see output above"; exit 1; }
+
+say "local dist build"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+git worktree add -q "$WORK" "refs/tags/$VERSION" 2>/dev/null || git worktree add -q "$WORK" origin/main
+( cd "$WORK" && make release VERSION="$VERSION" ) || { git worktree remove -f "$WORK"; exit 1; }
+
+say "publish to public bucket (creds via op, not displayed)"
+( cd "$WORK" && \
+  AWS_ACCESS_KEY_ID=$(op item get "$OP_ITEM" --fields "label=$OP_FIELD_KEY_ID" --reveal) \
+  AWS_SECRET_ACCESS_KEY=$(op item get "$OP_ITEM" --fields "label=$OP_FIELD_APP_KEY" --reveal) \
+  make release-publish VERSION="$VERSION" )
+git worktree remove -f "$WORK" 2>/dev/null || true
+trap - EXIT
+
+say "verify public manifest"
+for i in 1 2 3; do
+  latest=$(curl -s https://tychofleet.com/dl/manifest.json | python3 -c 'import json,sys; print(json.load(sys.stdin).get("latest",""))' 2>/dev/null || true)
+  [ "$latest" = "$VERSION" ] && { echo "PUBLIC: latest=$latest — live on tychofleet.com/download"; exit 0; }
+  sleep 5
+done
+echo "manifest still shows '$latest' — check CDN cache or publish output"; exit 1


### PR DESCRIPTION
publish-client.sh (the whole cut->publish flow behind an op-signin gate, idempotent) + loopctl helper-pod timeout 180s->900s (release builds were being reaped mid-build). Born from tonight's v0.10.0 cut taking four manual attempts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command for creating Forgejo issues directly from repository content.
  - Added an end-to-end client release workflow that builds, publishes, and verifies release artifacts automatically.

- **Improvements**
  - Increased the helper pod wait period to support longer-running operations.

- **Documentation**
  - Documented shared code style guidance and how it relates to project specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->