### PR TITLE
deploy gateway b6203cf0: INGEST FREEZE ON (consent migration step 1)

### DIFF
--- a/gitops/tools/apps/tycho/gateway/deployment.yaml
+++ b/gitops/tools/apps/tycho/gateway/deployment.yaml
@@ -74,6 +74,11 @@ spec:
               memory: "512Mi"
               cpu: "1000m"
           env:
+            # Master ingest pause for the collection-consent migration
+            # (loop-bot/tycho#249). Flip to "false" at per-scope
+            # re-enable time; remove after the migration completes.
+            - name: INGEST_FROZEN
+              value: "true"
             - name: LISTEN_ADDR
               value: ":8080"
             - name: S3_ENDPOINT

--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-gateway
-    newTag: "8fd78255"
+    newTag: "b6203cf0"


### PR DESCRIPTION
Gateway 8fd78255 -> b6203cf0 (loop-bot/tycho#249, merged) + INGEST_FROZEN=true: every upload route 503s with a plain-language message until the campaign-scoped collection machinery ships and clients migrate. Founder-blessed fleet pause. Heartbeats, scope API, enrolment, deliveries, combines all unaffected. Digest sha256:1433fee7...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Paused master ingest during the collection-consent migration.
  * Updated the gateway service to a newer container image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->