### PR TITLE
deploy tychofleet a539d52: v0.10.0 patch note

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:1310a60
+          image: zot.phillips-homelab.net/tychofleet:a539d52
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Bumps tychofleet 1310a60 -> a539d52 (loop-bot/tychofleet#92, merged): the client v0.10.0 release note on /patch-notes.