### PR TITLE
loop rig: rust-2 image with Windows cross-check + OSC stage specs

### DIFF
--- a/loops/images/rust-dev/Dockerfile
+++ b/loops/images/rust-dev/Dockerfile
@@ -16,9 +16,15 @@ FROM rust:1-bookworm
 RUN apt-get update && apt-get install -y --no-install-recommends \
       git make jq curl ca-certificates ripgrep unzip \
       pkg-config libudev-dev libdbus-1-dev \
+      gcc-mingw-w64-x86-64 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN rustup component add clippy rustfmt
+# Windows cross-check target: `cargo check --target x86_64-pc-windows-gnu`
+# in the gate catches windows.rs breakage that otherwise ships blind
+# (the sandbox has no Windows; check compiles everything incl. native
+# build scripts, hence the mingw cross-gcc above, but never links).
+RUN rustup component add clippy rustfmt && \
+    rustup target add x86_64-pc-windows-gnu
 
 # claude CLI (native installer drops it in ~/.local/bin; promote to PATH)
 RUN curl -fsSL https://claude.ai/install.sh | bash && \

--- a/loops/specs/osc-config-files/SPEC.md
+++ b/loops/specs/osc-config-files/SPEC.md
@@ -1,0 +1,93 @@
+# SPEC — osc-config-files: profiles on disk (profiles stage 2)
+
+Repo: `loop-bot/OpenSteamController`. Gate: `make build test lint`.
+Image: rust-1.
+
+**Read first, all on main:** `CLAUDE.md`;
+`docs/design/config-profiles.md` **v3** — law, specifically §3 (file
+locations, TOML document shapes, validation table, cycling/selection
+rules), §4 (CatalogSnapshot generations, carry-forward stale, durable
+serial identity, lifecycle table), §5 (TrayState/TrayCommand, dynamic
+submenu, zero-controller reload), §6 (the D-Bus contract:
+`dev.opensteamcontroller.Daemon1`, digest-attributed `ReloadProfiles`,
+dedicated pump thread, `dbus-crossroads`), §7 (activator
+warn-and-inert), §9 (Windows: none of this exists there). Stage 1
+(merged: `osc-config` crate, `step` interpreter, compiled-in defaults)
+is the foundation; do not modify the interpreter or vocabulary.
+
+## Why
+
+Stage 1 made modes data; stage 2 makes them *files*. After this loop a
+user can drop `elden-ring.toml` in the profiles dir, pick it from the
+tray (or D-Bus), and the mapper runs it — with the shipped defaults
+untouchable underneath, broken files held to last-good, and every
+error visible instead of silent.
+
+## Build, in order
+
+1. - [ ] **TOML round-trip in `osc-config`**: parse/serialize the §3
+   profile and games.toml document shapes into the existing stage-1
+   types, emitting §3's validation table as typed `Diagnostic`s —
+   red-first tests covering EVERY table row (schema gating, mode
+   cardinality, overlay rules, unknown-key rejection at every depth,
+   activator warn-and-inert, combination-rule errors, games.toml rule
+   validation). Property: any accepted document re-serializes to an
+   equivalent document (editor round-trip safety, stage 4 depends on
+   it).
+2. - [ ] **ConfigStore + CatalogSnapshot** (daemon, coordinator-owned):
+   XDG discovery, generation counter, carry-forward-stale semantics,
+   `default` reservation (file named `default.toml` = load error), the
+   full §4 lifecycle table as pure-testable transitions. games.toml
+   loads/validates here too (matching itself is stage 3 — store the
+   rules, don't act on them).
+3. - [ ] **Selection plumbing**: `SetProfile(id)` through the
+   coordinator → queued per-controller transition carrying the
+   snapshot Arc → next transaction swaps and reconciles (behavior
+   memory cleared — the §4 rules). Accepted-profile rule: first
+   non-overlay mode. Reload-while-latched: preserve by mode name,
+   else first. Serial-keyed persistence in `state.toml`,
+   coordinator-writes-only; no-serial controllers are session-only.
+4. - [ ] **TrayState/TrayCommand**: the §5 owned structs replacing the
+   cloned-`DeviceProperties`-only channel; dynamic profile submenu
+   (owned strings, NOT the `'static` Choice descriptor) + per-device
+   active profile/mode + catalog statuses + diagnostics + reload
+   action, in BOTH `status_tray.rs` and `status_tray_not_linux.rs`;
+   the non-Linux skip-if-unchanged check compares full `TrayState`
+   including generation. Reload must work with zero controllers.
+5. - [ ] **D-Bus service**: `dev.opensteamcontroller.Daemon` name,
+   §6 object/interface, `ReloadProfiles(a(ss)) -> (u, a(ssssss))`
+   exactly — digest verification per §6, one lossless `Diagnostic`
+   schema everywhere. `dbus-crossroads` added (founder-approved,
+   Linux-only dep). Dedicated pump thread owning the connection,
+   channels to the coordinator, bounded replies. `FocusChanged` is
+   NOT implemented (stage 3); do not stub it into the interface.
+
+## Warts / traps
+
+- **No D-Bus session, no hardware in the sandbox.** Structure the
+  D-Bus layer so everything interesting (digest matching, diagnostic
+  assembly, request→coordinator→reply flow) is pure-testable with the
+  bus mocked as channels; the actual connection glue must be thin and
+  is untestable here — say so in PR.md, never "verified".
+- Do not touch `osc-config`'s interpreter, vocabulary, or defaults
+  beyond what TOML derives strictly need (serde attrs on existing
+  types are fine; semantic changes are not).
+- Windows (§9): no profile loading, no submenu, no D-Bus — `cfg` it
+  out cleanly; workspace still compiles blind for that target.
+- Filesystem tests use temp dirs; never read the real XDG paths in
+  tests. The daemon must not create the profiles dir with contents —
+  empty dir + compiled-in default is the fresh-install state.
+- Steam+X cycling semantics (non-overlay modes, file order) are
+  interpreter-side and already landed in stage 1 — do not
+  re-implement; just feed it profiles.
+- Never `git add -A`.
+
+## Finish — PR.md must contain
+
+- The validation-table audit: every §3 row → the test that pins it.
+- The lifecycle audit: every §4 table row → the test that pins it.
+- A fresh-install walkthrough (empty config dir → default profile
+  active → drop a file → reload → select → reboot persistence), as a
+  narrated sequence of the actual tests that cover each step.
+- The exact D-Bus interface XML/introspection as implemented.
+- Untested-here honesty section (live bus, live tray, hardware).

--- a/loops/specs/osc-config-model/SPEC.md
+++ b/loops/specs/osc-config-model/SPEC.md
@@ -1,0 +1,91 @@
+# SPEC — osc-config-model: the data-driven mode program (profiles stage 1)
+
+Repo: `loop-bot/OpenSteamController`. Gate: `make build test lint`.
+Image: rust-1.
+
+**Read first, all on main:** `CLAUDE.md`;
+`docs/design/config-profiles.md` **v3** — law for this loop,
+specifically §1 (mode program + `step` signature + field-combination
+rules + equivalence gate), §2 (closed vocabulary, serialized
+spellings), §3 (identity + validation types), §8 (workspace topology,
+additive gate), §11 stage 1 (dependency scope); and
+`docs/design/input-modes.md` (settled law the new model must express).
+The two review rounds that shaped v3 are on branches
+`loop/sol-review-osc-profiles` and `loop/sol-review-osc-profiles-2` —
+their failure scenarios are your test cases.
+
+## Why
+
+Per-game profiles need the three shipped modes to become *data* in a
+model users can also write. Two review rounds established the traps:
+the mode behavior is NOT just the desired-outputs table (stateful
+behaviors: stick-arrows, zone-dpad, motion anchors, guide-tap), the
+vocabulary must be closed and exhaustive (round 2 caught a missing
+D-pad!), and chords must flow through the interpreter's return value.
+This stage converts the architecture; it must change **zero runtime
+behavior**.
+
+## Build, in order
+
+1. - [ ] **Workspace conversion**: three-crate layout per §8
+   (`osc-config` new; daemon stays `open-steam-controller`;
+   `osc-editor` is NOT created yet — two members for now, topology
+   ready for the third). Makefile gains `--workspace --all-targets`
+   **additively** — `--release --locked`, `--locked` test, clippy
+   `-D warnings`, `fmt --check` all retained. Update `CLAUDE.md`'s
+   gate/map wording in the same commit so docs stay true.
+2. - [ ] **`osc-config` types**: §2 enums with exact serialized
+   spellings (serde derives; serde+toml are `osc-config` deps only),
+   §1 `Mode`/program types + field-combination validation, §3
+   profile-ID rules + the validation table as typed
+   `Diagnostic { profile_id, severity, code, mode, source, message }`
+   results. Unit tests exercise every §3 table row and every §1
+   combination rule. NO file I/O anywhere in this stage.
+3. - [ ] **Red-first equivalence suite**: the compiled-in
+   Gamepad/Desktop/Hybrid `Mode` values expressed in the new model,
+   with tests asserting the §1 equivalence gate list — all three
+   defaults' full tables including D-pad rows, relative motion,
+   hysteresis sequences, guide-tap eligibility, Nintendo swap
+   output-side rule, alias refcounting, Hybrid's inherited rows —
+   written against the NEW interpreter API before it exists (red),
+   alongside the existing suite (which must keep passing throughout).
+4. - [ ] **The interpreter**: implement §1 `step` exactly —
+   `(RawState, ActiveSnapshot, Selection, MapperMemory) ->
+   (DesiredOutputs, Vec<RelativeEvent>, Vec<DaemonCommand>,
+   Selection', MapperMemory')` — chords resolved first inside `step`,
+   Steam+X updating `Selection'` with interpretation running under it
+   in the same call, Steam+Y/Steam+A returned as `DaemonCommand`s.
+   `MapperMemory` owns all cross-report state, typed per behavior;
+   every behavior machine works for ANY mode that declares the
+   behavior. Custom-mode tests per §1 (silent-gamepad key mode,
+   arrows stick in a custom mode, zone-dpad in a custom mode).
+5. - [ ] **Cutover**: `steam_controller.rs`/`mod.rs` drive `step`;
+   `InputMode`, `compute_gamepad/desktop/hybrid`, and every
+   mode-enum branch deleted; the tray's mode submenu now lists the
+   active (compiled-in) profile's mode names via the existing
+   descriptor (still three static names — dynamic tray is stage 2).
+   `ActiveSnapshot` for now wraps only the compiled-in default
+   profile — the type exists, the ConfigStore does not.
+
+## Warts / traps
+
+- **Zero behavior change is the contract.** The pre-existing test
+  suite passes unchanged; any test edit beyond imports/namespacing is
+  a red flag to justify line-by-line in PR.md.
+- Dependency scope per §11: serde/toml in `osc-config` only; daemon
+  runtime does no file I/O, no D-Bus changes, no new daemon deps.
+- No hardware in the sandbox; pure tests only. "Verified" may not
+  appear in PR.md for anything you could not execute.
+- Windows must keep compiling blind: the workspace conversion and
+  cutover touch shared files — keep `cfg` symmetry, extend
+  windows-policy tests to the new API (effective-Gamepad forcing now
+  lives in `Selection` resolution).
+- Never `git add -A`.
+
+## Finish — PR.md must contain
+
+- The equivalence audit: every default-mode table row old-vs-new,
+  divergences called out (there must be none).
+- The custom-mode test list, named individually.
+- The workspace layout tree and the exact Makefile diff.
+- Untested-here honesty section.

--- a/loops/specs/osc-steam-tap-home/SPEC.md
+++ b/loops/specs/osc-steam-tap-home/SPEC.md
@@ -1,0 +1,65 @@
+# SPEC — osc-steam-tap-home: Steam button = Guide tap on un-chorded release
+
+Repo: `loop-bot/OpenSteamController`. Gate: `make build test lint`.
+Image: rust-1.
+
+**Read first, both on main:** `CLAUDE.md`, and
+`docs/design/input-modes.md` §Chords — specifically the "Steam tap =
+Guide (founder ruling)" paragraph, which is law and defines this loop
+completely. The mode system it amends landed in PR #1 (branch
+`loop/osc-mode-system`, merged); `src/devices/mapper.rs` is the pure
+transaction core you are extending.
+
+## Why
+
+Founder ruling: pressing the Steam button alone should act like the
+Xbox Guide button, the way real Steam behaves — emulator frontends and
+overlays key off it. PR #1 made Steam a pure chord modifier with no
+output; that was flagged in its PR.md as a design tension and the
+ruling resolves it: silent while held, Guide tap on un-chorded release.
+
+## Build
+
+1. - [ ] **Red-first tests** in `mapper.rs`, then the implementation:
+   - un-chorded Steam press+release in Gamepad emits Home press in the
+     release transaction and Home release in the next transaction —
+     exactly one pulse, both edges;
+   - same in Hybrid;
+   - any chord fired during the hold (test Steam+Y, Steam+A, Steam+X)
+     → no Home pulse at all;
+   - Desktop mode: un-chorded tap emits nothing;
+   - Menu held (momentary Desktop) at Steam-release time: effective
+     mode is Desktop → no pulse;
+   - `reset_outputs` between the pulse's press and release
+     transactions releases Home like any held output — no stuck Guide;
+   - two consecutive un-chorded taps produce two clean pulses.
+2. - [ ] The pulse state lives beside the mapper's other cross-report
+   state (like the pad-zone machine), NOT as a timer or thread; the
+   design's "press in release transaction, release in next
+   transaction" is the whole mechanism.
+
+## Warts / traps
+
+- Touch nothing outside `mapper.rs` (+ its tests) unless the pulse
+  state genuinely needs a field beside its siblings — the I/O glue
+  already forwards whatever the mapper emits.
+- Do not add Home to Desktop's table, do not touch the deviations
+  table, do not revisit PR #1 decisions.
+- `Home` is an existing `ControllerInput` variant already registered in
+  both backends — no backend changes.
+- No hardware in the sandbox; pure tests only. "Verified" may not
+  appear in PR.md for anything you could not execute.
+- Never `git add -A`.
+
+## Finish — PR.md must contain
+
+- The test list, named individually, one line each on what it pins.
+- A short "how the pulse interacts with chords/reset" paragraph a
+  reviewer can check against the design paragraph.
+- Untested-here honesty section (hardware behavior of the pulse width).
+
+## Outcome (conductor note, post-loop)
+
+Landed green in one effective iteration as
+`loop-bot/OpenSteamController` PR #2, merged 2026-08-18. 8 new tests,
+83 total; implementation confined to `mapper.rs` as fenced.

