### PR TITLE
deploy: gateway b7d193cf (migration 0011 fix)

### DIFF
--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-gateway
-    newTag: "604040b5"
+    newTag: "b7d193cf"


### PR DESCRIPTION
Remedy for the 604040b5 crashloop: migration 0011's COMMENT ON string had a bare apostrophe (loop-bot/tycho#252). One character; all 11 catalog migrations verified clean against postgres:16 before build. The failed 0011 ran in a transaction and rolled back, so this applies fresh. INGEST_FROZEN=true unchanged — the freeze holds until per-scope re-enable.