### PR TITLE
deploy: consent server pair (gateway CollectionScope + site intervals)

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:12a984b
+          image: zot.phillips-homelab.net/tychofleet:e015605
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-gateway
-    newTag: "b6203cf0"
+    newTag: "604040b5"


### PR DESCRIPTION
The server half of the consent migration, deployed together under the standing INGEST_FROZEN=true:

- tycho-gateway b6203cf0 -> 604040b5 (loop-bot/tycho#251): CollectionScope projection (catalog migration 0011), 60s-lease read endpoint, ingest enforcement on real FITS OBJECT headers, provenance stamping, fail-closed. Freeze flag unchanged and still ON.
- tychofleet 12a984b -> e015605 (loop-bot/tychofleet#94): append-only enrollment intervals + migration, synchronous CollectionScope publisher with full-resync, backfill join UX (default off).

After ArgoCD syncs: fleetsync populates projections; I verify Glen's and Casey's scopes show correct collection scopes at the gateway before the client loop starts. Client migration and per-scope re-enable follow. Digests sha256:7a892427... / sha256:a6b0aefb...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Tychofleet deployment to a newer container version.
  * Updated the Tycho Gateway deployment to a newer container version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->