--- a/loops/specs/sol-review-osc-profiles-2/SPEC.md
+++ b/loops/specs/sol-review-osc-profiles-2/SPEC.md
@@ -1,0 +1,38 @@
+# SPEC — sol-review-osc-profiles-2: verify the fold (REVIEW ONLY)
+
+Repo: `loop-bot/OpenSteamController`. Gate: `test -s /workspace/repo/REVIEW.md`.
+Engine: codex (Sol). You change NOTHING except creating `REVIEW.md` at
+the repo root.
+
+## What to review
+
+`docs/design/config-profiles.md` is now **v2**, rewritten to fold the
+9 findings from the previous adversarial review — which is preserved
+verbatim on branch `loop/sol-review-osc-profiles` (fetch it:
+`git fetch origin loop/sol-review-osc-profiles` and read `REVIEW.md`
+from that branch). This is a VERIFICATION pass, not a fresh review:
+
+1. For each of the 9 prior findings, state RESOLVED / PARTIALLY
+   RESOLVED / UNRESOLVED against v2's actual text, with the v2 section
+   that resolves it or the gap that remains.
+2. Hunt for NEW holes the fold introduced — a rewrite this size
+   invents fresh contradictions: cross-section inconsistencies
+   (vocabulary vs. validation table vs. mode-program fields), the
+   §1 interpreter contract vs. the real code in
+   `src/devices/mapper.rs` / `src/devices/steam_controller.rs`, the §4
+   lifecycle table vs. §5 TrayState vs. §6 D-Bus reply shapes, the §8
+   workspace/gate changes vs. the existing Makefile and CLAUDE.md.
+3. Judge implementability of stage 1 specifically: could an unattended
+   build loop implement §1+§2+§3-types from this text without filing
+   avoidable decisions or inventing semantics?
+
+Do not relitigate settled founder rulings (egui, TOML, manual-first
+switching, activator reservation, the §13 crate list) or the shipped
+input-modes design. Concision beats completeness of prose — findings
+only need file/section references and concrete failure scenarios.
+
+## Output
+
+`REVIEW.md` at repo root: the 9-finding resolution table first, then
+any new findings ranked by severity, then GO / NO-GO for stage 1
+(`osc-config-model`) and which findings, if any, block stages 2–4.

