### PR TITLE
deploy: consent alias pair (gateway alias matcher + site alias publisher)

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:e015605
+          image: zot.phillips-homelab.net/tychofleet:2207707
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/gitops/tools/apps/tycho/gateway/kustomization.yaml
+++ b/gitops/tools/apps/tycho/gateway/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   # images`/`make push` (or .forgejo/workflows/ci.yml's tag-triggered
   # job) actually published, e.g. a git short sha.
   - name: zot.phillips-homelab.net/tycho-gateway
-    newTag: "b7d193cf"
+    newTag: "191b489f"


### PR DESCRIPTION
The alias widening (loop-bot/tycho#253 + loop-bot/tychofleet#95), still under INGEST_FROZEN=true:

- tycho-gateway b7d193cf -> 191b489f: campaign Aliases set (migration 0013, verified against postgres:16 with all 13 migrations), Authorize matches target_name plus aliases, aliases on the upsert wire and lease read.
- tychofleet e015605 -> 2207707: publisher sends each part of the catalog designation as an alias.

After rollout I trigger the admin resync so all scopes republish at a bumped generation with aliases, then verify the projections carry them. Digests sha256:0d64384d... / sha256:00b3758c...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Tychofleet container to a newer release.
  * Updated the Tycho Gateway container to a newer release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->