### PR TITLE
deploy tychofleet 2eb29b5: client v0.12.0-v0.12.3 patch notes

### DIFF
--- a/gitops/apps/tychofleet/deployment.yaml
+++ b/gitops/apps/tychofleet/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: zot.phillips-homelab.net/tychofleet:b1fe856
+          image: zot.phillips-homelab.net/tychofleet:2eb29b5
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Bumps the tychofleet site image b1fe856 -> 2eb29b5.

Ships the four pending client patch notes (loop-bot/tychofleet#97, #98, #99, #100) — the live site still shows v0.11.0 as the newest note. Image built from tychofleet main 2eb29b5 and pushed to zot (both the sha tag and latest).

The client release itself is already live and verified: /dl/manifest.json latest=v0.12.3, all five platform archives sha256-verified against the manifest via the public URLs.

https://claude.ai/code/session_01VdjxY7MB4q1RmA1vH79Rmq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TychoFleet deployment to the latest application version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->