--- a/loops/specs/sol-review-osc-profiles/SPEC.md
+++ b/loops/specs/sol-review-osc-profiles/SPEC.md
@@ -1,0 +1,86 @@
+# SPEC — sol-review-osc-profiles: adversarial review of the per-game profiles design (REVIEW ONLY)
+
+Repo: `loop-bot/OpenSteamController`. Gate: `test -s /workspace/repo/REVIEW.md`.
+Engine: codex (Sol). This is a DESIGN review, before any build loop.
+You change NOTHING except creating `REVIEW.md` at the repo root. Any
+other file modification is a spec violation.
+
+## What to review
+
+`docs/design/config-profiles.md` on `main` — a per-game profile system
+(TOML config model, profile switching, KWin auto-switch, separate egui
+editor) — against the codebase it lands in, especially:
+
+- `src/devices/mapper.rs`: the reconciliation transaction the design
+  claims needs no changes below `compute_desired_outputs`. The shipped
+  three-mode design (`docs/design/input-modes.md` v2) is settled law —
+  review the NEW design's fit against it, not the old decisions.
+- `src/devices/mod.rs`: DeviceCommand/DeviceProperties/tray descriptor
+  plumbing that `SetProfile` and the profile submenu must ride.
+- `src/main.rs`, `src/multi_threading.rs`: thread/ownership boundaries
+  the ConfigStore and D-Bus reload signal must respect.
+- `Cargo.toml`: the dependency reality (dbus 0.9 already present;
+  serde/toml/eframe are proposed additions).
+- `CLAUDE.md`: sandbox constraints every implementing loop lives under
+  (no hardware, no D-Bus session, Windows compiles blind).
+
+## The brief — try to break it
+
+An unattended build loop implements whatever this design
+underspecifies. Hunt specifically for:
+
+- **The interpreter refactor's equivalence claim.** "Existing tests
+  pass unchanged against the built-in default profile" — is that
+  actually achievable given how the current compute functions compose
+  (Hybrid building on Gamepad's output, the overlay resolution, the
+  Nintendo swap placement)? Find any current behavior that the
+  proposed Profile/Mode/Binding data model *cannot express*, which
+  would force either a model change or a silent behavior change.
+- **Schema soundness.** Typos-as-errors vs. the activator
+  warn-and-inert exception: is the boundary crisp enough to implement?
+  Version gating (`schema = 1`): what happens to a schema-2 file, a
+  missing version, a duplicate mode name, zero modes, 9 modes, two
+  overlay modes, an overlay-only profile? Output vocabulary: any
+  `ControllerInput` reachable today that the proposed vocabulary can't
+  name, or names ambiguously (trigger click vs axis, stick click vs
+  stick mode)?
+- **Profile lifecycle races.** SetProfile mid-transaction vs. the
+  HID-report-first-then-command ordering; reload of the ACTIVE profile
+  while a mode within it is latched (mode index still valid? name
+  lookup?); last-good semantics when the active profile's file becomes
+  invalid; per-controller active profiles when a profile is deleted on
+  disk; what the tray shows during each of these.
+- **The D-Bus surface.** The design hangs reload-signaling and the
+  FocusWatcher on the existing `dbus` 0.9 crate — check what that
+  crate actually is (blocking libdbus bindings): does receiving
+  signals fit the current thread model without a dedicated D-Bus
+  thread, and does the design say who owns it? Is the daemon
+  exporting a name/object actually specified (name, path, interface),
+  or hand-waved?
+- **KWin focus watching.** Is "KWin exposes focus via its
+  scripting/D-Bus surface" real and stable enough to spec a loop
+  against, or does it need a KWin script installed (user-visible
+  setup)? What's the story on X11 games under XWayland — do they get
+  usable app-ids? The design must not send a loop to "verify against
+  the target system" it doesn't have — the sandbox has no KDE. Flag
+  what must be resolved by the conductor on real hardware first.
+- **Editor boundary.** Atomic-write + reload-signal on save: TOCTOU
+  between editor write and daemon reload? Editor and daemon versions
+  drifting (editor writes vocabulary the daemon doesn't know — is the
+  shared-crate boundary specified, or will the loop invent two
+  vocabularies?). Is "daemon never links egui" actually enforceable in
+  one workspace (feature flags / separate crates) as written?
+- **Scope-fence integrity.** Anything the design implies but fences
+  out (activator timing, hot-reload watching, Windows profiles) that
+  will force an implementing loop to violate a fence or file
+  avoidable decisions.
+
+## Output
+
+Create `REVIEW.md` at the repo root: ranked findings (most-severe
+first), each with the design section or file:line, why it's a problem,
+a concrete failure scenario, and a suggested design edit. Separate
+genuine correctness/underspecification findings from taste. If parts
+are solid, say so plainly — do not invent problems. End with GO /
+NO-GO for handing stage-1 (osc-config-model) to a build loop, and note
+which findings block only later stages.


### PR DESCRIPTION
Adds gcc-mingw-w64 + x86_64-pc-windows-gnu target to the rust loop image (pushed to zot as loop-dev:rust-2) so the OSC gate's new Windows cross-check runs in sandboxes; records the profile-stage specs. Approved by Casey in-session.