### PR TITLE
deploy tychofleet 12a984b: patch-notes voice pass

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:a539d52
+          image: zot.phillips-homelab.net/tychofleet:12a984b
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Bumps tychofleet a539d52 -> 12a984b (loop-bot/tychofleet#93, merged): all patch-note entries rewritten plain-text (no markdown/em dashes/idioms, ESL-first), voice rules in the collection README, guard test against markdown tokens.