### PR TITLE
deploy: tychofleet b1fe856 (v0.11.0 patch note)

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:2207707
+          image: zot.phillips-homelab.net/tychofleet:b1fe856
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Site-only bump: adds the client v0.11.0 patch-notes entry (loop-bot/tychofleet#96). No gateway change; freeze unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Tychofleet application to a newer container image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->